### PR TITLE
Add metadata and CSS in exported HTML view

### DIFF
--- a/rdmo/projects/templates/projects/project_view_export.html
+++ b/rdmo/projects/templates/projects/project_view_export.html
@@ -1,6 +1,20 @@
 {% extends 'core/export.html' %}
 {% load i18n %}
 
+
+{% block head %}
+	<title>DMP_{{ values.project.funder.grant_nr }}_{{ values.project.research_question.acronym }}_v{{ values.project.dmp.dmp_version|default:"1" }}</title>
+	<meta charset="UTF-8" />
+	<meta name="category"	content="{{ values.project.funder.grant_nr }}" />
+	<meta name="subject"	content="{{ values.project.research_question.acronym }}" />
+	<meta name="description"	content="{{ values.project.research_question.title }}" />
+	<meta name="keywords"	content={{ values.project.research_question.keywords }}" />
+	<meta name="contentStatus"	content={{ values.project.dmp.dmp_version|default:"1" }} />
+	<style type="text/css">
+  	table {	table-layout: fixed; border: 0; white-space: nowrap; margin-left: auto; margin-right: auto;	}
+		td, th {	padding: 10px;	}
+  </style>
+{% endblock %}
 {% block body %}
 
 {{ rendered_view }}


### PR DESCRIPTION
The added CSS block is only a trial; probably we need something more customisable.  
Possibly solves #255