### PR TITLE
ci: let pre-commit-autoupdate create prs in draft mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
       - conftest.py
       - package.json
       - pyproject.toml
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review # this is needed to trigger checks, when an auto-generated "draft" PR is set for "ready for review".
 
 # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -37,7 +37,8 @@ jobs:
           sed -i -e 's/\]/>/g' updates.log
           echo -e "## Proposed changes\n\nBumps the pre-commit config with the following updates:\n" > pr-body.md
           cat updates.log >> pr-body.md
-          echo -e "\n---\nThis PR is auto-generated once a month." >> pr-body.md
+          echo -e "\nThis PR is auto-generated once a month.\n\n---" >> pr-body.md
+          echo -e "\n> [!NOTE]\n> Mark this PR as "ready for review" to trigger additional checks." >> pr-body.md
       # Ref: https://github.com/peter-evans/create-pull-request
       - name: Create pull request
         uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6.0.2
@@ -55,6 +56,7 @@ jobs:
             pre-commit
             type:maintenance
           delete-branch: true
+          draft: true
       - name: Write to job summary
         run: |
           cat updates.log >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

At the moment the pre-commit PRs do not trigger checks, which is not ideal, because the updates could lead the failing tests.

This PR updates the pre-commit-autoupdate job to create PR in draft mode. Once a draft PR is set to "ready for review" by a RMDO contributor, the additional CI checks will run on that PR.

## Motivation and Context

See above.

## How has this been tested?

In my fork of the project.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## Checklist

- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
