### PR TITLE
refactor: use admin.register decorator

### DIFF
--- a/rdmo/accounts/admin.py
+++ b/rdmo/accounts/admin.py
@@ -5,14 +5,17 @@ from django.db.models import Count, Value
 from .models import AdditionalField, AdditionalFieldValue, ConsentFieldValue, Role
 
 
+@admin.register(AdditionalField)
 class AdditionalFieldAdmin(admin.ModelAdmin):
     pass
 
 
+@admin.register(AdditionalFieldValue)
 class AdditionalFieldValueAdmin(admin.ModelAdmin):
     readonly_fields = ('user', )
 
 
+@admin.register(ConsentFieldValue)
 class ConsentFieldValueAdmin(admin.ModelAdmin):
     readonly_fields = ('user', 'consent')
 
@@ -20,6 +23,7 @@ class ConsentFieldValueAdmin(admin.ModelAdmin):
         return False
 
 
+@admin.register(Role)
 class RoleAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'user__email')
     list_filter = ('member', 'manager', 'editor', 'reviewer')
@@ -50,9 +54,3 @@ class RoleAdmin(admin.ModelAdmin):
 
     def reviewers(self, obj):
         return self.render_all_sites_or_join(obj, 'reviewer')
-
-
-admin.site.register(AdditionalField, AdditionalFieldAdmin)
-admin.site.register(AdditionalFieldValue, AdditionalFieldValueAdmin)
-admin.site.register(ConsentFieldValue, ConsentFieldValueAdmin)
-admin.site.register(Role, RoleAdmin)

--- a/rdmo/conditions/admin.py
+++ b/rdmo/conditions/admin.py
@@ -17,6 +17,7 @@ class ConditionAdminForm(forms.ModelForm):
         ConditionLockedValidator(self.instance)(self.cleaned_data)
 
 
+@admin.register(Condition)
 class ConditionAdmin(admin.ModelAdmin):
     form = ConditionAdminForm
 
@@ -25,6 +26,3 @@ class ConditionAdmin(admin.ModelAdmin):
     readonly_fields = ('uri', )
     list_filter = ('relation', )
     filter_horizontal = ('editors', )
-
-
-admin.site.register(Condition, ConditionAdmin)

--- a/rdmo/domain/admin.py
+++ b/rdmo/domain/admin.py
@@ -19,6 +19,7 @@ class AttributeAdminForm(forms.ModelForm):
         AttributeLockedValidator(self.instance)(self.cleaned_data)
 
 
+@admin.register(Attribute)
 class AttributeAdmin(admin.ModelAdmin):
     form = AttributeAdminForm
 
@@ -37,6 +38,3 @@ class AttributeAdmin(admin.ModelAdmin):
 
     def projects_count(self, obj):
         return obj.projects_count
-
-
-admin.site.register(Attribute, AttributeAdmin)

--- a/rdmo/options/admin.py
+++ b/rdmo/options/admin.py
@@ -39,6 +39,7 @@ class OptionSetOptionInline(admin.TabularInline):
     extra = 0
 
 
+@admin.register(OptionSet)
 class OptionSetAdmin(admin.ModelAdmin):
     form = OptionSetAdminForm
     inlines = (OptionSetOptionInline, )
@@ -49,6 +50,7 @@ class OptionSetAdmin(admin.ModelAdmin):
     filter_horizontal = ('editors', 'conditions')
 
 
+@admin.register(Option)
 class OptionAdmin(admin.ModelAdmin):
     form = OptionAdminForm
 
@@ -57,7 +59,3 @@ class OptionAdmin(admin.ModelAdmin):
     readonly_fields = ('uri', )
     list_filter = ('editors', 'optionsets', 'additional_input')
     filter_horizontal = ('editors', )
-
-
-admin.site.register(OptionSet, OptionSetAdmin)
-admin.site.register(Option, OptionAdmin)

