### PR TITLE
ci: add build-wheel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,35 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-wheel:
+    name: Build python wheel
+    needs: test
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: npm
+    - run: npm install
+    - run: npm run build:prod
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: pip
+    - run: python -m pip install --upgrade build pip setuptools wheel
+    - run: python -m build --wheel
+    - run: |
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        WHL_FILE=$(ls dist/*.whl)
+        NEW_NAME="${WHL_FILE/-py3-none-any/dev${PR_NUMBER}-py3-none-any}"
+        mv "$WHL_FILE" "$NEW_NAME"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wheel
+        path: dist/*.whl
+
   dev-setup:
     # Ref: structlog (MIT licensed) <https://github.com/hynek/structlog/blob/main/.github/workflows/ci.yml>
     name: "Test dev setup on ${{ matrix.os }}"
@@ -170,6 +199,7 @@ jobs:
       - lint
       - test
       - coveralls
+      - build-wheel
       - dev-setup
       - optional-dependencies
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

I added a CI job `build-wheel`, that runs on each pull request.

The job will build the frontend bundle using webpack and then build a python wheel.

The wheel will be renamed from the default name rdmo-{version}-py3-none-any.whl (e.g. `rdmo-2.0.2-py3-none-any.whl`) to rdmo-{version}-pr{pr-number}-py3-none-any.whl (e.g. `rdmo-2.0.2-pr-802-py3-none-any.whl`). This enables developers to install the wheel locally or on their test servers and then test the changes of a PR. The renaming makes it easier to tell the difference between wheels from different PRs.

Is the renaming reasonable or should it I remove this step?

Related issue: #802

## Types of Changes
- [x] Build related changes

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.