### PR TITLE
Fix Catalog uri_path verbose_name

### DIFF
--- a/rdmo/questions/migrations/0078_catalog_uri_path.py
+++ b/rdmo/questions/migrations/0078_catalog_uri_path.py
@@ -23,6 +23,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='catalog',
             name='uri_path',
-            field=models.CharField(blank=True, help_text='The path for the URI of this catalog.', max_length=512, verbose_name='Path'),
+            field=models.CharField(blank=True, help_text='The path for the URI of this catalog.', max_length=512, verbose_name='URI Path'),
         ),
     ]

--- a/rdmo/questions/models/catalog.py
+++ b/rdmo/questions/models/catalog.py
@@ -43,7 +43,7 @@ class Catalog(Model, TranslationMixin):
     )
     uri_path = models.CharField(
         max_length=512, blank=True,
-        verbose_name=_('Path'),
+        verbose_name=_('URI Path'),
         help_text=_('The path for the URI of this catalog.')
     )
     comment = models.TextField(


### PR DESCRIPTION
This PR fixes a tiny typo retroactively in the migrations. I think it works, but maybe somebody else should double check.