### PR TITLE
Validate conflicts

### DIFF
--- a/rdmo/core/constants.py
+++ b/rdmo/core/constants.py
@@ -60,6 +60,7 @@ PERMISSIONS = {
 }
 
 HUMAN2BYTES_MAPPER = {
+    "b": {"base": 1000, "power": 0},
     "kb": {"base": 1000, "power": 1},
     "k": {"base": 1000, "power": 1},
     "mb": {"base": 1000, "power": 2},

--- a/rdmo/core/constants.py
+++ b/rdmo/core/constants.py
@@ -58,3 +58,21 @@ PERMISSIONS = {
         'views.add_view', 'views.change_view', 'views.delete_view'
     )
 }
+
+HUMAN2BYTES_MAPPER = {
+    "kb": {"base": 1000, "power": 1},
+    "k": {"base": 1000, "power": 1},
+    "mb": {"base": 1000, "power": 2},
+    "m": {"base": 1000, "power": 2},
+    "gb": {"base": 1000, "power": 3},
+    "g": {"base": 1000, "power": 3},
+    "tb": {"base": 1000, "power": 4},
+    "t": {"base": 1000, "power": 4},
+    "p": {"base": 1000, "power": 5},
+    "pb": {"base": 1000, "power": 5},
+    "kib": {"base": 1024, "power": 1},
+    "mib": {"base": 1024, "power": 2},
+    "gib": {"base": 1024, "power": 3},
+    "tib": {"base": 1024, "power": 4},
+    "pib": {"base": 1024, "power": 5},
+}

--- a/rdmo/core/tests/test_utils.py
+++ b/rdmo/core/tests/test_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from rdmo.core.utils import human2bytes, join_url, sanitize_url
@@ -15,6 +17,12 @@ urls = (
     (1, ''),
 )
 
+human2bytes_test_values = (
+    ("1Gb", 1e+9),
+    (None, 0),
+    ("0", 0),
+)
+
 
 @pytest.mark.parametrize("url,sanitized_url", urls)
 def test_sanitize_url(url, sanitized_url):
@@ -25,13 +33,6 @@ def test_join_url():
     assert join_url('https://example.com//', '/terms', 'foo') == 'https://example.com/terms/foo'
 
 
-def test_human2bytes():
-    assert human2bytes('1Gb') == 1e+9
-
-
-def test_human2bytes_none():
-    assert human2bytes(None) == 0
-
-
-def test_human2bytes_zero():
-    assert human2bytes('0') == 0
+@pytest.mark.parametrize("human,bytes", human2bytes_test_values)
+def test_human2bytes(human: Optional[str], bytes: float):
+    assert human2bytes(human) == bytes

--- a/rdmo/core/tests/test_utils.py
+++ b/rdmo/core/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rdmo.core.utils import join_url, sanitize_url
+from rdmo.core.utils import human2bytes, join_url, sanitize_url
 
 urls = (
     ('', ''),
@@ -23,3 +23,15 @@ def test_sanitize_url(url, sanitized_url):
 
 def test_join_url():
     assert join_url('https://example.com//', '/terms', 'foo') == 'https://example.com/terms/foo'
+
+
+def test_human2bytes():
+    assert human2bytes('1Gb') == 1e+9
+
+
+def test_human2bytes_none():
+    assert human2bytes(None) == 0
+
+
+def test_human2bytes_zero():
+    assert human2bytes('0') == 0

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -351,7 +351,7 @@ def copy_model(instance, **kwargs):
 
 
 def human2bytes(string):
-    if not string:
+    if not string or string == '0':
         return 0
 
     m = re.match(r'([0-9.]+)\s*([A-Za-z]+)', string)

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -18,6 +18,8 @@ import pypandoc
 from defusedcsv import csv
 from markdown import markdown
 
+from .constants import HUMAN2BYTES_MAPPER
+
 log = logging.getLogger(__name__)
 
 
@@ -357,26 +359,9 @@ def human2bytes(string):
     m = re.match(r'([0-9.]+)\s*([A-Za-z]+)', string)
     number, unit = float(m.group(1)), m.group(2).strip().lower()
 
-    if unit == 'kb' or unit == 'k':
-        return number * 1000
-    elif unit == 'mb' or unit == 'm':
-        return number * 1000**2
-    elif unit == 'gb' or unit == 'g':
-        return number * 1000**3
-    elif unit == 'tb' or unit == 't':
-        return number * 1000**4
-    elif unit == 'pb' or unit == 'p':
-        return number * 1000**5
-    elif unit == 'kib':
-        return number * 1024
-    elif unit == 'mib':
-        return number * 1024**2
-    elif unit == 'gib':
-        return number * 1024**3
-    elif unit == 'tib':
-        return number * 1024**4
-    elif unit == 'pib':
-        return number * 1024**5
+    conversion = HUMAN2BYTES_MAPPER[unit]
+    number = number*conversion['base']**(conversion['power'])
+    return number
 
 
 def is_truthy(value):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -8,7 +8,7 @@ from rdmo.questions.models import Catalog
 from rdmo.services.validators import ProviderValidator
 
 from ...models import Integration, IntegrationOption, Invite, Issue, IssueResource, Membership, Project, Snapshot, Value
-from ...validators import ValueValidator
+from ...validators import ValueConflictValidator, ValueQuotaValidator
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -259,7 +259,10 @@ class ProjectValueSerializer(serializers.ModelSerializer):
             'unit',
             'external_id'
         )
