### PR TITLE
docs: update project urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ RDMO is a tool to support the systematic planning, organisation and implementati
   <dt>Source code</dt>
   <dd>https://github.com/rdmorganiser/rdmo</dd>
   <dt>Documentation</dt>
-  <dd>http://rdmo.readthedocs.io</dd>
+  <dd>https://rdmo.readthedocs.io</dd>
   <dt>Mailing list</dt>
   <dd>https://www.listserv.dfn.de/sympa/subscribe/rdmo</dd>
   <dt>Slack</dt>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,12 @@ pytest = [
 ]
 
 [project.urls]
-Changelog = "https://github.com/rdmorganiser/rdmo/blob/master/CHANGELOG.md"
-Documentation = "https://rdmo.readthedocs.io"
-Homepage = "https://rdmorganiser.github.io"
-Issues = "https://github.com/rdmorganiser/rdmo/issues"
-Repository = "https://github.com/rdmorganiser/rdmo.git"
+changelog = "https://github.com/rdmorganiser/rdmo/blob/master/CHANGELOG.md"
+documentation = "https://rdmo.readthedocs.io"
+homepage = "https://rdmorganiser.github.io"
+issues = "https://github.com/rdmorganiser/rdmo/issues"
+repository = "https://github.com/rdmorganiser/rdmo.git"
+slack = "https://rdmo.slack.com"
 
 [tool.setuptools.packages.find]
 include = ["rdmo*"]


### PR DESCRIPTION
## Proposed changes

This PR proposed the following changes:
- use https instead of http for docs url in readme
- use lowercase for project urls in pyproject.toml
- add slack url to project urls

Refs: https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet