### PR TITLE
ci: add python 3.12-dev test run in ci

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,6 +43,12 @@ jobs:
       matrix:
         python-version: ['3.8', '3.11']
         db-backend: [mysql, postgres]
+        # test Python 3.12 already using 3.12-dev
+        # release is scheduled for 2023-10-02 (https://peps.python.org/pep-0693/)
+        # when released: replace "python-version: ['3.8', '3.11']" with python-version: ['3.8', '3.12']
+        include:
+        - python-version: '3.12-dev'
+          db-backend: postgres
 
     name: "Test (Python: ${{ matrix.python-version }}, DB: ${{ matrix.db-backend }})"
     needs: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dynamic = [
   "version",


### PR DESCRIPTION
## Proposed Changes

This PR proposes the following changes:
- add python version 3.12-dev to the CI runs

Python 3.12 is scheduled to be released on 2023-10-02 (https://peps.python.org/pep-0693/). That is three weeks from now.

The tests are passing, so rdmo is ready for Python 3.12, when it gets released in three weeks.