### PR TITLE
ci: add dependency tree to step summary of optional-dependencies job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         python-version: "3.12"
         cache: pip
-    - run: python -m pip install --upgrade pip setuptools wheel
-    - run: python -m pip install -e .[dev]
+    - run: python -m pip install --upgrade pip
+    - run: python -m pip install --editable .[dev]
     - name: Set up pre-commit cache
       uses: actions/cache@v3
       with:
@@ -65,16 +65,16 @@ jobs:
       run: |
         sudo apt update
         sudo apt install --yes pandoc texlive-xetex librsvg2-bin
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         pandoc --version
     - name: Install rdmo[mysql] and start mysql
       run: |
-        python -m pip install -e .[ci,mysql]
+        python -m pip install --editable .[ci,mysql]
         sudo systemctl start mysql.service
       if: matrix.db-backend == 'mysql'
     - name: Install rdmo[postgres] and start postgresql
       run: |
-        python -m pip install -e .[ci,postgres]
+        python -m pip install --editable .[ci,postgres]
         sudo systemctl start postgresql.service
         pg_isready
         sudo -u postgres psql --command="CREATE USER postgres_user PASSWORD 'postgres_password' CREATEDB"
@@ -159,13 +159,15 @@ jobs:
       with:
         python-version: '3.12'
         cache: pip
-    - run: python -m pip install --upgrade build pip setuptools twine wheel
+    - run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[dev]
     - name: Build the wheel
       run: python -m build --wheel
     - name: Check metadata
       run: python -m twine check --strict dist/*
     - name: Install package from built wheel
-      run: python -m pip install dist/rdmo*.whl
+      run: python -m pip install --force-reinstall dist/rdmo*.whl
     - name: Write info to step summary
       run: |
         echo -e "# ✓ Wheel successfully built (v${{ steps.new-version.outputs.new_version }})\n\n" >> $GITHUB_STEP_SUMMARY
@@ -194,7 +196,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: python -Im pip install -e .[dev]
+      - run: python -Im pip install --editable .[dev]
       - run: python -Ic 'import rdmo; print(rdmo.__version__)'
 
   optional-dependencies:
@@ -210,7 +212,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install --yes libldap2-dev libsasl2-dev
-      - run: python -m pip install --upgrade pip pipdeptree setuptools
+      - run: python -m pip install --upgrade pip
       - run: python -m pip install .[allauth,shibboleth,ci,dev,gunicorn,ldap,mysql,postgres,pytest]
       - name: Write info to step summary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,23 @@ jobs:
         run: |
           sudo apt update
           sudo apt install --yes libldap2-dev libsasl2-dev
-      - run: python -m pip install --upgrade pip setuptools
+      - run: python -m pip install --upgrade pip pipdeptree setuptools
       - run: python -m pip install .[allauth,shibboleth,ci,dev,gunicorn,ldap,mysql,postgres,pytest]
-      - run: python -m pip freeze
-      - run: python -m pip list --outdated
+      - name: Write info to step summary
+        run: |
+          {
+            echo -e "# ✓ All optional dependency groups successfully installed in combination\n\n"
+            echo '<details><summary>Installed Python packages as dependency tree</summary>'
+            echo -e "\n\`\`\`console"
+            echo "$ python -m pipdeptree --local-only --exclude=pip,pipdeptree"
+            python -m pipdeptree --local-only --exclude=pip,pipdeptree
+            echo -e "\`\`\`\n</details>"
+            echo '<details><summary>Outdated dependencies</summary>'
+            echo -e "\n\`\`\`console"
+            echo "$ python -m pip list --outdated"
+            python -m pip list --outdated
+            echo -e "\`\`\`\n</details>"
+          } >> $GITHUB_STEP_SUMMARY
 
   required-checks-pass:
     if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,12 @@ ci = [
   "rdmo[dev]",
 ]
 dev = [
+  "build~=1.0",
+  "pipdeptree~=2.13",
   "pre-commit~=3.4",
+  "setuptools~=69.0",
+  "twine~=4.0",
+  "wheel~=0.42.0",
   "rdmo[allauth]",
   "rdmo[pytest]",
 ]


### PR DESCRIPTION
## Description

Promise: This is my last PR to dev-2.1.0.

This PR proposes to add a new step summary to the optional-dependencies job.

The summary makes use of [pipdeptree](https://pypi.org/project/pipdeptree/) to show to installed python packages and their transitive dependencies. This way we can make sure, that `packaging`  for example is installed and see where it comes from.

What do you think?

See the summary in: https://github.com/rdmorganiser/rdmo/actions/runs/7104483723

## Types of Changes
- [x] Other (please describe): CI

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.