--- a/rdmo/overlays/admin.py
+++ b/rdmo/overlays/admin.py
@@ -3,10 +3,8 @@ from django.contrib import admin
 from .models import Overlay
 
 
+@admin.register(Overlay)
 class OverlayAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'url_name', 'current')
     list_display = ('user', 'site', 'url_name', 'current')
     list_filter = ('url_name', 'current')
-
-
-admin.site.register(Overlay, OverlayAdmin)

--- a/rdmo/projects/admin.py
+++ b/rdmo/projects/admin.py
@@ -15,6 +15,7 @@ from .models import (
 )
 
 
+@admin.register(Project)
 class ProjectAdmin(admin.ModelAdmin):
     search_fields = ('title', 'user__username')
     list_display = ('title', 'owners', 'updated', 'created')
@@ -32,43 +33,51 @@ class ProjectAdmin(admin.ModelAdmin):
         return ', '.join([membership.user.username for membership in obj.owner_memberships])
 
 
+@admin.register(Membership)
 class MembershipAdmin(admin.ModelAdmin):
     search_fields = ('project__title', 'user__username', 'role')
     list_display = ('project', 'user', 'role')
 
 
+@admin.register(Continuation)
 class ContinuationAdmin(admin.ModelAdmin):
     search_fields = ('project__title', 'user__username')
     list_display = ('project', 'user', 'page')
 
 
+@admin.register(Integration)
 class IntegrationAdmin(admin.ModelAdmin):
     search_fields = ('project__title', 'provider_key')
     list_display = ('project', 'provider_key')
 
 
+@admin.register(IntegrationOption)
 class IntegrationOptionAdmin(admin.ModelAdmin):
     search_fields = ('integration__project__title', 'key', 'value')
     list_display = ('integration', 'key', 'value')
 
 
+@admin.register(Invite)
 class InviteAdmin(admin.ModelAdmin):
     search_fields = ('project__title', 'user__username', 'email', 'role')
     list_display = ('project', 'user', 'email', 'token', 'timestamp')
     readonly_fields = ('token', 'timestamp')
 
 
+@admin.register(Issue)
 class IssueAdmin(admin.ModelAdmin):
     search_fields = ('project__title', 'task', 'status')
     list_display = ('project', 'task', 'status')
     list_filter = ('status', )
 
 
+@admin.register(IssueResource)
 class IssueResourceAdmin(admin.ModelAdmin):
     search_fields = ('issue__project__title', 'url')
     list_display = ('issue', 'url')
 
 
+@admin.register(Snapshot)
 class SnapshotAdmin(admin.ModelAdmin):
     search_fields = ('title', 'project__title', 'project__user__username')
     list_display = ('title', 'project', 'owners', 'updated', 'created')
@@ -86,6 +95,7 @@ class SnapshotAdmin(admin.ModelAdmin):
         return ', '.join([membership.user.username for membership in obj.project.owner_memberships])
 
 
+@admin.register(Value)
 class ValueAdmin(admin.ModelAdmin):
     search_fields = ('attribute__uri', 'project__title', 'snapshot__title', 'project__user__username')
     list_display = ('attribute', 'set_prefix', 'set_index', 'collection_index', 'project', 'snapshot_title')
@@ -94,15 +104,3 @@ class ValueAdmin(admin.ModelAdmin):
     def snapshot_title(self, obj):
         if obj.snapshot:
             return obj.snapshot.title
-
-
-admin.site.register(Project, ProjectAdmin)
-admin.site.register(Membership, MembershipAdmin)
-admin.site.register(Continuation, ContinuationAdmin)
-admin.site.register(Integration, IntegrationAdmin)
-admin.site.register(IntegrationOption, IntegrationOptionAdmin)
-admin.site.register(Invite, InviteAdmin)
-admin.site.register(Issue, IssueAdmin)
-admin.site.register(IssueResource, IssueResourceAdmin)
-admin.site.register(Snapshot, SnapshotAdmin)
-admin.site.register(Value, ValueAdmin)

