### PR TITLE
setup.py: Allow "Django>=2.2.4,<2.3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'coverage==4.5.3',
         'defusedxml==0.6.0',
-        'Django==2.2.3',
+        'Django>=2.2.4,<2.3',
         'django-allauth==0.39.1',
         'django-compressor==2.3',
         'django-extensions==2.1.7',


### PR DESCRIPTION
Don't force a specific Django patch release unless it's absolutely necessary, rather just forbid upgrade to the next (potentially breaking) minor version branch. Force Django 2.2.4 as the minimum version since that release fixes a bunch of CVEs.

Forcing exact dependency versions is bad practice since it prevents users from upgrading dependencies when new patch releases of said dependencies are released.

The rest of the dependencies in setup.py should be fixed the same way.