### PR TITLE
chore: update ruff repo name in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
         exclude: \.dot$
       - id: debug-statements
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.291
     hooks:
       - id: ruff


### PR DESCRIPTION
## Description

This PR just updates the name of the ruff repo in the pre-commit config. The official ruff repo is under the github org `astral-sh`.

## Types of Changes
- [x] Build related changes

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.