-        validators = (ValueValidator(), )
+        validators = (
+            ValueConflictValidator(),
+            ValueQuotaValidator()
+        )
 
 
 class MembershipSerializer(serializers.ModelSerializer):

--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -1067,11 +1067,19 @@ angular.module('project_questions')
         service.values[attribute][set_prefix][set_index][collection_index].autocomplete_text = '';
         service.values[attribute][set_prefix][set_index][collection_index].autocomplete_locked = false;
         service.values[attribute][set_prefix][set_index][collection_index].changed = true;
+
+        if (service.settings.project_questions_autosave) {
+            service.save(false);
+        }
     };
 
     service.removeValue = function(attribute, set_prefix, set_index, collection_index) {
         service.values[attribute][set_prefix][set_index][collection_index].removed = true;
         service.values[attribute][set_prefix][set_index][collection_index].changed = true;
+
+        if (service.settings.project_questions_autosave) {
+            service.save(false);
+        }
     };
 
     service.openValueSetFormModal = function(questionset, set_prefix, set_index) {

--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -706,6 +706,9 @@ angular.module('project_questions')
     };
 
     service.storeValue = function(value, question, set_prefix, set_index, collection_index) {
+        // reset value errors
+        value.errors = []
+
         if (angular.isDefined(value.removed) && value.removed) {
             // remove additional_input from unselected checkboxes
             value.additional_input = {};
@@ -826,10 +829,16 @@ angular.module('project_questions')
             }, function (response) {
                 if (response.status == 500) {
                     service.error = response;
+                } else if (response.status == 400) {
+                    service.error = true;
+                    value.errors = Object.keys(response.data);
+                } else if (response.status == 404) {
+                    service.error = true;
+                    value.errors = ['not_found']
                 }
             })
         }
-};
+    };
 
     service.storeValues = function() {
         var promises = [];

--- a/rdmo/projects/templates/projects/project_questions_form_group_autocomplete.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_autocomplete.html
@@ -44,6 +44,8 @@
                     </div>
                 </div>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_checkbox.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_checkbox.html
@@ -24,6 +24,9 @@
                         ng-disabled="service.project.read_only"
                         ng-change="service.changed(service.values[question.attribute][valueset.set_prefix][valueset.set_index][$index])" />
                 </label>
+                <div ng-init="value = service.values[question.attribute][valueset.set_prefix][valueset.set_index][$index]">
+                    {% include 'projects/project_questions_value_errors.html' %}
+                </div>
             </div>
         </div>
     </div>

--- a/rdmo/projects/templates/projects/project_questions_form_group_date.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_date.html
@@ -24,6 +24,8 @@
                     ng-change="service.changed(value, true)"
                     ng-class="{'default-value': service.isDefaultValue(question, value)}"/>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_file.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_file.html
@@ -33,6 +33,8 @@
                     </ul>
                 </label>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_radio.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_radio.html
@@ -43,6 +43,8 @@
                     </div>
                 </div>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_range.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_range.html
@@ -31,6 +31,8 @@
                         ng-class="{'default-value': service.isDefaultValue(question, value)}"/>
                 </div>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_select.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_select.html
@@ -28,6 +28,8 @@
                     </option>
                 </select>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_text.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_text.html
@@ -21,6 +21,8 @@
                     ng-disabled="service.project.read_only"
                     ng-change="service.changed(value)"
                     ng-class="{'default-value': service.isDefaultValue(question, value)}">
+
+                {% include 'projects/project_questions_value_errors.html' %}
             </div>
         </div>
 

--- a/rdmo/projects/templates/projects/project_questions_form_group_textarea.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_textarea.html
@@ -23,6 +23,8 @@
                     ng-class="{'default-value': service.isDefaultValue(question, value)}">
                 </textarea>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_form_group_yesno.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_yesno.html
@@ -41,6 +41,8 @@
                     </div>
                 </div>
             </div>
+
+            {% include 'projects/project_questions_value_errors.html' %}
         </div>
 
         <div ng-if="question.is_collection">

--- a/rdmo/projects/templates/projects/project_questions_overview.html
+++ b/rdmo/projects/templates/projects/project_questions_overview.html
@@ -11,6 +11,9 @@
 
 <ul class="list-unstyled">
     <li>
+        <a href="#" onclick="window.location.reload();">{% trans 'Reload page' %}</a>
+    </li>
+    <li>
         <a href="{% url 'projects' %}">{% trans 'Back to my projects' %}</a>
     </li>
 </ul>

--- a/rdmo/projects/templates/projects/project_questions_save_error.html
+++ b/rdmo/projects/templates/projects/project_questions_save_error.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load core_tags %}
 
