### PR TITLE
Remove diverging font for headings

### DIFF
--- a/rdmo/core/static/core/css/fonts.scss
+++ b/rdmo/core/static/core/css/fonts.scss
@@ -35,9 +35,6 @@
 body {
     font-family: DroidSans, sans;
 }
-h1, h2, h3, h4, h5, h6 {
-    font-family: DroidSerif, serif;
-}
 
 a.fa {
     text-decoration: none !important;


### PR DESCRIPTION
Just use the same font that is also used for body (=everything else).

Currently, headings (`<h1>`-`<h6>`) use DroidSerif while everything else (`<body>` and all its child nodes) uses DroidSans, which looks kinda goofy.