### PR TITLE
chore: remove obsolete black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,11 +114,6 @@ exclude = ["*assets*", "*tests*"]
 [tool.setuptools.dynamic]
 version = {attr = "rdmo.__version__"}
 
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-target_version = ["py38", "py39", "py310", "py311"]
-
 [tool.ruff]
 target-version = "py38"
 line-length = 120


### PR DESCRIPTION
## Description

We decided not to use the black formatter, but somehow its config section survived in the pyproject.toml. Let's remove it.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.