### PR TITLE
fix for serializers in prep-2.0.0_rebase

### DIFF
--- a/rdmo/conditions/serializers/v1.py
+++ b/rdmo/conditions/serializers/v1.py
@@ -17,10 +17,12 @@ class ConditionSerializer(ReadOnlyObjectPermissionsSerializerMixin, ElementModel
     model = serializers.SerializerMethodField()
     key = serializers.SlugField(required=True)
     source = serializers.PrimaryKeyRelatedField(queryset=Attribute.objects.all(), required=True)
-    optionsets = OptionSetSerializer(many=True, read_only=True)
-    questionsets = QuestionSetSerializer(many=True, read_only=True)
-    questions = QuestionSerializer(many=True, read_only=True)
-    tasks = TaskSerializer(many=True, read_only=True)
+
+    optionsets = serializers.PrimaryKeyRelatedField(queryset=OptionSet.objects.all(), required=False, many=True)
+    pages = serializers.PrimaryKeyRelatedField(queryset=Page.objects.all(), required=False, many=True)
+    questionsets = serializers.PrimaryKeyRelatedField(queryset=QuestionSet.objects.all(), required=False, many=True)
+    questions = serializers.PrimaryKeyRelatedField(queryset=Question.objects.all(), required=False, many=True)
+    tasks = serializers.PrimaryKeyRelatedField(queryset=Task.objects.all(), required=False, many=True)
     read_only = serializers.SerializerMethodField()
 
     class Meta:

--- a/rdmo/domain/serializers/v1.py
+++ b/rdmo/domain/serializers/v1.py
@@ -74,7 +74,7 @@ class AttributeSerializer(BaseAttributeSerializer):
         return [attribute.id for attribute in obj.get_descendants()]
 
 
-class AttributeNestedSerializer(ReadOnlyObjectPermissionsSerializerMixin, serializers.ModelSerializer):
+class AttributeListSerializer(ElementExportSerializerMixin, BaseAttributeSerializer):
 
     xml_url = serializers.SerializerMethodField()
 

--- a/rdmo/tasks/serializers/v1.py
+++ b/rdmo/tasks/serializers/v1.py
@@ -1,16 +1,17 @@
 from rest_framework import serializers
 
 from rdmo.core.serializers import (ElementExportSerializerMixin,
+                                   ElementModelSerializerMixin,
                                    ElementWarningSerializerMixin,
                                    TranslationSerializerMixin,
                                    ReadOnlyObjectPermissionsSerializerMixin)
-from rdmo.core.utils import get_language_warning
 
 from ..models import Task
 from ..validators import TaskLockedValidator, TaskUniqueURIValidator
 
 
-class TaskSerializer(ReadOnlyObjectPermissionsSerializerMixin, TranslationSerializerMixin, serializers.ModelSerializer):
+class BaseTaskSerializer(ReadOnlyObjectPermissionsSerializerMixin, TranslationSerializerMixin, ElementModelSerializerMixin,
+                         serializers.ModelSerializer):
 
     model = serializers.SerializerMethodField()
     read_only = serializers.SerializerMethodField()
@@ -65,7 +66,7 @@ class TaskListSerializer(ElementExportSerializerMixin, ElementWarningSerializerM
 
     warning = serializers.SerializerMethodField()
     xml_url = serializers.SerializerMethodField()
-    
+
     class Meta(BaseTaskSerializer.Meta):
         fields = BaseTaskSerializer.Meta.fields + (
             'warning',
@@ -74,6 +75,7 @@ class TaskListSerializer(ElementExportSerializerMixin, ElementWarningSerializerM
         warning_fields = (
             'title',
         )
+
 
 class TaskIndexSerializer(serializers.ModelSerializer):
 

--- a/rdmo/views/serializers/v1.py
+++ b/rdmo/views/serializers/v1.py
@@ -6,13 +6,13 @@ from rdmo.core.serializers import (ElementExportSerializerMixin,
                                    ElementWarningSerializerMixin,
                                    TranslationSerializerMixin,
                                    ReadOnlyObjectPermissionsSerializerMixin)
-from rdmo.core.utils import get_language_warning
 
 from ..models import View
 from ..validators import ViewLockedValidator, ViewUniqueURIValidator
 
 
-class ViewSerializer(ReadOnlyObjectPermissionsSerializerMixin, TranslationSerializerMixin, serializers.ModelSerializer):
+class BaseViewSerializer(ReadOnlyObjectPermissionsSerializerMixin, TranslationSerializerMixin, 
+                            ElementModelSerializerMixin,serializers.ModelSerializer):
 
     model = serializers.SerializerMethodField()
     read_only = serializers.SerializerMethodField()


### PR DESCRIPTION
made some mistakes, some code of the serializers of `refactor_elements` were overwritten.
I hope that the correct commits from `refactor_elements` remain when I rebase this onto the prep branch.