### PR TITLE
Add a content editor permission role (m2m with sites) and add permission check for content items

### DIFF
--- a/rdmo/accounts/admin.py
+++ b/rdmo/accounts/admin.py
@@ -20,7 +20,7 @@ class ConsentFieldValueAdmin(admin.ModelAdmin):
 
 class RoleAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'user__email')
-    list_filter = ('member', 'manager')
+    list_filter = ('member', 'manager', 'content_editor')
 
 
 admin.site.register(AdditionalField, AdditionalFieldAdmin)

--- a/rdmo/accounts/admin.py
+++ b/rdmo/accounts/admin.py
@@ -20,7 +20,17 @@ class ConsentFieldValueAdmin(admin.ModelAdmin):
 
 class RoleAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'user__email')
-    list_filter = ('member', 'manager', 'content_editor')
+    list_filter = ('member', 'manager', 'editor')
+    list_display = ('user', 'manager_str', 'editor_str', 'member_str')
+
+    def member_str(self, obj):
+        return ', '.join([site.name for site in obj.member.all()])
+    def manager_str(self, obj):
+        return ', '.join([site.name for site in obj.manager.all()])
+    def editor_str(self, obj):
+        if obj.instance_editor:
+            return "Instance Editor"
+        return ', '.join([site.name for site in obj.editor.all()])
 
 
 admin.site.register(AdditionalField, AdditionalFieldAdmin)

--- a/rdmo/accounts/models.py
+++ b/rdmo/accounts/models.py
@@ -138,6 +138,12 @@ class Role(models.Model):
         help_text=_('The sites for which this user is manager.')
     )
 
+    content_editor = models.ManyToManyField(
+        Site, related_name='content_editors', blank=True,
+        verbose_name=_('Content Editors'),
+        help_text=_('The sites for which this user is a content editor.')
+    )
+
     class Meta:
         ordering = ('user', )
         verbose_name = _('Role')

--- a/rdmo/accounts/models.py
+++ b/rdmo/accounts/models.py
@@ -138,7 +138,7 @@ class Role(models.Model):
         help_text=_('The sites for which this user is manager.')
     )
 
