### PR TITLE
ci: add dependency groups to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,77 @@
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    target-branch: dependency-updates
-    labels:
-      - dependencies
-      - python
-      - type:maintenance
-    ignore:
-      - dependency-name: django-mptt # pinned, 0.15 requires Python >= 3.9
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    target-branch: dependency-updates
-    labels:
-      - dependencies
-      - github_actions
-      - type:maintenance
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    target-branch: dependency-updates
-    labels:
-      - dependencies
-      - javascript
-      - type:maintenance
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: dependency-updates
+  labels:
+  - dependencies
+  - python
+  - type:maintenance
+  ignore:
+  - dependency-name: django-mptt # pinned, 0.15 requires Python >= 3.9
+  groups:
+    # create a single pull request containing all updates for the optional dependencies
+    optional:
+      patterns:
+      - coveralls
+      - django-allauth
+      - django-auth-ldap
+      - gunicorn
+      - mysqlclient
+      - pre-commit
+      - psycopg*
+      - pytest*
+    # create a single pull request containing all updates for django related dependencies
+    django:
+      patterns:
+      - django*
+      - drf*
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: dependency-updates
+  labels:
+  - dependencies
+  - github_actions
+  - type:maintenance
+  groups:
+    # create a single pull request containing all updates for GitHub Actions
+    github-actions:
+      patterns:
+      - '*'
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: dependency-updates
+  labels:
+  - dependencies
+  - javascript
+  - type:maintenance
+  groups:
+    react:
+      patterns:
+      - react*
+    redux:
+      patterns:
+      - redux*
+    babel:
+      patterns:
+      - '@babel*'
+      - babel*
+    webpack:
+      patterns:
+      - webpack*
+    eslint:
+      patterns:
+      - eslint*
+    prod-dependencies:
+      dependency-type: production
+    dev-dependencies:
+      dependency-type: development


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- add several groups for dependabot updates:
- all optional python dependencies
- all django related dependencies
- all github actions
- several groups for javascript libraries, e.g.
- react
- redux
- ...
- other productions dependencies
- other development dependencies

Using these groups the number of dependabot update PRs per month should decrease significantly.

Related issue: #811

## Types of Changes
- [x] Other (please describe): CI, dependabot config

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.