### PR TITLE
ci: add pre-commit autoupdate ci job

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,60 @@
+# This CI job is adapted from:
+# Cookiecutter Django (2013-10-17), BSD-3-Clause license
+# Ref: https://github.com/cookiecutter/cookiecutter-django/blob/2023.10.17/.github/workflows/pre-commit-autoupdate.yml
+
+name: Update pre-commit hooks
+
+on:
+  schedule:
+    # run once a month at midnight of the first day of the month
+    - cron: 0 0 1 * *
+  # run manually from actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-update:
+    # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    if: github.repository_owner == 'rdmorganiser'
+    permissions:
+      contents: write # for peter-evans/create-pull-request to create branch
+      pull-requests: write # for peter-evans/create-pull-request to create a PR
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install pre-commit
+      - run: pre-commit autoupdate > autoupdate.log
+      - name: Prepare message for pr body
+        run: |
+          grep "updating" autoupdate.log > updates.log
+          sed -i -e 's/\[/- </g' updates.log
+          sed -i -e 's/\]/>/g' updates.log
+          echo -e "## Proposed changes\n\nBumps the pre-commit config with the following updates:\n" > pr-body.md
+          cat updates.log >> pr-body.md
+          echo -e "\n---\nThis PR is auto-generated once a month." >> pr-body.md
+      # Ref: https://github.com/peter-evans/create-pull-request
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          branch: pre-commit-autoupdate
+          base: dependency-updates
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          title: "build: update pre-commit hooks"
+          commit-message: "build: update pre-commit hooks"
+          add-paths: .pre-commit-config.yaml
+          body-path: pr-body.md
+          labels: |
+            dependencies
+            pre-commit
+            type: maintenance
+          delete-branch: true
+      - name: Write to job summary
+        run: |
+          cat updates.log >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- add a pre-commit autoupdate ci job
- the job runs once a month or can be triggered manually
- the job calls pre-commit autoupdate and creates a PR with the updates in the PR body

Related issue: #777

- [x] rebase

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.