### PR TITLE
Add "last_login" and "date_joined" fields to user serializer

### DIFF
--- a/rdmo/accounts/serializers/v1.py
+++ b/rdmo/accounts/serializers/v1.py
@@ -74,5 +74,7 @@ class UserSerializer(serializers.ModelSerializer):
                 'username',
                 'first_name',
                 'last_name',
-                'email'
+                'email',
+                'last_login',
+                'date_joined',
             ]


### PR DESCRIPTION
We would like to have these extra fields in the api/v1 for anonymous user statistical purposes

Can we assume that the `last_login` and `date_joined` are always in the `User` model?

or should I add a check under [serializers/v1.py#L77](https://github.com/rdmorganiser/rdmo/blob/c6a930f6adfaa0fc5a3ce3fbd4fbac3c85cea2a1/rdmo/accounts/serializers/v1.py#L77)  like this?
```py
if hasattr(model, 'last_login'):
    fields += [
        'last_login',
    ]
```