### PR TITLE
Fix ordering on page

### DIFF
--- a/rdmo/projects/tests/test_viewset_project_page.py
+++ b/rdmo/projects/tests/test_viewset_project_page.py
@@ -49,7 +49,7 @@ def test_detail(db, client, username, password, project_id, page_id):
 
 def test_detail_order_in_page(db, client):
     project_id = 1
-    username = 'user'
+    username = 'owner'
     ordered_page = 16
     ordered_page_question_ids = {
         16: [18, 19, 32, 33, 34, 89, 35, 36, 82]
@@ -60,13 +60,31 @@ def test_detail_order_in_page(db, client):
     url = reverse(urlnames['detail'], args=[project_id, ordered_page])
     response = client.get(url)
 
-    if project_id in view_questionset_permission_map.get(username, []):
-        data = response.json()
-        questions = [i for i in data['elements'] if i['model'] == "questions.question"]
-        question_ids = [i['id'] for i in questions]
+    data = response.json()
+    questions = [i for i in data['elements'] if i['model'] == "questions.question"]
+    question_ids = [i['id'] for i in questions]
 
-        assert response.status_code == 200
-        assert response.json().get('id') == ordered_page
-        assert question_ids == ordered_page_question_ids.get(ordered_page)
-    else:
-        assert response.status_code == 404
+    assert response.status_code == 200
+    assert response.json().get('id') == ordered_page
+    assert question_ids == ordered_page_question_ids.get(ordered_page)
+
+
+def test_detail_page_with_nested_questionsets(db, client):
+    project_id = 1
+    username = 'owner'
+    page_id = 87
+    nested_questionsets_id = [90]
+    nested_element_ids = [95, 96, 94, 89]
+
+    client.login(username=username, password=username)
+
+    url = reverse(urlnames['detail'], args=[project_id, page_id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    questionsets = [i for i in data['elements'] if i['model'] == "questions.questionset"]
+    questionsets_ids = [i['id'] for i in questionsets]
+    assert questionsets_ids == nested_questionsets_id
+    element_ids = [i['id'] for qs in questionsets for i in qs['elements']]
+    assert element_ids == nested_element_ids

--- a/rdmo/projects/tests/test_viewset_project_page.py
+++ b/rdmo/projects/tests/test_viewset_project_page.py
@@ -45,3 +45,28 @@ def test_detail(db, client, username, password, project_id, page_id):
         assert response.json().get('id') == page_id
     else:
         assert response.status_code == 404
+
+
+def test_detail_order_in_page(db, client):
+    project_id = 1
+    username = 'user'
+    ordered_page = 16
+    ordered_page_question_ids = {
+        16: [18, 19, 32, 33, 34, 89, 35, 36, 82]
+    }
+
+    client.login(username=username, password=username)
+
+    url = reverse(urlnames['detail'], args=[project_id, ordered_page])
+    response = client.get(url)
+
+    if project_id in view_questionset_permission_map.get(username, []):
+        data = response.json()
+        questions = [i for i in data['elements'] if i['model'] == "questions.question"]
+        question_ids = [i['id'] for i in questions]
+
+        assert response.status_code == 200
+        assert response.json().get('id') == ordered_page
+        assert question_ids == ordered_page_question_ids.get(ordered_page)
+    else:
+        assert response.status_code == 404

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -385,10 +385,14 @@ class ProjectPageViewSet(ProjectNestedViewSetMixin, RetrieveModelMixin, GenericV
     serializer_class = PageSerializer
 
     def get_queryset(self):
-        # prefetch the catalogs elements, this will also prefetch the page query below
         try:
             self.project.catalog.prefetch_elements()
-            return Page.objects.filter_by_catalog(self.project.catalog)
+            page = Page.objects.filter_by_catalog(self.project.catalog).prefetch_related(
+                *Page.prefetch_lookups,
+                'page_questions__question__optionsets__optionset_options__option',
+                'page_questionsets__questionset__questionset_questions__question__optionsets__optionset_options__option',
+            )
+            return page
         except AttributeError:
             # this is needed for the swagger ui
             return Page.objects.none()


### PR DESCRIPTION
## Description

This PR fixes the worst bug in `2.0.0` so far. The questions (or questionsets) are not ordered correctly. Someone ... forgot to adjust the `PageSerializer` in `projects` to the new data model.

@MyPyDavid can you check if it works now?