-    content_editor = models.ManyToManyField(
+    editor = models.ManyToManyField(
         Site, related_name='content_editors', blank=True,
         verbose_name=_('Content Editors'),
         help_text=_('The sites for which this user is a content editor.')
@@ -152,6 +152,9 @@ class Role(models.Model):
     def __str__(self):
         return self.user.username
 
+    @property
+    def instance_editor(self):
+        return self.editor.all().count() == Site.objects.all().count()
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def post_save_user(sender, **kwargs):

--- a/rdmo/core/validators.py
+++ b/rdmo/core/validators.py
@@ -68,7 +68,6 @@ class LockedValidator(InstanceValidator):
 
     def __call__(self, data):
         is_locked = False
-
         # lock if a parent_field is set and a parent is set and the parent is locked
         if self.parent_field:
             parent = data.get(self.parent_field)
@@ -78,7 +77,13 @@ class LockedValidator(InstanceValidator):
         # lock only if the instance is now locked and was locked before
         if self.instance:
             is_locked |= data.get('locked', False) and self.instance.is_locked
-
+        # compare the content_editor sites of the user with the editor_sites of the instance
+        if not is_locked:
+            if self.serializer:
+                instance_editable_by_user = is_editable_by_user(self.instance, self.serializer.context['request']._user)
+                if not instance_editable_by_user:
+                    is_locked = True
+            
         if is_locked:
             if data.get('locked'):
                 raise self.raise_validation_error({
@@ -88,3 +93,20 @@ class LockedValidator(InstanceValidator):
                 raise self.raise_validation_error({
                     'locked': _('A superior element is locked.')
                 })
+                
+def is_editable_by_user(obj, user) -> bool:
+    ''' checks permission for the given object and user '''
+
+    if not hasattr(obj, 'editor_sites'):
+        # no editor_sites on object, so no locking (during development)
+        return True
+
+    if not user.role.content_editor.all().exists():
+        # user has no content_editor rights
+        return False
+
+    obj_editable_by_sites = obj.editor_sites.all()
+    user_role_editor_sites = user.role.content_editor.all()
+    obj_editable_by_user = user_role_editor_sites.filter(id__in=obj_editable_by_sites).exists()
+
+    return obj_editable_by_user

--- a/rdmo/questions/admin.py
+++ b/rdmo/questions/admin.py
@@ -67,7 +67,8 @@ class CatalogAdmin(admin.ModelAdmin):
     form = CatalogAdminForm
 
     search_fields = ['uri'] + get_language_fields('title')
-    list_display = ('uri', 'title', 'projects_count', 'available')
+    list_display = ('uri', 'title', 'projects_count', 'available',
+                    'sites_str_joined', 'editor_sites_str_joined',)
     readonly_fields = ('uri', )
     list_filter = ('available', )
 
@@ -77,6 +78,12 @@ class CatalogAdmin(admin.ModelAdmin):
 
     def projects_count(self, obj):
         return obj.projects_count
+    
+    def sites_str_joined(self, obj):
+        return ', '.join([site.name for site in obj.sites.all()])
+    
+    def editor_sites_str_joined(self, obj):
+        return ', '.join([site.name for site in obj.editor_sites.all()])
 
 
 class SectionAdmin(admin.ModelAdmin):

--- a/rdmo/questions/admin.py
+++ b/rdmo/questions/admin.py
@@ -68,7 +68,7 @@ class CatalogAdmin(admin.ModelAdmin):
 
     search_fields = ['uri'] + get_language_fields('title')
     list_display = ('uri', 'title', 'projects_count', 'available',
-                    'sites_str_joined', 'editor_sites_str_joined',)
+                    'sites_str_joined', 'sites_editors_str_joined',)
     readonly_fields = ('uri', )
     list_filter = ('available', )
 
@@ -82,8 +82,8 @@ class CatalogAdmin(admin.ModelAdmin):
     def sites_str_joined(self, obj):
         return ', '.join([site.name for site in obj.sites.all()])
     
-    def editor_sites_str_joined(self, obj):
-        return ', '.join([site.name for site in obj.editor_sites.all()])
+    def sites_editors_str_joined(self, obj):
+        return ', '.join([site.name for site in obj.sites_editors.all()])
 
 
 class SectionAdmin(admin.ModelAdmin):

--- a/rdmo/questions/models/catalog.py
+++ b/rdmo/questions/models/catalog.py
@@ -49,6 +49,14 @@ class Catalog(Model, TranslationMixin):
         verbose_name=_('Sites'),
         help_text=_('The sites this catalog belongs to (in a multi site setup).')
     )
+
+    editor_sites = models.ManyToManyField(
+        Site, blank=True,
+        verbose_name=_('edited by Sites'),
+        related_name='edited_catalogs',
+        help_text=_('The sites that edit this catalog (in a multi site setup).')
+    )
+
     groups = models.ManyToManyField(
         Group, blank=True,
         verbose_name=_('Group'),
@@ -137,6 +145,7 @@ class Catalog(Model, TranslationMixin):
         # copy m2m fields
         catalog.sites.set(self.sites.all())
         catalog.groups.set(self.groups.all())
+        catalog.editor_sites.set(self.editor_sites.all())
 
         # copy children
         for section in self.sections.all():

--- a/rdmo/questions/rules.py
+++ b/rdmo/questions/rules.py
@@ -1,0 +1,76 @@
+from django.contrib.sites.shortcuts import get_current_site
+
+import rules
+
+           
+def is_editable_by_user(obj, user) -> bool:
+    ''' checks permission for the given object and user '''
+    
+    # # compare the content_editor sites of the user with the sites_editors of the instance
+    # if not is_locked:
+    #     if self.serializer:
+    #         instance_editable_by_user = is_editable_by_user(self.instance, self.serializer.context['request']._user)
+    #         if not instance_editable_by_user:
+    #             is_locked = True
+
+    if not hasattr(obj, 'sites_editors'):
+        # no sites_editors on object, so no locking (during development)
+        return True
+
+    if not user.role.editor.all().exists():
+        # user has no content_editor rights
+        return False
+
+    obj_editable_by_sites = obj.sites_editors.all()
+    user_role_sites_editors = user.role.content_editor.all()
+    obj_editable_by_user = user_role_sites_editors.filter(id__in=obj_editable_by_sites).exists()
+
+    return obj_editable_by_user
+
+
+@rules.predicate
+def is_object_editor(user, object):
+    ''' Check if the user is a site editor for the object's site. '''
+    
+    if not user.is_authenticated:
+        return False
+    # if user is editor
+    if not user.role.filter(name='editor').exists():
+        return False
+    if user.is_superuser or user.is_staff:
+        return True
+    
+    user.groups.filter(name='editor') and user.role.members.filter(site=get_current_site(object))
+    # and user.groups.filter(name='editor').sites.filter(id=get_current_site(request).id).exists()
+    
+        
+    # current_site = get_current_site()
+    if not user.role.manager.filter(pk=object._edited_by.site.pk).exists():
+        return False
+    # object._edited_by.site.pk
+    # user
+    return user in object.member
+# or (project.parent and is_project_member(user, project.parent))
+
+@rules.predicate
+def is_instance_editor(user):
+    if not user.is_authenticated:
+        return False
+    
+    return user.role.instance_editor
+        
+
+@rules.predicate
+def is_current_project_member(user, project):
+    return user in project.member
+
+
+rules.add_perm('projects.view_value_object', is_project_member | is_site_manager)
+rules.add_perm('projects.add_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)
+rules.add_perm('projects.change_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)
+rules.add_perm('projects.delete_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)
+
+rules.add_perm('questions.view_questionset_object', is_project_member | is_site_manager)
+
+# TODO: use one of the permissions above
+rules.add_perm('projects.is_project_owner', is_project_owner)

--- a/rdmo/questions/serializers/v1.py
+++ b/rdmo/questions/serializers/v1.py
@@ -35,6 +35,7 @@ class CatalogSerializer(TranslationSerializerMixin, serializers.ModelSerializer)
             'order',
             'available',
             'sites',
+            'editor_sites',
             'groups',
             'projects_count'
         )
@@ -344,6 +345,7 @@ class CatalogNestedSerializer(TranslationSerializerMixin, serializers.ModelSeria
 
     sections = SectionNestedSerializer(many=True, read_only=True)
     sites = SiteSerializer(many=True, read_only=True)
+    editor_sites = SiteSerializer(many=True, read_only=True)
     warning = serializers.SerializerMethodField()
     xml_url = serializers.SerializerMethodField()
     export_urls = serializers.SerializerMethodField()
@@ -359,6 +361,7 @@ class CatalogNestedSerializer(TranslationSerializerMixin, serializers.ModelSeria
             'locked',
             'order',
             'sites',
+            'editor_sites',
             'title',
             'help',
             'sections',

--- a/rdmo/questions/serializers/v1.py
+++ b/rdmo/questions/serializers/v1.py
@@ -35,7 +35,7 @@ class CatalogSerializer(TranslationSerializerMixin, serializers.ModelSerializer)
             'order',
             'available',
             'sites',
-            'editor_sites',
+            'sites_editors',
             'groups',
             'projects_count'
         )
@@ -345,7 +345,7 @@ class CatalogNestedSerializer(TranslationSerializerMixin, serializers.ModelSeria
 
     sections = SectionNestedSerializer(many=True, read_only=True)
     sites = SiteSerializer(many=True, read_only=True)
-    editor_sites = SiteSerializer(many=True, read_only=True)
+    sites_editors = SiteSerializer(many=True, read_only=True)
     warning = serializers.SerializerMethodField()
     xml_url = serializers.SerializerMethodField()
     export_urls = serializers.SerializerMethodField()
@@ -361,7 +361,7 @@ class CatalogNestedSerializer(TranslationSerializerMixin, serializers.ModelSeria
             'locked',
             'order',
             'sites',
-            'editor_sites',
+            'sites_editors',
             'title',
             'help',
             'sections',

--- a/rdmo/questions/templates/questions/catalogs.html
+++ b/rdmo/questions/templates/questions/catalogs.html
@@ -63,10 +63,10 @@
             {% if settings.MULTISITE %}
             <div class="panel-body">
                 <div class="row">
-                    <div class="col-sm-3">
+                    <div class="col-sm-2">
                         <strong>{% trans 'Sites for this catalog' %}</strong>
                     </div>
-                    <div class="col-sm-9">
+                    <div class="col-sm-3">
                          <ul>
                             <li ng-show="service.catalog.sites.length > 0 && service.catalog.sites.length < service.sites.length"
                                 ng-repeat="site in service.catalog.sites">
@@ -75,6 +75,23 @@
                             <li ng-show="service.catalog.sites.length == 0 || service.catalog.sites.length == service.sites.length">
                                 {% trans 'All sites' %}
                             </li>
+                        </ul>
+                    </div>
+                    <div class="col-sm-2">
+                        <strong>{% trans 'Editor Sites' %}</strong>
+                    </div>
+                    <div class="col-sm-3">
+                         <ul>
+                            <li ng-show="service.catalog.editor_sites.length > 0 && service.catalog.editor_sites.length < service.sites.length"
+                                ng-repeat="site in service.catalog.editor_sites">
+                                {$ site.name $}
+                            </li>
+                            <li ng-show="service.catalog.editor_sites.length == service.sites.length">
+                                {% trans 'All sites' %}
+                            </li>
+                            <li ng-show="service.catalog.editor_sites.length == 0">
+                                {% trans 'No sites' %}
+                            </li>                           
                         </ul>
                     </div>
                 </div>

--- a/rdmo/questions/templates/questions/catalogs.html
+++ b/rdmo/questions/templates/questions/catalogs.html
@@ -82,14 +82,14 @@
                     </div>
                     <div class="col-sm-3">
                          <ul>
-                            <li ng-show="service.catalog.editor_sites.length > 0 && service.catalog.editor_sites.length < service.sites.length"
-                                ng-repeat="site in service.catalog.editor_sites">
+                            <li ng-show="service.catalog.sites_editors.length > 0 && service.catalog.sites_editors.length < service.sites.length"
+                                ng-repeat="site in service.catalog.sites_editors">
                                 {$ site.name $}
                             </li>
-                            <li ng-show="service.catalog.editor_sites.length == service.sites.length">
+                            <li ng-show="service.catalog.sites_editors.length == service.sites.length">
                                 {% trans 'All sites' %}
                             </li>
-                            <li ng-show="service.catalog.editor_sites.length == 0">
+                            <li ng-show="service.catalog.sites_editors.length == 0">
                                 {% trans 'No sites' %}
                             </li>                           
                         </ul>

--- a/rdmo/questions/templates/questions/catalogs_modal_form_catalogs.html
+++ b/rdmo/questions/templates/questions/catalogs_modal_form_catalogs.html
@@ -133,6 +133,17 @@
                                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                     </a>
                                 </li>
+
+                                <li role="presentation" ng-class="{
+                                    'has-error': service.errors.editor-sites,
+                                }">
+                                    <a class="control-label" href="#catalogs-editor-sites"
+                                        role="tab" data-toggle="tab" aria-controls="catalogs-editor-sites">
+
+                                        {% trans 'Editor Sites' %}
+                                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    </a>
+                                </li>
                                 {% endif %}
                             </ul>
                             <div class="tab-content">
@@ -196,6 +207,18 @@
                                         data-label="{% trans 'Sites' %}"
                                         data-model="service.values.sites"
                                         data-errors="service.errors.sites"
+                                        data-options="service.sites"
+                                        data-options-label="name"
+                                        data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">
+                                    </formgroup>
+                                </div>
+                                <div role="tabpanel" class="tab-pane" id="catalogs-editor-sites">
+                                    <formgroup
+                                        data-id="catalog_editor_sites"
+                                        data-type="selectmultiple"
+                                        data-label="{% trans 'Sites' %}"
+                                        data-model="service.values.editor_sites"
+                                        data-errors="service.errors.editor_sites"
                                         data-options="service.sites"
                                         data-options-label="name"
                                         data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">

--- a/rdmo/questions/templates/questions/catalogs_modal_form_catalogs.html
+++ b/rdmo/questions/templates/questions/catalogs_modal_form_catalogs.html
@@ -214,11 +214,11 @@
                                 </div>
                                 <div role="tabpanel" class="tab-pane" id="catalogs-editor-sites">
                                     <formgroup
-                                        data-id="catalog_editor_sites"
+                                        data-id="catalog_sites_editors"
                                         data-type="selectmultiple"
                                         data-label="{% trans 'Sites' %}"
-                                        data-model="service.values.editor_sites"
-                                        data-errors="service.errors.editor_sites"
+                                        data-model="service.values.sites_editors"
+                                        data-errors="service.errors.sites_editors"
                                         data-options="service.sites"
                                         data-options-label="name"
                                         data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">


### PR DESCRIPTION
In order to make content items (eg Catalogs etc..) editable only by users with editor roles from certain sites. 

An extra field  `content_editor` was added to the `Role` model.
An extra field to `editor_sites` was added to the `Catalog` model.
The "permission check" or validation is now done through the `LockedValidator`.

Draft for #490 