### PR TITLE
Fix attribute index api

### DIFF
--- a/rdmo/conditions/viewsets.py
+++ b/rdmo/conditions/viewsets.py
@@ -33,7 +33,7 @@ class ConditionViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        queryset = self.get_queryset()
+        queryset = Condition.objects.select_related('source', 'target_option')
         serializer = ConditionIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/rdmo/domain/static/domain/js/domain.js
+++ b/rdmo/domain/static/domain/js/domain.js
@@ -51,7 +51,7 @@ angular.module('domain', ['core'])
 
     service.initView = function() {
         service.domain = resources.attributes.query({list_action: 'nested'})
-        service.attributes = resources.attributes.query(function(response) {
+        service.attributes = resources.attributes.query({list_action: 'index'}, function(response) {
             service.uri_prefixes = response.reduce(function(list, item) {
                 if (list.indexOf(item.uri_prefix) < 0) {
                     list.push(item.uri_prefix)

--- a/rdmo/domain/viewsets.py
+++ b/rdmo/domain/viewsets.py
@@ -40,7 +40,7 @@ class AttributeViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        queryset = self.get_queryset()
+        queryset = Attribute.objects.order_by('path')
         serializer = AttributeIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/rdmo/options/viewsets.py
+++ b/rdmo/options/viewsets.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
+
 from django_filters.rest_framework import DjangoFilterBackend
+
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -43,7 +45,8 @@ class OptionSetViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = OptionSetIndexSerializer(self.get_queryset(), many=True)
+        queryset = OptionSet.objects.order_by('order').prefetch_related('options')
+        serializer = OptionSetIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])
@@ -78,7 +81,8 @@ class OptionViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = OptionIndexSerializer(self.get_queryset(), many=True)
+        queryset = Option.objects.order_by('optionset__order', 'order')
+        serializer = OptionIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])

--- a/rdmo/questions/viewsets.py
+++ b/rdmo/questions/viewsets.py
@@ -72,7 +72,8 @@ class CatalogViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = CatalogIndexSerializer(self.get_queryset(), many=True)
+        queryset = Catalog.objects.all()
+        serializer = CatalogIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])
@@ -131,7 +132,8 @@ class SectionViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = SectionIndexSerializer(self.get_queryset(), many=True)
+        queryset = Section.objects.all()
+        serializer = SectionIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])
@@ -190,7 +192,8 @@ class QuestionSetViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = QuestionSetIndexSerializer(self.get_queryset(), many=True)
+        queryset = QuestionSet.objects.all()
+        serializer = QuestionSetIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])
@@ -244,7 +247,8 @@ class QuestionViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = QuestionIndexSerializer(self.get_queryset(), many=True)
+        queryset = Question.objects.all()
+        serializer = QuestionIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])

--- a/rdmo/tasks/viewsets.py
+++ b/rdmo/tasks/viewsets.py
@@ -28,7 +28,7 @@ class TaskViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        queryset = self.get_queryset()
+        queryset = Task.objects.select_related('start_attribute', 'end_attribute')
         serializer = TaskIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/rdmo/views/viewsets.py
+++ b/rdmo/views/viewsets.py
@@ -27,7 +27,8 @@ class ViewViewSet(CopyModelMixin, ModelViewSet):
 
     @action(detail=False)
     def index(self, request):
-        serializer = ViewIndexSerializer(self.get_queryset(), many=True)
+        queryset =  View.objects.all()
+        serializer = ViewIndexSerializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, permission_classes=[HasModelPermission])


### PR DESCRIPTION
This PR fixes the `/domain/attributes/index` API to use a simpler query and the `domain` angular app to use this API instead of `/domain/attributes/`.