-    <div class="text-danger" ng-show="service.error">
+    <div class="text-danger" ng-show="service.error.statusText && service.error.status">
         <p>
             {% trans 'An error occurred while saving the answer. Please contact support if this problem persists.' %}
         </p>

--- a/rdmo/projects/templates/projects/project_questions_value_errors.html
+++ b/rdmo/projects/templates/projects/project_questions_value_errors.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+    <ul class="help-block list-unstyled" ng-if="value.errors.length > 0">
+        <li class="text-danger" ng-repeat="error in value.errors">
+            <span ng-show="error == 'conflict'">
+                {% blocktrans trimmed %}
+                This field could not be saved, since somebody else did so while you were editing.
+                You will need to reload the page to make changes, but your input will be overwritten.
+                {% endblocktrans %}
+            </span>
+            <span ng-show="error == 'not_found'">
+                {% blocktrans trimmed %}
+                This field could not be saved, since somebody else removed it while you were editing.
+                You will need to reload the page to proceed, but your input will be lost.
+                {% endblocktrans %}
+            </span>
+            <span ng-show="error == 'quota'">
+                {% trans 'You reached the file quota for this project.' %}
+            </span>
+        </li>
+    </ul>

--- a/rdmo/projects/tests/test_validator_conflict.py
+++ b/rdmo/projects/tests/test_validator_conflict.py
@@ -1,0 +1,123 @@
+from datetime import timedelta
+
+import pytest
+
+from rest_framework.exceptions import ValidationError as RestFameworkValidationError
+
+from ..models import Project, Value
+from ..serializers.v1 import ValueSerializer
+from ..validators import ValueConflictValidator
+
+project_id = 1
+attribute_path = attribute__path='individual/single/text'
+
+
+def test_serializer_create(db):
+    class MockedView:
+        project = Project.objects.get(id=project_id)
+
+    value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'attribute': value.attribute,
+        'set_prefix': value.set_prefix,
+        'set_index': value.set_index,
+        'collection_index': value.collection_index + 1,
+    }, serializer)
+
+
+def test_serializer_create_error(db):
+    class MockedView:
+        project = Project.objects.get(id=project_id)
+
+    value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    with pytest.raises(RestFameworkValidationError):
+        validator({
+            'attribute': value.attribute,
+            'set_prefix': value.set_prefix,
+            'set_index': value.set_index,
+            'collection_index': value.collection_index,
+        }, serializer)
+
+
+def test_serializer_update(db):
+    value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    class MockedRequest:
+        data = {
+            'updated': value.updated .isoformat()
+        }
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.instance = value
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'attribute': value.attribute,
+        'set_prefix': value.set_prefix,
+        'set_index': value.set_index,
+        'collection_index': value.collection_index,
+    }, serializer)
+
+
+def test_serializer_update_error(db):
+    value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    class MockedRequest:
+        data = {
+            'updated': (value.updated - timedelta(seconds=1)).isoformat()
+        }
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.instance = value
+    serializer.context['view'] = MockedView()
+
+    with pytest.raises(RestFameworkValidationError):
+        validator({
+            'attribute': value.attribute,
+            'set_prefix': value.set_prefix,
+            'set_index': value.set_index,
+            'collection_index': value.collection_index,
+        }, serializer)
+
+
+def test_serializer_update_missing_updated(db):
+    value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    class MockedRequest:
+        data = {}
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.instance = value
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'attribute': value.attribute,
+        'set_prefix': value.set_prefix,
+        'set_index': value.set_index,
+        'collection_index': value.collection_index,
+    }, serializer)

--- a/rdmo/projects/tests/test_validator_quota.py
+++ b/rdmo/projects/tests/test_validator_quota.py
@@ -9,13 +9,15 @@ project_id = 1
 attribute_path = attribute__path='individual/single/text'
 
 
-def test_serializer_create_file(db):
+def test_serializer_create_file(db, settings):
     class MockedProject:
         file_size = 1
 
     class MockedView:
         action = 'create'
         project = MockedProject()
+
+    settings.PROJECT_FILE_QUOTA = '1b'
 
     validator = ValueQuotaValidator()
     serializer = ValueSerializer()
