### PR TITLE
fix: add required dependency packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
   "drf-extensions~=0.7.1",
   "iso8601~=2.0",
   "markdown~=3.4",
+  "packaging~=23.2",
   "pypandoc~=1.11",
   "requests-toolbelt~=1.0",
   "rules~=3.3",


### PR DESCRIPTION
## Description

The `packaging` library is used in `rdmo/core/xml.py`, but it was not listed in the requirements. If users install rdmo without rdmo[dev], they do not install pytest. Pytest installs packaging in CI, so the error never showed in CI.

## Motivation and Context

@jochenklar mentioned this in the slack channel. I can confirm, that simply installing rdmo, does not install packaging.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.