### PR TITLE
ci: remove playwright browsers caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,6 @@ jobs:
         node-version: 18
         cache: npm
       if: matrix.python-version == '3.12' && matrix.db-backend == 'postgres'
-    - name: Cache Playwright browsers
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/ms-playwright/
-        key: playwright-browsers
-      if: matrix.python-version == '3.12' && matrix.db-backend == 'postgres'
     - name: Install e2e tests dependencies
       run: |
         npm install


### PR DESCRIPTION
## Description

The caching of the playwright browsers does not work as expected. It just creates a new cache with every CI run and fills up the GitHub Actions cache. The playwright docs actually do not recommend caching the browsers.

So let's remove this step.

## Types of Changes
- [x] Other (please describe): CI

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.