### PR TITLE
Fix management when BASE_URL is set

### DIFF
--- a/webpack/common.config.js
+++ b/webpack/common.config.js
@@ -58,7 +58,6 @@ module.exports = [
     },
     output: {
       filename: 'js/management.js',
-      publicPath: '/static/management/',
       path: path.resolve(__dirname, '../rdmo/management/static/management/'),
     }
   })


### PR DESCRIPTION
This PR removes the `publicPath` setting from the webpack config, which *should* fix the problem when using `BASE_URL`...