### PR TITLE
Refactor serializers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,7 @@ python --reuse-db                                               # keep the datab
 pytest rdmo/domain                                              # test only the domain app
 pytest rdmo/domain/tests/test_viewsets.py                       # run only a specific test file
 pytest rdmo/domain/tests/test_viewsets.py::test_attribute_list  # run only a specific test
+pytest -k 'test_validator'                                      # run only set of test files, using substring matching
 ```
 
 Coverage

--- a/rdmo/conditions/tests/test_validator_locked.py
+++ b/rdmo/conditions/tests/test_validator_locked.py
@@ -59,29 +59,29 @@ def test_update_unlock(db):
 
 def test_serializer_create(db):
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer())
+    serializer = ConditionSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer())
+    serializer = ConditionSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     condition = Condition.objects.first()
 
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
-    validator({})
+    validator({}, serializer)
 
 
 def test_serializer_update_error(db):
@@ -90,23 +90,23 @@ def test_serializer_update_error(db):
     condition.save()
 
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)
 
 
 def test_serializer_update_lock(db):
     condition = Condition.objects.first()
 
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update_unlock(db):
@@ -115,8 +115,8 @@ def test_serializer_update_unlock(db):
     condition.save()
 
     validator = ConditionLockedValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
     validator({
         'locked': False
-    })
+    }, serializer)

--- a/rdmo/conditions/tests/test_validator_unique_uri.py
+++ b/rdmo/conditions/tests/test_validator_unique_uri.py
@@ -45,45 +45,45 @@ def test_unique_uri_validator_update_error(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = ConditionUniqueURIValidator()
-    validator.set_context(ConditionSerializer())
+    serializer = ConditionSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = ConditionUniqueURIValidator()
-    validator.set_context(ConditionSerializer())
+    serializer = ConditionSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Condition.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     condition = Condition.objects.first()
 
     validator = ConditionUniqueURIValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
     validator({
         'uri_prefix': condition.uri_prefix,
         'uri_path': condition.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     condition = Condition.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).first()
 
     validator = ConditionUniqueURIValidator()
-    validator.set_context(ConditionSerializer(instance=condition))
+    serializer = ConditionSerializer(instance=condition)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': condition.uri_prefix,
             'uri_path': Condition.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)

--- a/rdmo/core/tests/test_validators.py
+++ b/rdmo/core/tests/test_validators.py
@@ -21,7 +21,8 @@ def test_instance_validator_instance():
 def test_instance_validator_serializer():
     validator = InstanceValidator()
     serializer = serializers.Serializer()
-    validator.set_context(serializer)
+
+    validator({}, serializer)
 
     assert validator.serializer == serializer
     assert validator.serializer.instance is None
@@ -31,7 +32,9 @@ def test_instance_validator_serializer_instance():
     validator = InstanceValidator()
     instance = object()
     serializer = serializers.Serializer(instance=instance)
-    validator.set_context(serializer)
+
+    validator({}, serializer)
+
     assert validator.serializer == serializer
     assert validator.serializer.instance == serializer.instance
 
@@ -47,7 +50,9 @@ def test_instance_validator_validation_error():
 
 def test_instance_validator_validation_serializer_error():
     validator = InstanceValidator()
-    validator.set_context(serializers.Serializer())
+    serializer = serializers.Serializer()
+
+    validator({}, serializer)
 
     with pytest.raises(serializers.ValidationError):
         validator.raise_validation_error({

--- a/rdmo/domain/tests/test_validator_locked.py
+++ b/rdmo/domain/tests/test_validator_locked.py
@@ -114,31 +114,31 @@ def test_update_parent_error(db):
 
 def test_serializer_create(db):
     validator = AttributeLockedValidator()
-    validator.set_context(AttributeSerializer())
+    serializer = AttributeSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = AttributeLockedValidator()
-    validator.set_context(AttributeSerializer())
+    serializer = AttributeSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
 
     validator = AttributeLockedValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -147,9 +147,9 @@ def test_serializer_update_error(db):
     attribute.save()
 
     validator = AttributeLockedValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/domain/tests/test_validator_parent.py
+++ b/rdmo/domain/tests/test_validator_parent.py
@@ -41,39 +41,39 @@ def test_serializer_create(db):
         action = 'create'
 
     validator = AttributeParentValidator()
-    validator.set_context(AttributeSerializer())
-    validator.serializer.context['view'] = MockedView()
+    serializer = AttributeSerializer()
+    serializer.context['view'] = MockedView()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'key': 'test',
         'parent': Attribute.objects.get(uri='http://example.com/terms/domain/individual/single')
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
     validator = AttributeParentValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     validator({
         'uri_prefix': attribute.uri_prefix,
         'key': attribute.key,
         'parent':  attribute.parent
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
     validator = AttributeParentValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': attribute.uri_prefix,
             'key': attribute.key,
             'parent':  attribute  # set self as parent
-        })
+        }, serializer)
 
 
 def test_import_create(db):

--- a/rdmo/domain/tests/test_validator_unique_uri.py
+++ b/rdmo/domain/tests/test_validator_unique_uri.py
@@ -48,47 +48,47 @@ def test_validator_update_error(db):
 
 def test_validator_serializer_create(db):
     validator = AttributeUniqueURIValidator()
-    validator.set_context(AttributeSerializer())
+    serializer = AttributeSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'key': 'test',
         'parent': Attribute.objects.get(uri='http://example.com/terms/domain/individual/single')
-    })
+    }, serializer)
 
 
 def test_validator_serializer_create_error(db):
     validator = AttributeUniqueURIValidator()
-    validator.set_context(AttributeSerializer())
+    serializer = AttributeSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'key': 'text',
             'parent': Attribute.objects.get(uri='http://example.com/terms/domain/individual/single')
-        })
+        }, serializer)
 
 
 def test_validator_serializer_update(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
     validator = AttributeUniqueURIValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     validator({
         'uri_prefix': attribute.uri_prefix,
         'key': 'test',
         'parent':  attribute.parent
-    })
+    }, serializer)
 
 
 def test_validator_serializer_update_error(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
     validator = AttributeUniqueURIValidator()
-    validator.set_context(AttributeSerializer(instance=attribute))
+    serializer = AttributeSerializer(instance=attribute)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': attribute.uri_prefix,
             'key': 'textarea',
             'parent': attribute.parent
-        })
+        }, serializer)

--- a/rdmo/domain/validators.py
+++ b/rdmo/domain/validators.py
@@ -28,7 +28,9 @@ class AttributeUniqueURIValidator(UniqueURIValidator):
 
 class AttributeParentValidator(InstanceValidator):
 
-    def __call__(self, data):
+    def __call__(self, data, serializer=None):
+        super().__call__(data, serializer)
+
         parent = data.get('parent')
         if parent is None:
             # workaround for import

--- a/rdmo/options/tests/test_validator_locked_options.py
+++ b/rdmo/options/tests/test_validator_locked_options.py
@@ -105,31 +105,31 @@ def test_update_optionset_error(db):
 
 def test_serializer_create(db):
     validator = OptionLockedValidator()
-    validator.set_context(OptionSerializer())
+    serializer = OptionSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = OptionLockedValidator()
-    validator.set_context(OptionSerializer())
+    serializer = OptionSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     option = Option.objects.first()
 
     validator = OptionLockedValidator()
-    validator.set_context(OptionSerializer(instance=option))
+    serializer = OptionSerializer(instance=option)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -138,9 +138,9 @@ def test_serializer_update_error(db):
     option.save()
 
     validator = OptionLockedValidator()
-    validator.set_context(OptionSerializer(instance=option))
+    serializer = OptionSerializer(instance=option)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/options/tests/test_validator_locked_optionsets.py
+++ b/rdmo/options/tests/test_validator_locked_optionsets.py
@@ -59,31 +59,31 @@ def test_update_unlock(db):
 
 def test_serializer_create(db):
     validator = OptionSetLockedValidator()
-    validator.set_context(OptionSetSerializer())
+    serializer = OptionSetSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = OptionSetLockedValidator()
-    validator.set_context(OptionSetSerializer())
+    serializer = OptionSetSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     optionset = OptionSet.objects.first()
 
     validator = OptionSetLockedValidator()
-    validator.set_context(OptionSetSerializer(instance=optionset))
+    serializer = OptionSetSerializer(instance=optionset)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -92,9 +92,9 @@ def test_serializer_update_error(db):
     optionset.save()
 
     validator = OptionSetLockedValidator()
-    validator.set_context(OptionSetSerializer(instance=optionset))
+    serializer = OptionSetSerializer(instance=optionset)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/options/tests/test_validator_unique_uri_options.py
+++ b/rdmo/options/tests/test_validator_unique_uri_options.py
@@ -63,45 +63,45 @@ def test_unique_uri_validator_update_error_optionset(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = OptionUniqueURIValidator()
-    validator.set_context(OptionSerializer())
+    serializer = OptionSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = OptionUniqueURIValidator()
-    validator.set_context(OptionSerializer())
+    serializer = OptionSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Option.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = Option.objects.first()
 
     validator = OptionUniqueURIValidator()
-    validator.set_context(OptionSerializer(instance=instance))
+    serializer = OptionSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = Option.objects.first()
 
     validator = OptionUniqueURIValidator()
-    validator.set_context(OptionSerializer(instance=instance))
+    serializer = OptionSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': Option.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/options/tests/test_validator_unique_uri_optionsets.py
+++ b/rdmo/options/tests/test_validator_unique_uri_optionsets.py
@@ -63,45 +63,45 @@ def test_unique_uri_validator_update_error_optionset(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = OptionSetUniqueURIValidator()
-    validator.set_context(OptionSetSerializer())
+    serializer = OptionSetSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = OptionSetUniqueURIValidator()
-    validator.set_context(OptionSetSerializer())
+    serializer = OptionSetSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': OptionSet.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = OptionSet.objects.first()
 
     validator = OptionSetUniqueURIValidator()
-    validator.set_context(OptionSetSerializer(instance=instance))
+    serializer = OptionSetSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = OptionSet.objects.first()
 
     validator = OptionSetUniqueURIValidator()
-    validator.set_context(OptionSetSerializer(instance=instance))
+    serializer = OptionSetSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': OptionSet.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_locked_catalogs.py
+++ b/rdmo/questions/tests/test_validator_locked_catalogs.py
@@ -59,29 +59,29 @@ def test_update_unlock(db):
 
 def test_serializer_create(db):
     validator = CatalogLockedValidator()
-    validator.set_context(CatalogSerializer())
+    serializer = CatalogSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = CatalogLockedValidator()
-    validator.set_context(CatalogSerializer())
+    serializer = CatalogSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     catalog = Catalog.objects.first()
 
     validator = CatalogLockedValidator()
-    validator.set_context(CatalogSerializer(instance=catalog))
+    serializer = CatalogSerializer(instance=catalog)
 
-    validator({})
+    validator({}, serializer)
 
 
 def test_serializer_update_error(db):
@@ -90,9 +90,9 @@ def test_serializer_update_error(db):
     catalog.save()
 
     validator = CatalogLockedValidator()
-    validator.set_context(CatalogSerializer(instance=catalog))
+    serializer = CatalogSerializer(instance=catalog)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_locked_pages.py
+++ b/rdmo/questions/tests/test_validator_locked_pages.py
@@ -155,31 +155,31 @@ def test_update_section_error_catalog(db):
 
 def test_serializer_create(db):
     validator = PageLockedValidator()
-    validator.set_context(PageSerializer())
+    serializer = PageSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = PageLockedValidator()
-    validator.set_context(PageSerializer())
+    serializer = PageSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     page = Page.objects.first()
 
     validator = PageLockedValidator()
-    validator.set_context(PageSerializer(instance=page))
+    serializer = PageSerializer(instance=page)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -188,9 +188,9 @@ def test_serializer_update_error(db):
     page.save()
 
     validator = PageLockedValidator()
-    validator.set_context(PageSerializer(instance=page))
+    serializer = PageSerializer(instance=page)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_locked_questions.py
+++ b/rdmo/questions/tests/test_validator_locked_questions.py
@@ -397,31 +397,31 @@ def test_update_questionset_error_catalog(db):
 
 def test_serializer_create(db):
     validator = QuestionLockedValidator()
-    validator.set_context(QuestionSerializer())
+    serializer = QuestionSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = QuestionLockedValidator()
-    validator.set_context(QuestionSerializer())
+    serializer = QuestionSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     question = Question.objects.first()
 
     validator = QuestionLockedValidator()
-    validator.set_context(QuestionSerializer(instance=question))
+    serializer = QuestionSerializer(instance=question)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -430,9 +430,9 @@ def test_serializer_update_error(db):
     question.save()
 
     validator = QuestionLockedValidator()
-    validator.set_context(QuestionSerializer(instance=question))
+    serializer = QuestionSerializer(instance=question)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_locked_questionsets.py
+++ b/rdmo/questions/tests/test_validator_locked_questionsets.py
@@ -355,31 +355,31 @@ def test_update_questionset_error_catalog(db):
 
 def test_serializer_create(db):
     validator = QuestionSetLockedValidator()
-    validator.set_context(QuestionSetSerializer())
+    serializer = QuestionSetSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = QuestionSetLockedValidator()
-    validator.set_context(QuestionSetSerializer())
+    serializer = QuestionSetSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     instance = QuestionSet.objects.first()
 
     validator = QuestionSetLockedValidator()
-    validator.set_context(QuestionSetSerializer(instance=instance))
+    serializer = QuestionSetSerializer(instance=instance)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -388,9 +388,9 @@ def test_serializer_update_error(db):
     instance.save()
 
     validator = QuestionSetLockedValidator()
-    validator.set_context(QuestionSetSerializer(instance=instance))
+    serializer = QuestionSetSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_locked_sections.py
+++ b/rdmo/questions/tests/test_validator_locked_sections.py
@@ -115,31 +115,31 @@ def test_update_catalog_error(db):
 
 def test_serializer_create(db):
     validator = SectionLockedValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = SectionLockedValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     section = Section.objects.first()
 
     validator = SectionLockedValidator()
-    validator.set_context(SectionSerializer(instance=section))
+    serializer = SectionSerializer(instance=section)
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_update_error(db):
@@ -148,9 +148,9 @@ def test_serializer_update_error(db):
     section.save()
 
     validator = SectionLockedValidator()
-    validator.set_context(SectionSerializer(instance=section))
+    serializer = SectionSerializer(instance=section)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_unique_uri_catalogs.py
+++ b/rdmo/questions/tests/test_validator_unique_uri_catalogs.py
@@ -117,45 +117,45 @@ def test_unique_uri_validator_update_error_catalog(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = CatalogUniqueURIValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = CatalogUniqueURIValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Section.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = Catalog.objects.first()
 
     validator = CatalogUniqueURIValidator()
-    validator.set_context(SectionSerializer(instance=instance))
+    serializer = SectionSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = Catalog.objects.first()
 
     validator = CatalogUniqueURIValidator()
-    validator.set_context(SectionSerializer(instance=instance))
+    serializer = SectionSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': Section.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_unique_uri_pages.py
+++ b/rdmo/questions/tests/test_validator_unique_uri_pages.py
@@ -117,45 +117,45 @@ def test_unique_uri_validator_update_error_catalog(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = PageUniqueURIValidator()
-    validator.set_context(PageSerializer())
+    serializer = PageSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = PageUniqueURIValidator()
-    validator.set_context(PageSerializer())
+    serializer = PageSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Page.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = Page.objects.first()
 
     validator = PageUniqueURIValidator()
-    validator.set_context(PageSerializer(instance=instance))
+    serializer = PageSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = Page.objects.first()
 
     validator = PageUniqueURIValidator()
-    validator.set_context(PageSerializer(instance=instance))
+    serializer = PageSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': Page.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_unique_uri_questions.py
+++ b/rdmo/questions/tests/test_validator_unique_uri_questions.py
@@ -117,45 +117,45 @@ def test_unique_uri_validator_update_error_catalog(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = QuestionUniqueURIValidator()
-    validator.set_context(QuestionSerializer())
+    serializer = QuestionSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = QuestionUniqueURIValidator()
-    validator.set_context(QuestionSerializer())
+    serializer = QuestionSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Question.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = Question.objects.first()
 
     validator = QuestionUniqueURIValidator()
-    validator.set_context(QuestionSerializer(instance=instance))
+    serializer = QuestionSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = Question.objects.first()
 
     validator = QuestionUniqueURIValidator()
-    validator.set_context(QuestionSerializer(instance=instance))
+    serializer = QuestionSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': Question.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_unique_uri_questionsets.py
+++ b/rdmo/questions/tests/test_validator_unique_uri_questionsets.py
@@ -117,45 +117,45 @@ def test_unique_uri_validator_update_error_catalog(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = QuestionSetUniqueURIValidator()
-    validator.set_context(QuestionSetSerializer())
+    serializer = QuestionSetSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = QuestionSetUniqueURIValidator()
-    validator.set_context(QuestionSetSerializer())
+    serializer = QuestionSetSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': QuestionSet.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = QuestionSet.objects.first()
 
     validator = QuestionSetUniqueURIValidator()
-    validator.set_context(QuestionSetSerializer(instance=instance))
+    serializer = QuestionSetSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = QuestionSet.objects.first()
 
     validator = QuestionSetUniqueURIValidator()
-    validator.set_context(QuestionSetSerializer(instance=instance))
+    serializer = QuestionSetSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': QuestionSet.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/tests/test_validator_unique_uri_sections.py
+++ b/rdmo/questions/tests/test_validator_unique_uri_sections.py
@@ -117,45 +117,45 @@ def test_unique_uri_validator_update_error_catalog(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = SectionUniqueURIValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = SectionUniqueURIValidator()
-    validator.set_context(SectionSerializer())
+    serializer = SectionSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Section.objects.first().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     instance = Section.objects.first()
 
     validator = SectionUniqueURIValidator()
-    validator.set_context(SectionSerializer(instance=instance))
+    serializer = SectionSerializer(instance=instance)
 
     validator({
         'uri_prefix': instance.uri_prefix,
         'uri_path': instance.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     instance = Section.objects.first()
 
     validator = SectionUniqueURIValidator()
-    validator.set_context(SectionSerializer(instance=instance))
+    serializer = SectionSerializer(instance=instance)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': instance.uri_prefix,
             'uri_path': Section.objects.exclude(id=instance.id).first().uri_path
-        })
+        }, serializer)

--- a/rdmo/questions/validators.py
+++ b/rdmo/questions/validators.py
@@ -38,7 +38,9 @@ class QuestionUniqueURIValidator(UniqueURIValidator):
 
 class QuestionSetQuestionSetValidator(InstanceValidator):
 
-    def __call__(self, data):
+    def __call__(self, data, serializer=None):
+        super().__call__(data, serializer)
+
         questionsets = data.get('questionsets')
         if not questionsets:
             return

--- a/rdmo/tasks/tests/test_validator_locked.py
+++ b/rdmo/tasks/tests/test_validator_locked.py
@@ -59,29 +59,29 @@ def test_update_unlock(db):
 
 def test_serializer_create(db):
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer())
+    serializer = TaskSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer())
+    serializer = TaskSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     task = Task.objects.first()
 
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
-    validator({})
+    validator({}, serializer)
 
 
 def test_serializer_update_error(db):
@@ -90,23 +90,23 @@ def test_serializer_update_error(db):
     task.save()
 
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)
 
 
 def test_serializer_update_lock(db):
     task = Task.objects.first()
 
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update_unlock(db):
@@ -115,8 +115,8 @@ def test_serializer_update_unlock(db):
     task.save()
 
     validator = TaskLockedValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
     validator({
         'locked': False
-    })
+    }, serializer)

--- a/rdmo/tasks/tests/test_validator_unique_uri.py
+++ b/rdmo/tasks/tests/test_validator_unique_uri.py
@@ -45,45 +45,45 @@ def test_unique_uri_validator_update_error(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = TaskUniqueURIValidator()
-    validator.set_context(TaskSerializer())
+    serializer = TaskSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = TaskUniqueURIValidator()
-    validator.set_context(TaskSerializer())
+    serializer = TaskSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': Task.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     task = Task.objects.first()
 
     validator = TaskUniqueURIValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
     validator({
         'uri_prefix': task.uri_prefix,
         'uri_path': task.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     task = Task.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).first()
 
     validator = TaskUniqueURIValidator()
-    validator.set_context(TaskSerializer(instance=task))
+    serializer = TaskSerializer(instance=task)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': task.uri_prefix,
             'uri_path': Task.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)

--- a/rdmo/views/tests/test_validator_locked.py
+++ b/rdmo/views/tests/test_validator_locked.py
@@ -59,29 +59,29 @@ def test_update_unlock(db):
 
 def test_serializer_create(db):
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer())
+    serializer = ViewSerializer()
 
     validator({
         'locked': False
-    })
+    }, serializer)
 
 
 def test_serializer_create_locked(db):
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer())
+    serializer = ViewSerializer()
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update(db):
     view = View.objects.first()
 
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
-    validator({})
+    validator({}, serializer)
 
 
 def test_serializer_update_error(db):
@@ -90,23 +90,23 @@ def test_serializer_update_error(db):
     view.save()
 
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'locked': True
-        })
+        }, serializer)
 
 
 def test_serializer_update_lock(db):
     view = View.objects.first()
 
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
     validator({
         'locked': True
-    })
+    }, serializer)
 
 
 def test_serializer_update_unlock(db):
@@ -115,8 +115,8 @@ def test_serializer_update_unlock(db):
     view.save()
 
     validator = ViewLockedValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
     validator({
         'locked': False
-    })
+    }, serializer)

--- a/rdmo/views/tests/test_validator_unique_uri.py
+++ b/rdmo/views/tests/test_validator_unique_uri.py
@@ -45,45 +45,45 @@ def test_unique_uri_validator_update_error(db):
 
 def test_unique_uri_validator_serializer_create(db):
     validator = ViewUniqueURIValidator()
-    validator.set_context(ViewSerializer())
+    serializer = ViewSerializer()
 
     validator({
         'uri_prefix': settings.DEFAULT_URI_PREFIX,
         'uri_path': 'test'
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_create_error(db):
     validator = ViewUniqueURIValidator()
-    validator.set_context(ViewSerializer())
+    serializer = ViewSerializer()
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': settings.DEFAULT_URI_PREFIX,
             'uri_path': View.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)
 
 
 def test_unique_uri_validator_serializer_update(db):
     view = View.objects.first()
 
     validator = ViewUniqueURIValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
     validator({
         'uri_prefix': view.uri_prefix,
         'uri_path': view.uri_path
-    })
+    }, serializer)
 
 
 def test_unique_uri_validator_serializer_update_error(db):
     view = View.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).first()
 
     validator = ViewUniqueURIValidator()
-    validator.set_context(ViewSerializer(instance=view))
+    serializer = ViewSerializer(instance=view)
 
     with pytest.raises(RestFameworkValidationError):
         validator({
             'uri_prefix': view.uri_prefix,
             'uri_path': View.objects.filter(uri_prefix=settings.DEFAULT_URI_PREFIX).last().uri_path
-        })
+        }, serializer)


### PR DESCRIPTION
This PR removes the `set_context` method for the serializers, so that the djang-rest-framwork can be updated eventually.