### PR TITLE
Fix github actions: pinning ubuntu image to 20.04

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         db-backend: [mysql, postgres, sqlite3]
-        python-version: ['3.6', '3.10']
+        python-version: ['3.6', '3.11']
 
     services:
       postgres:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         db-backend: [mysql, postgres, sqlite3]


### PR DESCRIPTION
This PR implements two changes to the github actions workflow checking pytests:

* pin the ubuntu image to 20.04 as `ubuntu-latest` now points to 22.04
* change the upper python version that will be tested from 3.10 to 3.11