### PR TITLE
ci: update ci job run conditions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,10 @@
 name: pytest
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Hi there,

after merging #652, you immediately received a couple or PRs by dependabot, which is great.

Dependabot creates an individual branch per updated dependency it found. With the current CI configuration each PR runs 12 CI jobs, 6 on the branch and 6 on the PR. A bit too much.

Running CI jobs only on master and PRs is also part of #586. But as that PR is still WIP, I wanted to suggest to merge this smaller change as soon as possible, to reduce the number of CI job runs.

What do you think?