### PR TITLE
pandoc versionen > 2.0 dropped --reference-odt/docx

### DIFF
--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -118,7 +118,7 @@ def render_to_format(request, format, title, template_src, context):
             # use reference document for certain file formats
             refdoc = set_export_reference_document(format)
             if refdoc is not None and (format == 'docx' or format == 'odt'):
-                    refdoc_param = '--reference-' + format + '=' + refdoc
+                    refdoc_param = '--reference-doc=' + refdoc
                     args.extend([refdoc_param])
 
             # create a temporary file

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -118,6 +118,10 @@ def render_to_format(request, format, title, template_src, context):
             # use reference document for certain file formats
             refdoc = set_export_reference_document(format)
             if refdoc is not None and (format == 'docx' or format == 'odt'):
+                if pypandoc.get_pandoc_version().startswith("1"):
+                    refdoc_param = '--reference-' + format + '=' + refdoc
+                    args.extend([refdoc_param])
+                else:
                     refdoc_param = '--reference-doc=' + refdoc
                     args.extend([refdoc_param])
 


### PR DESCRIPTION
The alternative would be to check the pandoc version and use parameters depending on that.
Better solution would be to simply raise the requirement to pandoc >2