### PR TITLE
Add pandoc args setting to local.py

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -217,6 +217,11 @@ EXPORT_REFERENCE_DOCX_VIEWS = {}
 EXPORT_REFERENCE_ODT = None
 EXPORT_REFERENCE_DOCX = None
 
+EXPORT_PANDOC_ARGS = {
+    'pdf': ['-V', 'geometry:margin=1in', '--pdf-engine=xelatex'],
+    'rtf': ['--standalone']
+}
+
 PROJECT_EXPORTS = [
     ('xml', _('RDMO XML'), 'rdmo.projects.exports.RDMOXMLExport'),
     ('csvcomma', _('CSV comma separated'), 'rdmo.projects.exports.CSVCommaExport'),


### PR DESCRIPTION
I added the possibility to set pandoc args in the local py. The entry structure looks like this: 

```python
EXPORT_PANDOC_ARGS = {
    'pdf': [ '-V', 'geometry:margin=1in', '--pdf-engine=xelatex' ],
    'rtf': ['--standalone']
}
```

When the entry doesn't exist the arguments for the file format will be empty during export. I don't know it this is a good idea or if it would be better to hard code a set of default args. The way it is know I find it clearer and more straight forward but the downside is that rtf exports will probably break at running instance that do not have the setting.

PS: I also make the linter happy and added a few line breaks at lines which were too long.