--- a/rdmo/questions/admin.py
+++ b/rdmo/questions/admin.py
@@ -96,6 +96,7 @@ class CatalogSectionInline(admin.TabularInline):
     extra = 0
 
 
+@admin.register(Catalog)
 class CatalogAdmin(admin.ModelAdmin):
     form = CatalogAdminForm
     inlines = (CatalogSectionInline, )
@@ -119,6 +120,7 @@ class SectionPageInline(admin.TabularInline):
     extra = 0
 
 
+@admin.register(Section)
 class SectionAdmin(admin.ModelAdmin):
     form = SectionAdminForm
     inlines = (SectionPageInline, )
@@ -140,6 +142,7 @@ class PageQuestionInline(admin.TabularInline):
     extra = 0
 
 
+@admin.register(Page)
 class PageAdmin(admin.ModelAdmin):
     form = PageAdminForm
     inlines = (PageQuestionSetInline, PageQuestionInline)
@@ -162,6 +165,7 @@ class QuestionSetQuestionInline(admin.TabularInline):
     extra = 0
 
 
+@admin.register(QuestionSet)
 class QuestionSetAdmin(admin.ModelAdmin):
     form = QuestionSetAdminForm
     inlines = (QuestionSetQuestionSetInline, QuestionSetQuestionInline)
@@ -173,6 +177,7 @@ class QuestionSetAdmin(admin.ModelAdmin):
     filter_horizontal = ('editors', 'conditions')
 
 
+@admin.register(Question)
 class QuestionAdmin(admin.ModelAdmin):
     form = QuestionAdminForm
 
@@ -182,10 +187,3 @@ class QuestionAdmin(admin.ModelAdmin):
     list_filter = ('pages__sections__catalogs', 'pages__sections', 'pages', 'is_collection',
                    'widget_type', 'value_type')
     filter_horizontal = ('editors', 'optionsets', 'conditions')
-
-
-admin.site.register(Catalog, CatalogAdmin)
-admin.site.register(Section, SectionAdmin)
-admin.site.register(Page, PageAdmin)
-admin.site.register(QuestionSet, QuestionSetAdmin)
-admin.site.register(Question, QuestionAdmin)

--- a/rdmo/tasks/admin.py
+++ b/rdmo/tasks/admin.py
@@ -19,6 +19,7 @@ class TaskAdminForm(forms.ModelForm):
         TaskLockedValidator(self.instance)(self.cleaned_data)
 
 
+@admin.register(Task)
 class TaskAdmin(admin.ModelAdmin):
     form = TaskAdminForm
 
@@ -27,6 +28,3 @@ class TaskAdmin(admin.ModelAdmin):
     readonly_fields = ('uri', )
     list_filter = ('available', )
     filter_horizontal = ('catalogs', 'sites', 'editors', 'groups', 'conditions')
-
-
-admin.site.register(Task, TaskAdmin)

--- a/rdmo/views/admin.py
+++ b/rdmo/views/admin.py
@@ -19,6 +19,7 @@ class ViewAdminForm(forms.ModelForm):
         ViewLockedValidator(self.instance)(self.cleaned_data)
 
 
+@admin.register(View)
 class ViewAdmin(admin.ModelAdmin):
     form = ViewAdminForm
 
@@ -27,6 +28,3 @@ class ViewAdmin(admin.ModelAdmin):
     readonly_fields = ('uri', )
     list_filter = ('available', )
     filter_horizontal = ('catalogs', 'sites', 'editors', 'groups')
-
-
-admin.site.register(View, ViewAdmin)


### PR DESCRIPTION
## Description

This PR proposed the following changes:

- make use of the `@admin.register` decorator that is available in Django

## Types of Changes
- [x] Refactoring (no functional changes, no api changes)

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
