### PR TITLE
Fix #560 cancel import project data

### DIFF
--- a/rdmo/projects/mixins.py
+++ b/rdmo/projects/mixins.py
@@ -204,6 +204,12 @@ class ProjectImportMixin(object):
     def import_project(self):
         current_project = self.object
 
+        if 'cancel' in self.request.POST:
+            if current_project:
+                return HttpResponseRedirect(current_project.get_absolute_url())
+            else:
+                return HttpResponseRedirect(self.success_url)
+
         # get the original project
         project = get_object_or_404(Project.objects.all(), id=self.request.POST.get('source'))
 


### PR DESCRIPTION
This PR aims at fixing issue #560 by adding a check for the existence of cancel the button in POST data. However, I am not sure if there is a better way for the implementation from the upper function `ProjectUpdateImportView.post()` so that not every single function inside the `ProjectImportMixin` needs to implement this but still redirects to the current project.