### PR TITLE
Edit list separator

### DIFF
--- a/rdmo/views/templates/views/tags/value_inline_list.html
+++ b/rdmo/views/templates/views/tags/value_inline_list.html
@@ -1,3 +1,3 @@
 {% for value in values %}
-    {{ value.value_and_unit }}{% if not forloop.last %}, {% endif %}
+    {{ value.value_and_unit }}{% if not forloop.last %}; {% endif %}
 {% endfor %}


### PR DESCRIPTION
The comma is not sufficient as a separator, in case the single entries are long sentences. I suggest the semicolon.