### PR TITLE
chore: update postgresql settings in test config

### DIFF
--- a/testing/config/settings/base.py
+++ b/testing/config/settings/base.py
@@ -29,7 +29,7 @@ if GITHUB_DB_BACKEND == 'mysql':
 elif GITHUB_DB_BACKEND == 'postgres':
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'rdmo',
             'USER': 'postgres_user',
             'PASSWORD': 'postgres_password',


### PR DESCRIPTION
## Description

The django docs 4.2 state, that you should use

`'ENGINE': 'django.db.backends.postgresql',` and that `psycopg2` will be deprecated in the future. I did not include that in my dependencies update PR. So this is a late addition to that change.

Refs:
- https://docs.djangoproject.com/en/4.2/ref/databases/#postgresql-notes

## Types of Changes
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
