### PR TITLE
Fix count_questions when no attribute is set for a question

### DIFF
--- a/rdmo/projects/progress.py
+++ b/rdmo/projects/progress.py
@@ -119,17 +119,17 @@ def count_questions(element, sets, conditions):
 
         # count the sets for the id attribute of the page or question
         if element.attribute is not None:
+            # nested loop over the seperate set_index lists in sets[element.attribute.id]
             for set_index in chain.from_iterable(sets[element.attribute.id].values()):
                 counted_sets.add(set_index)
 
         # count the sets for the questions in the page or question
         for child in element.elements:
-            if not isinstance(child, Question):
-                continue
-            if child.attribute is None:
-                continue
-            for set_index in chain.from_iterable(sets[child.attribute.id].values()):
-                counted_sets.add(set_index)
+            if isinstance(child, Question):
+                if child.attribute is not None:
+                    # nested loop over the seperate set_index lists in sets[element.attribute.id]
+                    for set_index in chain.from_iterable(sets[child.attribute.id].values()):
+                        counted_sets.add(set_index)
 
         set_count = len(counted_sets)
     else:

--- a/rdmo/projects/progress.py
+++ b/rdmo/projects/progress.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from itertools import chain
 
 from django.db.models import Exists, OuterRef, Q
 
@@ -118,19 +119,17 @@ def count_questions(element, sets, conditions):
 
         # count the sets for the id attribute of the page or question
         if element.attribute is not None:
-            for set_indexes in sets[element.attribute.id].values():
-                for set_index in set_indexes:
-                    if set_index not in counted_sets:
-                        counted_sets.add(set_index)
+            for set_index in chain.from_iterable(sets[element.attribute.id].values()):
+                counted_sets.add(set_index)
 
         # count the sets for the questions in the page or question
         for child in element.elements:
-            if isinstance(child, Question):
-                if child.attribute is not None:
-                    for set_indexes in sets[child.attribute.id].values():
-                        for set_index in set_indexes:
-                            if set_index not in counted_sets:
-                                counted_sets.add(set_index)
+            if not isinstance(child, Question):
+                continue
+            if child.attribute is None:
+                continue
+            for set_index in chain.from_iterable(sets[child.attribute.id].values()):
+                counted_sets.add(set_index)
 
         set_count = len(counted_sets)
     else:

--- a/rdmo/projects/progress.py
+++ b/rdmo/projects/progress.py
@@ -122,8 +122,9 @@ def count_questions(element, sets, conditions):
 
         for child in element.elements:
             if isinstance(child, Question):
-                child_count = sum(len(set_indexes) for set_indexes in sets[child.attribute.id].values())
-                set_count = max(set_count, child_count)
+                if child.attribute is not None:
+                    child_count = sum(len(set_indexes) for set_indexes in sets[child.attribute.id].values())
+                    set_count = max(set_count, child_count)
     else:
         set_count = 1
 

--- a/rdmo/projects/progress.py
+++ b/rdmo/projects/progress.py
@@ -110,21 +110,29 @@ def compute_progress(project, snapshot=None):
 def count_questions(element, sets, conditions):
     counts = defaultdict(int)
 
-    # obtain the maximum number of set-distinct values the questions in this element
-    # this number is how often each question is displayed and we will use this number
-    # to determine how often a question needs to be counted
+    # obtain the maximum number of set-distinct values for the questions in this page or
+    # question set this number is how often each question is displayed and we will use
+    # this number to determine how often a question needs to be counted
     if isinstance(element, (Page, QuestionSet)) and element.is_collection:
-        set_count = 0
+        counted_sets = set()
 
+        # count the sets for the id attribute of the page or question
         if element.attribute is not None:
-            child_count = sum(len(set_indexes) for set_indexes in sets[element.attribute.id].values())
-            set_count = max(set_count, child_count)
+            for set_indexes in sets[element.attribute.id].values():
+                for set_index in set_indexes:
+                    if set_index not in counted_sets:
+                        counted_sets.add(set_index)
 
+        # count the sets for the questions in the page or question
         for child in element.elements:
             if isinstance(child, Question):
                 if child.attribute is not None:
-                    child_count = sum(len(set_indexes) for set_indexes in sets[child.attribute.id].values())
-                    set_count = max(set_count, child_count)
+                    for set_indexes in sets[child.attribute.id].values():
+                        for set_index in set_indexes:
+                            if set_index not in counted_sets:
+                                counted_sets.add(set_index)
+
+        set_count = len(counted_sets)
     else:
         set_count = 1
 
@@ -138,10 +146,17 @@ def count_questions(element, sets, conditions):
 
         if not child_conditions or child_conditions.intersection(conditions):
             if isinstance(child, Question):
-                # for questions add the set_count to the counts dict
+                # for regular questions add the set_count to the counts dict, since the
+                # question should be answered in every set
+                # for optional questions add just the number of present answers, so that
+                # only answered questions count for the progress/navigation
                 # use the max function, since the same attribute could apear twice in the tree
-                if child.attribute is not None and not child.is_optional:
-                    counts[child.attribute.id] = max(counts[child.attribute.id], set_count)
+                if child.attribute is not None:
+                    if child.is_optional:
+                        child_count = sum(len(set_indexes) for set_indexes in sets[child.attribute.id].values())
+                        counts[child.attribute.id] = max(counts[child.attribute.id], child_count)
+                    else:
+                        counts[child.attribute.id] = max(counts[child.attribute.id], set_count)
             else:
                 # for everthing else, call this function recursively
                 counts.update(count_questions(child, sets, conditions))

--- a/rdmo/projects/tests/test_navigation.py
+++ b/rdmo/projects/tests/test_navigation.py
@@ -39,7 +39,7 @@ result_map = {
     'http://example.com/terms/questions/catalog/conditions/set_set': (0, 2, True),
     'http://example.com/terms/questions/catalog/conditions/optionset': (0, 2, True),
     'http://example.com/terms/questions/catalog/conditions/text_set': (0, 2, True),
-    'http://example.com/terms/questions/catalog/blocks/set': (6, 15, True),
+    'http://example.com/terms/questions/catalog/blocks/set': (9, 12, True),
 }
 
 

--- a/rdmo/projects/tests/test_progress.py
+++ b/rdmo/projects/tests/test_progress.py
@@ -6,7 +6,7 @@ from rdmo.projects.progress import compute_progress
 projects = [1, 11]
 
 results_map = {
-    1: (55, 84),
+    1: (58, 81),
     11: (0, 29)
 }
 


### PR DESCRIPTION
* Fix count_questions when no attribute is set for a question. In `2.1.1` not setting an attribute will cause a (hard to track) 500 on the navigation endpoint.
* Fix count_questions for question sets. Before when set 1 has the first question answered and set 2 has the second question answered, the computed set count was only 1. Only when one question was answered several times the count increased.