### PR TITLE
Fix progress action if progress did not change

### DIFF
--- a/rdmo/core/templates/core/about_text_en.html
+++ b/rdmo/core/templates/core/about_text_en.html
@@ -12,8 +12,8 @@
 
 <div class="text-justify">
     <p>
-        The Research Data Management Organiser (RDMO) enables institutions as well as researchers to plan and carry out their management of research data. RDMO can assemble all relevant planning information and data management tasks across the whole life cycle of the research data.
-        The RDMO tool was developed by the project partners of Leibniz Institute for Astrophysics Potsdam, University of Applied Sciences of Potsdam and the library of Karlsruhe Institute of Technology and is mantained by the RDMO consortium.
+        The Research Data Management Organiser (RDMO) enables institutions as well as researchers to plan and carry out their management of research data in a structured manner. RDMO can assemble all relevant planning information and data management tasks across the whole life cycle of the research data.
+        RDMO was developed within a cooperation between the Leibniz Institute for Astrophysics Potsdam, the University of Applied Sciences of Potsdam and the library of the Karlsruhe Institute of Technology and is now maintained, further developed and consolidated by the RDMO working group.
     </p>
 
     <p>

--- a/rdmo/core/templates/core/about_text_en.html
+++ b/rdmo/core/templates/core/about_text_en.html
@@ -12,8 +12,8 @@
 
 <div class="text-justify">
     <p>
-        The Research Data Management Organiser (RDMO) enables institutions as well as researchers to plan and carry out their management of research data in a structured manner. RDMO can assemble all relevant planning information and data management tasks across the whole life cycle of the research data.
-        RDMO was developed within a cooperation between the Leibniz Institute for Astrophysics Potsdam, the University of Applied Sciences of Potsdam and the library of the Karlsruhe Institute of Technology and is now maintained, further developed and consolidated by the RDMO working group.
+      With the Research Data Management Organiser (RDMO), institutions and researchers can plan and implement the research data management of their projects in a structured manner. It allows the recording of all relevant planning information in data management plans and the administration of all data management tasks over the entire data life cycle.
+      RDMO was developed as part of a co-operation between the Leibniz Institute for Astrophysics Potsdam, the University of Applied Sciences Potsdam and the library of the Karlsruhe Institute of Technology and is now maintained, further developed and consolidated by the RDMO working group.
     </p>
 
     <p>

--- a/rdmo/core/templates/core/about_text_en.html
+++ b/rdmo/core/templates/core/about_text_en.html
@@ -12,8 +12,8 @@
 
 <div class="text-justify">
     <p>
-      With the Research Data Management Organiser (RDMO), institutions and researchers can plan and implement the research data management of their projects in a structured manner. It allows the recording of all relevant planning information in data management plans and the administration of all data management tasks over the entire data life cycle.
-      RDMO was developed as part of a co-operation between the Leibniz Institute for Astrophysics Potsdam, the University of Applied Sciences Potsdam and the library of the Karlsruhe Institute of Technology and is now maintained, further developed and consolidated by the RDMO working group.
+        The Research Data Management Organiser (RDMO) enables institutions as well as researchers to plan and carry out their management of research data. RDMO can assemble all relevant planning information and data management tasks across the whole life cycle of the research data.
+        The RDMO tool was developed by the project partners of Leibniz Institute for Astrophysics Potsdam, University of Applied Sciences of Potsdam and the library of Karlsruhe Institute of Technology and is mantained by the RDMO consortium.
     </p>
 
     <p>

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -213,11 +213,12 @@ class ProjectViewSet(ModelViewSet):
         project = self.get_object()
 
         if request.method == 'POST' or project.progress_count is None or project.progress_total is None:
-            # compute the progress and store
+            # compute the progress, but store it only, if it has changed
             project.catalog.prefetch_elements()
-            project.progress_count, project.progress_total = compute_progress(project)
-            project.save()
-
+            progress_count, progress_total = compute_progress(project)
+            if progress_count != project.progress_count or progress_total != project.progress_total:
+                project.progress_count, project.progress_total = progress_count, progress_total
+                project.save()
         try:
             ratio = project.progress_count / project.progress_total
         except ZeroDivisionError:


### PR DESCRIPTION
This PR fixes the problem that the `project` is always saved on the `POST` request to the `progress` endpoint, regardless if the progress changed. This leads to a new `updated` timestamp in the `Project` model, even if people just click through the interview.