### PR TITLE
ci: add current git sha to version in build-wheel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,18 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - uses: actions/checkout@v4
+    - name: Get short commit SHA
+      id: short-sha
+      run: echo "sha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+    - name: Get current version (MAJOR.MINOR.PATCH)
+      id: current-version
+      run: echo "current_version=$(grep -Po '(?<=__version__ = ")[\d\w.]+(?=")' rdmo/__init__.py)" >> $GITHUB_OUTPUT
+    - name: Generate new version (current version + SHA)
+      id: new-version
+      run: echo "new_version=${{ steps.current-version.outputs.current_version }}+${{ steps.short-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+    - name: Update version in rdmo/__init__.py
+      run: |
+        sed -i "s/__version__ = .*/__version__ = \"${{ steps.new-version.outputs.new_version }}\"/" rdmo/__init__.py
     - uses: actions/setup-node@v4
       with:
         node-version: 18
@@ -147,17 +159,27 @@ jobs:
       with:
         python-version: '3.12'
         cache: pip
-    - run: python -m pip install --upgrade build pip setuptools wheel
-    - run: python -m build --wheel
-    - run: |
-        PR_NUMBER=${{ github.event.pull_request.number }}
-        WHL_FILE=$(ls dist/*.whl)
-        NEW_NAME="${WHL_FILE/-py3-none-any/dev${PR_NUMBER}-py3-none-any}"
-        mv "$WHL_FILE" "$NEW_NAME"
-    - uses: actions/upload-artifact@v3
+    - run: python -m pip install --upgrade build pip setuptools twine wheel
+    - name: Build the wheel
+      run: python -m build --wheel
+    - name: Check metadata
+      run: python -m twine check --strict dist/*
+    - name: Install package from built wheel
+      run: python -m pip install dist/rdmo*.whl
+    - name: Write info to step summary
+      run: |
+        echo -e "# ✓ Wheel successfully built (v${{ steps.new-version.outputs.new_version }})\n\n" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`console" >> $GITHUB_STEP_SUMMARY
+        echo "$ python -m pip show rdmo" >> $GITHUB_STEP_SUMMARY
+        python -m pip show rdmo >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+    - name: Upload wheel as artifact
+      uses: actions/upload-artifact@v3
       with:
         name: wheel
-        path: dist/*.whl
+        path: dist/rdmo*.whl
+        if-no-files-found: error
+        retention-days: 30
 
   dev-setup:
     # Ref: structlog (MIT licensed) <https://github.com/hynek/structlog/blob/main/.github/workflows/ci.yml>

--- a/rdmo/__init__.py
+++ b/rdmo/__init__.py
@@ -1,1 +1,1 @@
-VERSION = __version__ = "2.0.2"
+__version__ = "2.0.2"


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- remove the obsolote `VERSION` variable from __init__.py
- add the current git SHA to the version in build-wheel job

## Motivation and Context

As discussed in the slack channel yesterday, this was desired by @jochenklar.

Originally the build-wheel job was introduced in #812.

It created a python wheel (including the JavaScript frontend code bundled with webpack) under the name

`rdmo-{version}dev{pr_number}-py3-none-any.whl`

e.g. given
version = 2.0.2 and pr_number = 833
`rdmo-2.0.2dev833-py3-none-any.whl`

@jochenklar suggested the new wheel name to include the git SHA (7 chars short version) to ease deploying multiple times from the same PR (possibly long living like the dev2.1.0).

However the suggested form of
`rdmo-{version}.dev{sha}-py3-none-any.whl`
is invalid, due to PEP440 and [Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers). 

`dev` can only be followed by an integer, which the PR number was.

I chose this new pattern instead:

`rdmo-{version}.dev0+{sha}-py3-none-any.whl`

which is valid. Another possibility would be:

`rdmo-{version}+{sha}-py3-none-any.whl`

What do you think?

## How has this been tested?

Tested locally.

```console
$ python -m pip install rdmo-2.0.2.dev0+553c22a-py3-none-any.whl
```

```console
$ pip show rdmo                                       
Name: rdmo
Version: 2.0.2.dev0+553c22a
Summary: RDMO is a tool to support the systematic planning, organisation and implementation of the data management throughout the course of a research project.
Home-page: 
Author: 
Author-email: RDMO Arbeitsgemeinschaft <rdmo-team@listserv.dfn.de>
License: Apache-2.0
Location: /home/afuetterer/workspace/github/rdmo-fork/.venv/lib/python3.12/site-packages
Requires: defusedcsv, defusedxml, django, django-cleanup, django-compressor, django-extensions, django-filter, django-libsass, django-mathfilters, django-mptt, django-rest-swagger, django-settings-export, django-split-settings, django-widget-tweaks, djangorestframework, drf-extensions, iso8601, markdown, pypandoc, requests-toolbelt, rules
Required-by: 
```

## Types of Changes
- [x] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Tasks
- [x] update version regex to select string between quotes
- [x] remove dev+0
- [x] write version to github step summary
- [x] use pr head sha
