### PR TITLE
chore: remove obsolete dependency "jsonfield"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
   "djangorestframework~=3.12.4",
   "drf-extensions~=0.7.0",
   "iso8601~=2.0.0",
-  "jsonfield~=3.1.0",
   "Markdown~=3.3.7",
   "pypandoc~=1.10.0",
   "rules~=3.3.0",

--- a/rdmo/accounts/migrations/0001_initial.py
+++ b/rdmo/accounts/migrations/0001_initial.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import jsonfield.fields
 from django.conf import settings
 
 
@@ -21,7 +20,7 @@ class Migration(migrations.Migration):
                 ('label', models.CharField(max_length=256)),
                 ('type', models.CharField(choices=[('text', 'Input field'), ('textarea', 'Textarea field'), ('checkbox', 'Checkbox'), ('radio', 'Radio button'), ('select', 'Select field'), ('multiselect', 'Multiselect field')], max_length=8)),
                 ('hint', models.TextField(blank=True)),
-                ('options', jsonfield.fields.JSONField(null=True, blank=True)),
+                ('options', models.JSONField(null=True, blank=True)),
                 ('required', models.BooleanField()),
             ],
         ),
@@ -29,7 +28,7 @@ class Migration(migrations.Migration):
             name='Profile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', auto_created=True, serialize=False, primary_key=True)),
-                ('details', jsonfield.fields.JSONField(null=True, blank=True)),
+                ('details', models.JSONField(null=True, blank=True)),
                 ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={

--- a/rdmo/accounts/migrations/0003_hint_renamed_to_help_text.py
+++ b/rdmo/accounts/migrations/0003_hint_renamed_to_help_text.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import jsonfield.fields
 
 
 class Migration(migrations.Migration):
@@ -20,6 +19,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='detailkey',
             name='options',
-            field=jsonfield.fields.JSONField(blank=True, null=True, help_text='Enter valid JSON of the form [[key, label], [key, label], ...]'),
+            field=models.JSONField(blank=True, null=True, help_text='Enter valid JSON of the form [[key, label], [key, label], ...]'),
         ),
     ]


### PR DESCRIPTION
## Proposed changes

This PR proposed the following changes:
- remove third-party `jsonfield` dependency
- alter model fields in migrations files in rdmo/accounts

The fields that utilized the jsonfield dependency where part of the models `Profile` and `DetailKey`, that were both removed six years ago in https://github.com/rdmorganiser/rdmo/blob/44dcda2f419f6dff269ea5e0128cbcdf0d77006b/rdmo/accounts/migrations/0007_additional_fields.py

So I would suggest removing this dependency. Also if we ever need another `JSONField`, Django now supports this on its own without any third party package needed.

Related issue: #692