### PR TITLE
add quicksearch for questions-optionsets and -conditions

### DIFF
--- a/rdmo/questions/templates/questions/catalogs_modal_form_questions.html
+++ b/rdmo/questions/templates/questions/catalogs_modal_form_questions.html
@@ -359,7 +359,8 @@
                                         data-errors="service.errors.optionsets"
                                         data-options="service.optionsets"
                                         data-options-label="uri"
-                                        data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">
+                                        data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}"
+                                        data-quicksearch="true">
                                     </formgroup>
                                 </div>
                                 <div role="tabpanel" class="tab-pane" id="questions-conditions">
@@ -371,7 +372,8 @@
                                         data-errors="service.errors.conditions"
                                         data-options="service.conditions"
                                         data-options-label="uri"
-                                        data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">
+                                        data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}"
+                                        data-quicksearch="true">
                                     </formgroup>
                                 </div>
                                 <div role="tabpanel" class="tab-pane" id="questions-range">


### PR DESCRIPTION
implements the search box in the update question modal form,
via the built-in `data-quicksearch` feature:
```js
data-quicksearch="true"
```
