### PR TITLE
sidebar list style for catalog count ans management upload 

### DIFF
--- a/rdmo/management/templates/management/upload.html
+++ b/rdmo/management/templates/management/upload.html
@@ -83,8 +83,13 @@
                 </table>
             </div>
             <div class="sidebar col-md-3">
-                <input type="submit" value="{% trans 'Import elements' %}"
-                       class="btn btn-success btn-import"></submit>
+                 <ul class="list-unstyled">
+                    <li>
+                        <input type="submit" value="{% trans 'Import elements' %}"
+                               class="btn btn-success btn-import"></>
+                        </p>
+                    </li>
+                </ul>
             </div>
         </form>
     </div>

--- a/rdmo/questions/templates/questions/catalogs_sidebar.html
+++ b/rdmo/questions/templates/questions/catalogs_sidebar.html
@@ -103,9 +103,13 @@
             </li>
         </ul>
 
-        <p ng-show="service.catalog.projects_count">
-            {% blocktrans trimmed with projects_count='{$ service.catalog.projects_count $}' %}
-            This catalog is used in <b>{{ projects_count }} projects</b>.
-            {% endblocktrans %}
-        </p>
+        <ul class="list-unstyled">
+            <li>
+                <p ng-show="service.catalog.projects_count">
+                    {% blocktrans trimmed with projects_count='{$ service.catalog.projects_count $}' %}
+                    This catalog is used in <b>{{ projects_count }} projects</b>.
+                    {% endblocktrans %}
+                </p>
+            </li>
+        </ul>
     </div>


### PR DESCRIPTION
This PR integrates 'catalog count' entry and 'Catalog upload' into the sidebar via list style. 

This fixes possible overlapping with the upload button from the above entry (upload catalog). 

**without fix** (rdmo-v1.4)
![image](https://user-images.githubusercontent.com/30596226/102780413-2895e680-4396-11eb-841c-4d9ba7917f16.png)

and in the case for  'catalog upload' it adds space after the button in the sidebar, which is needed for sidebars using background color other than that of the page.
