### PR TITLE
chore: update ci jobs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,8 +27,8 @@ jobs:
       with:
         python-version: "3.11"
         cache: pip
-    - run: python -m pip install --upgrade pip
-    - run: pip install -e .[dev]
+    - run: python -m pip install --upgrade pip setuptools wheel
+    - run: python -m pip install -e .[dev]
     - name: Set up pre-commit cache
       uses: actions/cache@v3
       with:
@@ -56,17 +56,17 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install --yes pandoc texlive-xetex texlive-latex-extra texlive-fonts-recommended lmodern librsvg2-bin
-        python -m pip install --upgrade pip
+        sudo apt install --yes pandoc texlive-xetex
+        python -m pip install --upgrade pip setuptools wheel
         pandoc --version
     - name: Install rdmo[mysql] and start mysql
       run: |
-        pip install -e .[ci,mysql]
+        python -m pip install -e .[ci,mysql]
         sudo systemctl start mysql.service
       if: matrix.db-backend == 'mysql'
     - name: Install rdmo[postgres] and start postgresql
       run: |
-        pip install -e .[ci,postgres]
+        python -m pip install -e .[ci,postgres]
         sudo systemctl start postgresql.service
         pg_isready
         sudo -u postgres psql --command="CREATE USER postgres_user PASSWORD 'postgres_password' CREATEDB"
@@ -93,7 +93,7 @@ jobs:
     steps:
     - name: Run Coveralls finish
       run: |
-        pip install coveralls
+        python -m pip install coveralls
         coveralls --service=github --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

This PR proposed the following changes:
- consistently use `python -m pip` instead of just `pip`, more explicit
- pip upgrade `pip setuptools wheel` instead of just `pip`
- apt install `pandoc texlive-xetex`, other needed packages are transitive dependencies, compare your docker-compose repo does it the same way: https://github.com/afuetterer/rdmo-docker-compose/blob/3ccba08c3ac3f8f589174957f8fc156e0be8a11d/docker/rdmo/Dockerfile#L48

