### PR TITLE
Anmerkung zu "id"-Attribut hinzugefügt.

### DIFF
--- a/docs/management/domain.rst
+++ b/docs/management/domain.rst
@@ -46,6 +46,7 @@ Parent entity
 
 is collection
   Designates whether this entity can have several sets of values. A question set connected to this entity will show interface elements to create new sets of answers. All entities in the tree below a collection entity adopt this behavior, so that questions about the same set can be spread over several question sets on separate pages of the interview.
+  An attribute "id" belonging to the entity is needed in order for the answer sets to be saved properly.
 
 Attribute
 """""""""


### PR DESCRIPTION
Damit Sammlungs-Entitäten funktionieren, musste ich ein "id"-Attribut erstellen. Ich konnte in der Dokumentation aber keine Anmerkung dazu finden. Ist das Vorhandensein des "id"-Attributs obligatorisch oder habe ich etwas übersehen?