### PR TITLE
Add missing bootstrap fonts to VENDOR settings

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -323,6 +323,23 @@ VENDOR = {
                 'path': 'css/bootstrap.min.css',
                 'sri': 'sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu',
             }
+        ],
+        'font': [
+            {
+                'path': 'fonts/glyphicons-halflings-regular.eot'
+            },
+            {
+                'path': 'fonts/glyphicons-halflings-regular.woff'
+            },
+            {
+                'path': 'fonts/glyphicons-halflings-regular.woff2'
+            },
+            {
+                'path': 'fonts/glyphicons-halflings-regular.ttf'
+            },
+            {
+                'path': 'fonts/glyphicons-halflings-regular.svg'
+            }
         ]
     },
     'bootstrap-datepicker': {


### PR DESCRIPTION
This PR adds some missing fonts to the `VENDOR` settings (which caused no problems, but might, when using WhiteNoise).