### PR TITLE
Fix options endpoint for option set providers

### DIFF
--- a/rdmo/projects/templates/projects/project_questions_form_group_autocomplete.html
+++ b/rdmo/projects/templates/projects/project_questions_form_group_autocomplete.html
@@ -38,8 +38,7 @@
                             <li ng-repeat="option in value.items"
                                 ng-class="{'active': option.active}"
                                 ng-mousedown="service.selectAutocomplete(value, option)">
-                                <span ng-show="option.text_and_help">{$ option.text_and_help $}</span>
-                                <span ng-show="option.text">{$ option.text $}</span>
+                                {$ option.text_and_help $}
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
The new `text_and_help` field is not set for plugins, and the previous fix was not sufficient. Also a `project.catalog.prefetch_elements()` was missing which made the endpoint very slow.