### PR TITLE
Dev 1.11.0 requirements django-allauth 0.53.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ coverage==5.5
 defusedcsv~=2.0.0
 defusedxml~=0.7.1
 Django~=3.2.14
-django-allauth~=0.51.0
+django-allauth~=0.53.1
 django-cleanup~=6.0.0
 django-compressor==4.0
 django-extensions~=3.2.0


### PR DESCRIPTION
We are currently at version 0.51.0, I would like to have the 0.52.0 because it implements a new OpenID Connect Provider.
I have deployed this 0.53.1 version already to our Test Instance.

* https://django-allauth.readthedocs.io/en/latest/release-notes.html#section-2

We aim to get the current (or next) release, however 0.54.0 drops support for Python 3.6

