### PR TITLE
Add custom SearchFilter to account for the language fields

### DIFF
--- a/rdmo/conditions/tests/test_viewset_condition.py
+++ b/rdmo/conditions/tests/test_viewset_condition.py
@@ -78,6 +78,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['condition']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/conditions/viewsets.py
+++ b/rdmo/conditions/viewsets.py
@@ -1,5 +1,4 @@
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -7,6 +6,7 @@ from rest_framework.viewsets import ModelViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 from rdmo.core.views import ChoicesViewSet

--- a/rdmo/core/filters.py
+++ b/rdmo/core/filters.py
@@ -1,0 +1,30 @@
+from django.db.models import Q
+from django.utils.translation import get_language
+
+from rest_framework.filters import BaseFilterBackend
+
+from rdmo.core.utils import get_languages
+
+
+class SearchFilter(BaseFilterBackend):
+
+    def filter_queryset(self, request, queryset, view):
+        if view.detail:
+            return queryset
+
+        search = request.GET.get('search')
+        if search:
+            q = Q()
+
+            if 'uri' in view.search_fields:
+                q |= Q(uri__contains=search)
+
+            for lang_code, lang_string, lang_field in get_languages():
+                if lang_code == get_language():
+                    for search_field in ['title', 'text']:
+                        if search_field in view.search_fields:
+                            q |= Q(**{f'{search_field}_{lang_field}__contains': search})
+
+            queryset = queryset.filter(q)
+
+        return queryset

--- a/rdmo/domain/tests/test_viewset_attribute.py
+++ b/rdmo/domain/tests/test_viewset_attribute.py
@@ -68,6 +68,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['attribute']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/domain/viewsets.py
+++ b/rdmo/domain/viewsets.py
@@ -1,13 +1,13 @@
 from django.db import models
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import render_to_csv, render_to_format
 

--- a/rdmo/options/tests/test_viewset_options.py
+++ b/rdmo/options/tests/test_viewset_options.py
@@ -79,6 +79,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['option']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/options/tests/test_viewset_optionsets.py
+++ b/rdmo/options/tests/test_viewset_optionsets.py
@@ -79,6 +79,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['optionset', 'option']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/options/viewsets.py
+++ b/rdmo/options/viewsets.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.db import models
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -10,6 +9,7 @@ from rest_framework.viewsets import ModelViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 from rdmo.core.views import ChoicesViewSet

--- a/rdmo/questions/tests/test_viewset_catalog.py
+++ b/rdmo/questions/tests/test_viewset_catalog.py
@@ -82,6 +82,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['catalog', 'section', 'page', 'questionset', 'question']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/questions/tests/test_viewset_page.py
+++ b/rdmo/questions/tests/test_viewset_page.py
@@ -83,6 +83,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['page', 'questionset', 'question']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/questions/tests/test_viewset_question.py
+++ b/rdmo/questions/tests/test_viewset_question.py
@@ -83,6 +83,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['question']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/questions/tests/test_viewset_questionset.py
+++ b/rdmo/questions/tests/test_viewset_questionset.py
@@ -83,6 +83,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['questionset', 'question']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/questions/tests/test_viewset_section.py
+++ b/rdmo/questions/tests/test_viewset_section.py
@@ -83,6 +83,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['section', 'page', 'questionset', 'question']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/questions/viewsets.py
+++ b/rdmo/questions/viewsets.py
@@ -1,7 +1,6 @@
 from django.db import models
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -10,6 +9,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.constants import VALUE_TYPE_CHOICES
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 from rdmo.core.views import ChoicesViewSet

--- a/rdmo/tasks/tests/test_viewset_task.py
+++ b/rdmo/tasks/tests/test_viewset_task.py
@@ -78,6 +78,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['task']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/tasks/viewsets.py
+++ b/rdmo/tasks/viewsets.py
@@ -1,13 +1,13 @@
 from django.db import models
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 
@@ -26,7 +26,7 @@ class TaskViewSet(ModelViewSet):
                            .order_by('uri')
 
     filter_backends = (SearchFilter, DjangoFilterBackend)
-    search_fields = ('uri', )
+    search_fields = ('uri', 'title')
     filterset_fields = (
         'uri',
         'uri_prefix',

--- a/rdmo/views/tests/test_viewset_view.py
+++ b/rdmo/views/tests/test_viewset_view.py
@@ -78,6 +78,14 @@ def test_export(db, client, username, password, export_format):
             assert child.tag in ['view']
 
 
+def test_export_search(db, client):
+    client.login(username='editor', password='editor')
+
+    url = reverse(urlnames['export']) + 'xml/?search=bar'
+    response = client.get(url)
+    assert response.status_code == status_map['list']['editor'], response.content
+
+
 @pytest.mark.parametrize('username,password', users)
 def test_detail(db, client, username, password):
     client.login(username=username, password=password)

--- a/rdmo/views/viewsets.py
+++ b/rdmo/views/viewsets.py
@@ -1,13 +1,13 @@
 from django.db import models
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.exports import XMLResponse
+from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import render_to_format
 
@@ -25,7 +25,7 @@ class ViewViewSet(ModelViewSet):
                            .order_by('uri')
 
     filter_backends = (SearchFilter, DjangoFilterBackend)
-    search_fields = ('uri', )
+    search_fields = ('uri', 'title')
     filterset_fields = (
         'uri',
         'uri_prefix',


### PR DESCRIPTION
The new search filter backend accounts for the currently used language. This should fix https://github.com/rdmorganiser/rdmo/issues/881.