### PR TITLE
bug fix for typo in tasks modal form

### DIFF
--- a/rdmo/tasks/templates/tasks/tasks_modal_form_tasks.html
+++ b/rdmo/tasks/templates/tasks/tasks_modal_form_tasks.html
@@ -200,7 +200,7 @@
                                         data-model="service.values.groups"
                                         data-errors="service.errors.groups"
                                         data-options="service.groups"
-                                        data-options-label="uri"
+                                        data-options-label="name"
                                         data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">
                                     </formgroup>
                                 </div>
@@ -213,7 +213,7 @@
                                         data-model="service.values.sites"
                                         data-errors="service.errors.sites"
                                         data-options="service.sites"
-                                        data-options-label="uri"
+                                        data-options-label="name"
                                         data-help="{% trans 'Hold down Control, or Command on a Mac, to select more than one.' %}">
                                     </formgroup>
                                 </div>


### PR DESCRIPTION
mini bug-fix for tasks modal form, the "groups" and "sites" could not be seen..

