### PR TITLE
chore: add eslint pre-commit hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,47 +1,48 @@
 module.exports = {
-  "globals": {
-    "gettext": true,
-    "ngettext": true,
-    "interpolate": true,
-    "process": true,
-    "require": true
+  'globals': {
+    'gettext': true,
+    'ngettext': true,
+    'interpolate': true,
+    'process': true,
+    'require': true
   },
-  "env": {
-    "browser": true,
-    "es2021": true
+  'env': {
+    'browser': true,
+    'es2021': true,
+    'node': true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
+  'extends': [
+    'eslint:recommended',
+    'plugin:react/recommended'
   ],
-  "overrides": [],
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
+  'overrides': [],
+  'parserOptions': {
+    'ecmaVersion': 'latest',
+    'sourceType': 'module'
   },
-  "plugins": [
-    "react"
+  'plugins': [
+    'react'
   ],
-  "ignorePatterns": ["**/static/**/*.js"],
-  "rules": {
-    "indent": "off",
-    "no-empty-pattern": "off",
-    "linebreak-style": [
-      "error",
-      "unix"
+  'ignorePatterns': ['**/static/**/*.js'],
+  'rules': {
+    'indent': 'off',
+    'no-empty-pattern': 'off',
+    'linebreak-style': [
+      'error',
+      'unix'
     ],
-    "quotes": [
-      "error",
-      "single"
+    'quotes': [
+      'error',
+      'single'
     ],
-    "semi": [
-      "error",
-      "never"
+    'semi': [
+      'error',
+      'never'
     ]
   },
-  "settings": {
-    "react": {
-      "version": "detect"
+  'settings': {
+    'react': {
+      'version': 'detect'
     }
   }
 }

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: lint-${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: Run ruff via pre-commit
+    - name: Run linters via pre-commit (ruff, eslint)
       run: pre-commit run --all-files --color=always
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.41.0
+    hooks:
+      - id: eslint
+        args: [--fix, --color]
+        additional_dependencies:
+          - eslint@8.41.0
+          - eslint-plugin-react@7.32.2
+          - react@18.2.0

--- a/rdmo/core/tests/test_project_status.py
+++ b/rdmo/core/tests/test_project_status.py
@@ -1,8 +1,48 @@
+import json
+
+import pytest
 
 from django.core.management import call_command
+
+import yaml
 
 
 def test_makemigrations_has_no_changes(db, capsys):
     call_command("makemigrations", check=True, dry_run=True)
     captured = capsys.readouterr()
     assert "No changes detected" in captured.out
+
+@pytest.fixture(scope="session")
+def package_json():
+    with open("package.json") as f:
+        return json.load(f)
+
+@pytest.fixture(scope="session")
+def pre_commit_config():
+    with open(".pre-commit-config.yaml") as f:
+        return yaml.safe_load(f)
+
+@pytest.fixture(scope="session")
+def package_json_versions(package_json):
+    versions = {
+        "eslint": package_json["devDependencies"]["eslint"],
+        "eslint-plugin-react": package_json["devDependencies"]["eslint-plugin-react"],
+        "react": package_json["dependencies"]["react"],
+    }
+    return {name: version.replace("^", "") for name, version in versions.items()}
+
+@pytest.fixture(scope="session")
+def pre_commit_config_versions(pre_commit_config):
+    mirrors_eslint = "https://github.com/pre-commit/mirrors-eslint"
+    for repo in pre_commit_config["repos"]:
+        if repo["repo"] == mirrors_eslint:
+            eslint_config = repo["hooks"][0]
+            break
+    versions = {}
+    for dependency in sorted(eslint_config["additional_dependencies"]):
+        name, version = dependency.split("@")
+        versions[name] = version
+    return versions
+
+def test_package_json_and_pre_commit_versions_match(package_json_versions, pre_commit_config_versions):
+    assert package_json_versions == pre_commit_config_versions

--- a/webpack/common.config.js
+++ b/webpack/common.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack')
 const { merge } = require('webpack-merge')
 const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 const base = {
   resolve: {


### PR DESCRIPTION
## Proposed Changes

This PR proposes the following changes:

- add eslint pre-commit hook
- add `node` env to eslint config (to silence errors about undefined `module`, `_dirname`, ...)
- reformat eslint config to make itself happy
- remove unsused import of `CopyWebpackPlugin` in webpack config
- add a test case to make sure the javascript dependency versions in package.json and .pre-commit-config.yml match

I posed the questions in the dev-2.0.0 PR as well: Why are the .js files ins */static/* ignored from eslint?

## Tasks

- [x] add commonjs to .eslintrc.js
- [x] remove verbose: true?
- [x] add react to pre-commit:additional_dependencies
- [x] squash commits
- [x] delete CopyWebpackPlugin line
- [x] update lint job name, now it only says run ruff
- [x] update pr description
- [x] add test to compare versions in package.json and pre-commit:additional_dependencies
