### PR TITLE
set pdf pandoc export arg paper size to A4 as default setting

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -247,7 +247,7 @@ EXPORT_REFERENCE_ODT = None
 EXPORT_REFERENCE_DOCX = None
 
 EXPORT_PANDOC_ARGS = {
-    'pdf': ['-V', 'geometry:margin=1in', '--pdf-engine=xelatex'],
+    'pdf': ['-V', 'geometry:a4paper, margin=1in', '--pdf-engine=xelatex'],
     'rtf': ['--standalone']
 }
 


### PR DESCRIPTION
We received a request from a user about having the geometry of the exported `pdf` as `A4` instead of `Letter` format.

This can be done with the `EXPORT_PANDOC_ARGS` in the settings, but should we not set the `A4` size as the default setting?

With arg: `'geometry:a4paper, margin=1in'`


