### PR TITLE
requirements: drf-extensions >=0.5.0 

### DIFF
--- a/rdmo/conditions/urls/v1.py
+++ b/rdmo/conditions/urls/v1.py
@@ -8,8 +8,8 @@ from ..viewsets import ConditionViewSet, RelationViewSet
 app_name = 'v1-conditions'
 
 router = routers.DefaultRouter()
-router.register(r'conditions', ConditionViewSet, base_name='condition')
-router.register(r'relations', RelationViewSet, base_name='relation')
+router.register(r'conditions', ConditionViewSet, basename='condition')
+router.register(r'relations', RelationViewSet, basename='relation')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/core/urls/v1.py
+++ b/rdmo/core/urls/v1.py
@@ -5,7 +5,7 @@ from rest_framework import routers
 from ..viewsets import SettingsViewSet
 
 router = routers.DefaultRouter()
-router.register(r'settings', SettingsViewSet, base_name='setting')
+router.register(r'settings', SettingsViewSet, basename='setting')
 
 urlpatterns = [
     path('conditions/', include('rdmo.conditions.urls.v1')),

--- a/rdmo/domain/urls/v1.py
+++ b/rdmo/domain/urls/v1.py
@@ -10,7 +10,7 @@ from ..viewsets import AttributeViewSet
 app_name = 'v1-domain'
 
 router = routers.DefaultRouter()
-router.register(r'attributes', AttributeViewSet, base_name='attribute')
+router.register(r'attributes', AttributeViewSet, basename='attribute')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/options/urls/v1.py
+++ b/rdmo/options/urls/v1.py
@@ -7,8 +7,8 @@ from ..viewsets import OptionSetViewSet, OptionViewSet
 app_name = 'v1-options'
 
 router = routers.DefaultRouter()
-router.register(r'optionsets', OptionSetViewSet, base_name='optionset')
-router.register(r'options', OptionViewSet, base_name='option')
+router.register(r'optionsets', OptionSetViewSet, basename='optionset')
+router.register(r'options', OptionViewSet, basename='option')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/projects/urls/v1.py
+++ b/rdmo/projects/urls/v1.py
@@ -15,15 +15,15 @@ from ..viewsets import (
 app_name = 'v1-projects'
 
 router = ExtendedDefaultRouter()
-project_route = router.register(r'projects', ProjectViewSet, base_name='project')
-project_route.register(r'snapshots', ProjectSnapshotViewSet, base_name='project-snapshot',
+project_route = router.register(r'projects', ProjectViewSet, basename='project')
+project_route.register(r'snapshots', ProjectSnapshotViewSet, basename='project-snapshot',
                        parents_query_lookups=['project'])
-project_route.register(r'values', ProjectValueViewSet, base_name='project-value',
+project_route.register(r'values', ProjectValueViewSet, basename='project-value',
                        parents_query_lookups=['project'])
-router.register(r'snapshots', SnapshotViewSet, base_name='snapshot')
-router.register(r'values', ValueViewSet, base_name='value')
-router.register(r'questionsets', QuestionSetViewSet, base_name='questionset')
-router.register(r'catalogs', CatalogViewSet, base_name='catalog')
+router.register(r'snapshots', SnapshotViewSet, basename='snapshot')
+router.register(r'values', ValueViewSet, basename='value')
+router.register(r'questionsets', QuestionSetViewSet, basename='questionset')
+router.register(r'catalogs', CatalogViewSet, basename='catalog')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/questions/urls/v1.py
+++ b/rdmo/questions/urls/v1.py
@@ -14,12 +14,12 @@ from ..viewsets import (
 app_name = 'v1-questions'
 
 router = routers.DefaultRouter()
-router.register(r'catalogs', CatalogViewSet, base_name='catalog')
-router.register(r'sections', SectionViewSet, base_name='section')
-router.register(r'questionsets', QuestionSetViewSet, base_name='questionset')
-router.register(r'questions', QuestionViewSet, base_name='question')
-router.register(r'widgettypes', WidgetTypeViewSet, base_name='widgettype')
-router.register(r'valuetypes', ValueTypeViewSet, base_name='valuetype')
+router.register(r'catalogs', CatalogViewSet, basename='catalog')
+router.register(r'sections', SectionViewSet, basename='section')
+router.register(r'questionsets', QuestionSetViewSet, basename='questionset')
+router.register(r'questions', QuestionViewSet, basename='question')
+router.register(r'widgettypes', WidgetTypeViewSet, basename='widgettype')
+router.register(r'valuetypes', ValueTypeViewSet, basename='valuetype')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/tasks/urls/v1.py
+++ b/rdmo/tasks/urls/v1.py
@@ -7,7 +7,7 @@ from ..viewsets import TaskViewSet
 app_name = 'v1-tasks'
 
 router = routers.DefaultRouter()
-router.register(r'tasks', TaskViewSet, base_name='task')
+router.register(r'tasks', TaskViewSet, basename='task')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rdmo/views/urls/v1.py
+++ b/rdmo/views/urls/v1.py
@@ -7,7 +7,7 @@ from ..viewsets import ViewViewSet
 app_name = 'v1-views'
 
 router = routers.DefaultRouter()
-router.register(r'views', ViewViewSet, base_name='view')
+router.register(r'views', ViewViewSet, basename='view')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
     description=u'RDMO is a tool to support the systematic planning, organisation and implementation of the data management throughout the course of a research project.',
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django>=2.0',
-        'djangorestframework>=3.9.2',
-        'drf-extensions>=0.3',
+        'Django>=2.1,<3',
+        'djangorestframework>=3.9.3',
+        'drf-extensions>=0.5.0,<0.6',
         'django-extensions>=1.7',
         'django-allauth>=0.31',
         'django-filter>2.0',


### PR DESCRIPTION
With drf-extensons `base_name` is renamed to `basename`, so some changes are necessary to build and run RDMO.

Another option is to use drf-extensions>=0.4.0,<0.5, but soon or later these changes are required.

Anyway, I tested different versions of drf-extensions and find some incompatibility in the used requirements:

- drf-extensions 0.3.x is not usable with Django>=2
- drf-extensions 0.4.0 and 0.5.0 needs at least Django>=2.1

Rferences:

- [Support Django 2.1 and DRF 3.9 (drop 3.8) #248](https://github.com/chibisov/drf-extensions/pull/248)