@@ -62,4 +64,23 @@ def test_serializer_create_text(db, settings):
 
     validator({
         'value_type': 'text'
+    }, serializer)
+
+
+def test_serializer_update(db, settings):
+    class MockedProject:
+        file_size = 1
+
+    class MockedView:
+        action = 'update'
+        project = MockedProject()
+
+    settings.PROJECT_FILE_QUOTA = '0'
+
+    validator = ValueQuotaValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'value_type': 'file'
     }, serializer)

--- a/rdmo/projects/tests/test_validator_quota.py
+++ b/rdmo/projects/tests/test_validator_quota.py
@@ -1,0 +1,65 @@
+import pytest
+
+from rest_framework.exceptions import ValidationError as RestFameworkValidationError
+
+from ..serializers.v1 import ValueSerializer
+from ..validators import ValueQuotaValidator
+
+project_id = 1
+attribute_path = attribute__path='individual/single/text'
+
+
+def test_serializer_create_file(db):
+    class MockedProject:
+        file_size = 1
+
+    class MockedView:
+        action = 'create'
+        project = MockedProject()
+
+    validator = ValueQuotaValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'value_type': 'file'
+    }, serializer)
+
+
+def test_serializer_create_file_error(db, settings):
+    class MockedProject:
+        file_size = 1
+
+    class MockedView:
+        action = 'create'
+        project = MockedProject()
+
+    settings.PROJECT_FILE_QUOTA = '0'
+
+    validator = ValueQuotaValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    with pytest.raises(RestFameworkValidationError):
+        validator({
+            'value_type': 'file'
+        }, serializer)
+
+
+def test_serializer_create_text(db, settings):
+    class MockedProject:
+        file_size = 1
+
+    class MockedView:
+        action = 'create'
+        project = MockedProject()
+
+    settings.PROJECT_FILE_QUOTA = '0'
+
+    validator = ValueQuotaValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'value_type': 'text'
+    }, serializer)

--- a/rdmo/projects/validators.py
+++ b/rdmo/projects/validators.py
@@ -42,12 +42,9 @@ class ValueQuotaValidator:
     requires_context = True
 
     def __call__(self, data, serializer):
-        if data.get('value_type') == VALUE_TYPE_FILE:
-            try:
-                serializer.context['view'].get_object()
-            except AssertionError as e:
-                project = serializer.context['view'].project
-                if project.file_size > human2bytes(settings.PROJECT_FILE_QUOTA):
-                    raise serializers.ValidationError({
-                        'quota': [_('The file quota for this project has been reached.')]
-                    }) from e
+        if serializer.context['view'].action == 'create' and data.get('value_type') == VALUE_TYPE_FILE:
+            project = serializer.context['view'].project
+            if project.file_size > human2bytes(settings.PROJECT_FILE_QUOTA):
+                raise serializers.ValidationError({
+                    'quota': [_('The file quota for this project has been reached.')]
+                })

--- a/rdmo/projects/validators.py
+++ b/rdmo/projects/validators.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -7,7 +9,35 @@ from rdmo.core.constants import VALUE_TYPE_FILE
 from rdmo.core.utils import human2bytes
 
 
-class ValueValidator:
+class ValueConflictValidator:
+
+    requires_context = True
+
+    def __call__(self, data, serializer):
+        if serializer.instance:
+            # for an update, check if the value was updated in the meantime
+            updated = serializer.context['view'].request.data.get('updated')
+            if parse_datetime(updated) < serializer.instance.updated:
+                raise serializers.ValidationError({
+                    'conflict': [_('A newer version of this value was found.')]
+                })
+        else:
+            # for a new value, check if there is already a value with the same attribute and indexes
+            try:
+                serializer.context['view'].get_queryset().get(
+                    attribute=data.get('attribute'),
+                    set_prefix=data.get('set_prefix'),
+                    set_index=data.get('set_index'),
+                    collection_index=data.get('collection_index')
+                )
+                raise serializers.ValidationError({
+                    'conflict': [_('An existing value for this attribute/set_prefix/set_index/collection_index'
+                                  ' was found.')]
+                })
+            except ObjectDoesNotExist:
+                pass
+
+class ValueQuotaValidator:
 
     requires_context = True
 
@@ -20,5 +50,5 @@ class ValueValidator:
 
                 if project.file_size > human2bytes(settings.PROJECT_FILE_QUOTA):
                     raise serializers.ValidationError({
-                        'value': [_('You reached the file quota for this project.')]
+                        'quota': [_('The file quota for this project has been reached.')]
                     }) from e


### PR DESCRIPTION
This PR adds a validation to the `ProjectValueSerializer` that checks if the user tries to:

* create values which are already in the database, or
* update values which have newer versions in the database.

Related issues: #626.
