### PR TITLE
Fix import of Option.additional_input

### DIFF
--- a/rdmo/options/imports.py
+++ b/rdmo/options/imports.py
@@ -62,7 +62,7 @@ def import_option(element, save=False, user=None):
 
     set_common_fields(option, element)
 
-    option.additional_input = element.get('additional_input')
+    option.additional_input = element.get('additional_input') or ''
 
     set_lang_field(option, 'text', element)
     set_lang_field(option, 'help', element)


### PR DESCRIPTION
Right now, imports crash when `additional_input` is empty or not set. The change was missing when implementing the new textarea feature.