### PR TITLE
build: pin django-mptt dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - dependencies
       - python
       - type:maintenance
+    ignore:
+      - dependency-name: django-mptt # pinned, 0.15 requires Python >= 3.9
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  # dependencies with major version on zero are declared with
+  # major.minor.patch, because they can potentially introduce breaking changes
+  # in minor version updates anytime
   "defusedcsv~=2.0",
   "defusedxml~=0.7.1",
   "django~=4.2",
@@ -46,7 +49,7 @@ dependencies = [
   "django-filter~=23.2",
   "django-libsass~=0.9",
   "django-mathfilters~=1.0",
-  "django-mptt~=0.14.0",
+  "django-mptt==0.14.0", # pinned, 0.15 requires Python >= 3.9
   "django-rest-swagger~=2.2",
   "django-settings-export~=1.2",
   "django-split-settings~=1.2",


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- pin django-mptt dependency to 0.14.0, because the next minor version (0.15) requires Python >= 3.9
- set dependabot config to ignore updates for django-mptt

These settings should be relaxed once RDMO requires Python >= 3.9 as well, so potentially a year from now, when Python 3.8 reaches EOL.

This PR supersedes #753.

## Types of Changes
- [x] Build related changes

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

