### PR TITLE
Metadata

### DIFF
--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -1,5 +1,5 @@
-from defusedcsv import csv
 import importlib
+import json
 import logging
 import os
 import re
@@ -7,15 +7,16 @@ from pathlib import Path
 from tempfile import mkstemp
 from urllib.parse import urlparse
 
+from markdown import markdown
+
 import pypandoc
+from defusedcsv import csv
 from django.apps import apps
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.template.loader import get_template
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
-from markdown import markdown
-import json
 
 log = logging.getLogger(__name__)
 

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -334,11 +334,11 @@ def parse_metadata(html):
     soup = BeautifulSoup(html, 'html.parser')
     try:
         html_metadata = soup.find('metadata').extract()
-    except AttributeError:
-        pass
-    else:
         html_metadata = html_metadata.text
         metadata = json.loads(html_metadata)
+    except (AttributeError, json.JSONDecodeError):
+        pass
+    else:
         html = str(soup)
     return metadata, html
 
@@ -348,6 +348,5 @@ def save_metadata(metadata):
     with open(tmp_metadata_file, 'w') as f:
         json.dump(metadata, f)
     f = open(tmp_metadata_file)
-    data = json.load(f)
     log.info('Save metadata file %s %s', tmp_metadata_file, str(metadata))
     return tmp_metadata_file

--- a/rdmo/views/models.py
+++ b/rdmo/views/models.py
@@ -4,10 +4,8 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.template import Context, Template
 from django.utils.translation import gettext_lazy as _
-
-from rdmo.conditions.models import Condition
 from rdmo.core.models import TranslationMixin
-from rdmo.core.utils import copy_model, get_pandoc_version, join_url
+from rdmo.core.utils import copy_model, get_pandoc_main_version, join_url
 from rdmo.questions.models import Catalog
 
 from .managers import ViewManager
@@ -161,7 +159,7 @@ class View(models.Model, TranslationMixin):
             'project': project_wrapper,
             'conditions': project_wrapper.conditions,
             'format': export_format,
-            'pandoc_version': get_pandoc_version()
+            'pandoc_version': get_pandoc_main_version()
         }))
 
     @classmethod


### PR DESCRIPTION
A first suggestion how to add metadata to views. I decided to stick to html syntax because we use it in the views anyway. The block below shows how to add the metadata inside the view. What's inside the metadata tags gets written to a temporary file which pandoc is passed to pandoc as `--metadata-file`.

```
<metadata>
{
"title": "this is a very nice title",
"author": ["author one", "author two"],
"keywords": ["nothing", "something", "whatever"]
}
</metadata>
```

Anyway there are at least two we should be thinking about.

1. What about validation of the metadata set? If the json string is invalid the document export will work. Obviously without any metadata in it at the end. But it would be nice to show the user editing the view that the json string contains errors.

2. Looking at the view in RDMO the metadata block is displayed looking like a simple plain string. I think it would be nice to add a little css or something to make it look nicer.

3. I tested with pandoc  2.9.2.1. I will check out how earlier pandoc versions treat the metadata file and if there are any errors.