### PR TITLE
Remove links from projekt sidebar if tasks/views not available

### DIFF
--- a/rdmo/__init__.py
+++ b/rdmo/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'rdmo'
-__version__ = '1.8.2'
+__version__ = '1.9.0'
 __author__ = 'RDMO Arbeitsgemeinschaft'
 __email__ = 'rdmo-team@listserv.dfn.de'
 __license__ = 'Apache-2.0'

--- a/rdmo/projects/templates/projects/project_detail_sidebar.html
+++ b/rdmo/projects/templates/projects/project_detail_sidebar.html
@@ -52,12 +52,12 @@
         <a href="{% url 'project_update_parent' project.pk %}">{% trans 'Update parent project' %}</a>
     </li>
     {% endif %}
-    {% if settings.PROJECT_ISSUES %}
+    {% if settings.PROJECT_ISSUES and tasks_available %}
     <li>
         <a href="{% url 'project_update_tasks' project.pk %}">{% trans 'Update project tasks' %}</a>
     </li>
     {% endif %}
-    {% if settings.PROJECT_VIEWS %}
+    {% if settings.PROJECT_VIEWS and views_available %}
     <li>
         <a href="{% url 'project_update_views' project.pk %}">{% trans 'Update project views' %}</a>
     </li>


### PR DESCRIPTION
This fixes the sidebar in the projekts view so that task and view update links are not displayed if they are not available. Do we have to adjust the Overlays too? 