### PR TITLE
chore: remove obsolete dependency "pytest-dotenv"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ pytest = [
   "pytest~=7.4.0",
   "pytest-cov~=4.0.0",
   "pytest-django~=4.5.0",
-  "pytest-dotenv~=0.5.2",
   "pytest-mock~=3.11.0",
   "pytest-randomly~=3.15.0",
   "pytest-xdist~=3.3.1",


### PR DESCRIPTION
## Proposed changes

- remove obsolete dependency `pytest-dotenv`

`pytest-dotenv` is not utilized in the test suite anywhere. So I suggest its removal from the test dependencies. If one of you uses it locally, you can always install it locally in your venv.