### PR TITLE
Add last_changed to projects API and front-end

### DIFF
--- a/rdmo/projects/assets/js/components/helper/ProjectFilters.js
+++ b/rdmo/projects/assets/js/components/helper/ProjectFilters.js
@@ -25,6 +25,26 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
     projectsActions.fetchAllProjects()
   }
 
+  // Abstract function to handle date change
+  const handleDateChange = (type, position, date) => {
+    if (position === 'start') {
+      setStartDate(type, date)
+      if (date) {
+        configActions.updateConfig(`params.${type}_after`, formatISO(date, { representation: 'date' }))
+      } else {
+        configActions.deleteConfig(`params.${type}_after`)
+      }
+    } else if (position === 'end') {
+      setEndDate(type, date)
+      if (date) {
+        configActions.updateConfig(`params.${type}_before`, formatISO(date, { representation: 'date' }))
+      } else {
+        configActions.deleteConfig(`params.${type}_before`)
+      }
+    }
+    projectsActions.fetchAllProjects()
+  }
+
   return (
     <div className="panel panel-default panel-filters mt-10 mb-0">
       <div className="panel-body">
@@ -54,15 +74,7 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                       id="created-start-date-picker"
                       isClearable
                       locale={getLocale(language)}
-                      onChange={date => {
-                        setStartDate('created', date)
-                        if (date) {
-                          configActions.updateConfig('params.created_after', formatISO(date, { representation: 'date' }))
-                        } else {
-                          configActions.deleteConfig('params.created_after')
-                        }
-                        projectsActions.fetchAllProjects()
-                      }}
+                      onChange={date => handleDateChange('created', 'start', date)}
                       placeholderText={gettext('Select start date')}
                       selected={dateRange.createdStart ?? get(config, 'params.created_after', '')}
                     />
@@ -75,15 +87,7 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                       id="created-end-date-picker"
                       isClearable
                       locale={getLocale(language)}
-                      onChange={date => {
-                        setEndDate('created', date)
-                        if (date) {
-                          configActions.updateConfig('params.created_before', formatISO(date, { representation: 'date' }))
-                        } else {
-                          configActions.deleteConfig('params.created_before')
-                        }
-                        projectsActions.fetchAllProjects()
-                      }}
+                      onChange={date => handleDateChange('created', 'end', date)}
                       placeholderText={gettext('Select end date')}
                       selected={dateRange.createdEnd ?? get(config, 'params.created_before', '')}
                     />
@@ -104,15 +108,7 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                     id="last-changed-start-date-picker"
                     isClearable
                     locale={getLocale(language)}
-                    onChange={date => {
-                      setStartDate('last_changed', date)
-                      if (date) {
-                        configActions.updateConfig('params.last_changed_after', formatISO(date, { representation: 'date' }))
-                      } else {
-                        configActions.deleteConfig('params.last_changed_after')
-                      }
-                      projectsActions.fetchAllProjects()
-                    }}
+                    onChange={date => handleDateChange('last_changed', 'start', date)}
                     placeholderText={gettext('Select start date')}
                     selected={dateRange.lastChangedStart ?? get(config, 'params.last_changed_after', '')}
                   />
@@ -125,15 +121,7 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                     id="last-changed-end-date-picker"
                     isClearable
                     locale={getLocale(language)}
-                    onChange={date => {
-                      setEndDate('last_changed', date)
-                      if (date) {
-                        configActions.updateConfig('params.last_changed_before', formatISO(date, { representation: 'date' }))
-                      } else {
-                        configActions.deleteConfig('params.last_changed_before')
-                      }
-                      projectsActions.fetchAllProjects()
-                    }}
+                    onChange={date => handleDateChange('last_changed', 'end', date)}
                     placeholderText={gettext('Select end date')}
                     selected={dateRange.lastChangedEnd ?? get(config, 'params.last_changed_before', '')}
                   />

--- a/rdmo/projects/assets/js/components/helper/ProjectFilters.js
+++ b/rdmo/projects/assets/js/components/helper/ProjectFilters.js
@@ -101,20 +101,20 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                     autoComplete="off"
                     className="form-control"
                     dateFormat={dateFormat}
-                    id="updated-start-date-picker"
+                    id="last-changed-start-date-picker"
                     isClearable
                     locale={getLocale(language)}
                     onChange={date => {
-                      setStartDate('updated', date)
+                      setStartDate('last_changed', date)
                       if (date) {
-                        configActions.updateConfig('params.updated_after', formatISO(date, { representation: 'date' }))
+                        configActions.updateConfig('params.last_changed_after', formatISO(date, { representation: 'date' }))
                       } else {
-                        configActions.deleteConfig('params.updated_after')
+                        configActions.deleteConfig('params.last_changed_after')
                       }
                       projectsActions.fetchAllProjects()
                     }}
                     placeholderText={gettext('Select start date')}
-                    selected={dateRange.updatedStart ?? get(config, 'params.updated_after', '')}
+                    selected={dateRange.lastChangedStart ?? get(config, 'params.last_changed_after', '')}
                   />
                 </div>
                 <div className="col-md-6">
@@ -122,20 +122,20 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
                     autoComplete="off"
                     className="form-control"
                     dateFormat={dateFormat}
-                    id="updated-end-date-picker"
+                    id="last-changed-end-date-picker"
                     isClearable
                     locale={getLocale(language)}
                     onChange={date => {
-                      setEndDate('updated', date)
+                      setEndDate('last_changed', date)
                       if (date) {
-                        configActions.updateConfig('params.updated_before', formatISO(date, { representation: 'date' }))
+                        configActions.updateConfig('params.last_changed_before', formatISO(date, { representation: 'date' }))
                       } else {
-                        configActions.deleteConfig('params.updated_before')
+                        configActions.deleteConfig('params.last_changed_before')
                       }
                       projectsActions.fetchAllProjects()
                     }}
                     placeholderText={gettext('Select end date')}
-                    selected={dateRange.updatedEnd ?? get(config, 'params.updated_before', '')}
+                    selected={dateRange.lastChangedEnd ?? get(config, 'params.last_changed_before', '')}
                   />
                 </div>
               </div>

--- a/rdmo/projects/assets/js/components/helper/ProjectFilters.js
+++ b/rdmo/projects/assets/js/components/helper/ProjectFilters.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { get } from 'lodash'
 import DatePicker from 'react-datepicker'
-import { formatISO } from 'date-fns'
+import { formatISO, set  } from 'date-fns'
 
 import { Select } from 'rdmo/core/assets/js/components'
 import useDatePicker from '../../hooks/useDatePicker'
@@ -30,14 +30,16 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
     if (position === 'start') {
       setStartDate(type, date)
       if (date) {
-        configActions.updateConfig(`params.${type}_after`, formatISO(date, { representation: 'date' }))
+        const startOfDayDate = set(date, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 })
+        configActions.updateConfig(`params.${type}_after`, formatISO(startOfDayDate, { representation: 'complete' }))
       } else {
         configActions.deleteConfig(`params.${type}_after`)
       }
     } else if (position === 'end') {
       setEndDate(type, date)
       if (date) {
-        configActions.updateConfig(`params.${type}_before`, formatISO(date, { representation: 'date' }))
+        const endOfDayDate = set(date, { hours: 23, minutes: 59, seconds: 59, milliseconds: 999 })
+        configActions.updateConfig(`params.${type}_before`, formatISO(endOfDayDate, { representation: 'complete' }))
       } else {
         configActions.deleteConfig(`params.${type}_before`)
       }

--- a/rdmo/projects/assets/js/components/main/Projects.js
+++ b/rdmo/projects/assets/js/components/main/Projects.js
@@ -92,15 +92,15 @@ const Projects = ({ config, configActions, currentUserObject, projectsActions, p
     setStartDate('created', null)
     configActions.deleteConfig('params.created_before')
     setEndDate('created', null)
-    configActions.deleteConfig('params.updated_after')
-    setStartDate('updated', null)
-    configActions.deleteConfig('params.updated_before')
-    setEndDate('updated', null)
+    configActions.deleteConfig('params.last_changed_after')
+    setStartDate('last_changed', null)
+    configActions.deleteConfig('params.last_changed_before')
+    setEndDate('last_changed', null)
     projectsActions.fetchAllProjects()
   }
 
   /* order of elements in 'visibleColumns' corresponds to order of columns in table */
-  let visibleColumns = ['title', 'progress', 'updated', 'actions']
+  let visibleColumns = ['title', 'progress', 'last_changed', 'actions']
   let columnWidths
 
   if (myProjects) {
@@ -121,7 +121,7 @@ const Projects = ({ config, configActions, currentUserObject, projectsActions, p
     owner: (_content, row) => row.owners.map(owner => `${owner.first_name} ${owner.last_name}`).join('; '),
     progress: (_content, row) => getProgressString(row),
     created: content => useFormattedDateTime(content, language),
-    updated: content => useFormattedDateTime(content, language),
+    last_changed: content => useFormattedDateTime(content, language),
     actions: (_content, row) => {
       const rowUrl = `/projects/${row.id}`
       const path = `?next=${window.location.pathname}`

--- a/rdmo/projects/assets/js/hooks/useDatePicker.js
+++ b/rdmo/projects/assets/js/hooks/useDatePicker.js
@@ -6,8 +6,8 @@ const useDatePicker = () => {
     const [dateRange, setDateRange] = useState({
         createdStart: null,
         createdEnd: null,
-        updatedStart: null,
-        updatedEnd: null
+        lastChangedStart: null,
+        lastChangedEnd: null
     })
 
     const dateFormat = useMemo(() => {

--- a/rdmo/projects/assets/js/utils/constants.js
+++ b/rdmo/projects/assets/js/utils/constants.js
@@ -1,14 +1,14 @@
 // projects table
 export const INITIAL_TABLE_ROWS = '20'
 export const ROWS_TO_LOAD = '10'
-export const SORTABLE_COLUMNS = ['created', 'owner', 'progress', 'role', 'title', 'updated']
+export const SORTABLE_COLUMNS = ['created', 'owner', 'progress', 'role', 'title', 'last_changed']
 export const HEADER_FORMATTERS = {
   title: {render: () => gettext('Name')},
   role: {render: () => gettext('Role')},
   owner: {render: () =>  gettext('Owner')} ,
   progress: {render: () => gettext('Progress')},
   created: {render: () => gettext('Created')},
-  updated: {render: () => gettext('Last changed')},
+  last_changed: {render: () => gettext('Last changed')},
   actions: {render: () => null},
 }
 // project roles

--- a/rdmo/projects/filters.py
+++ b/rdmo/projects/filters.py
@@ -63,6 +63,14 @@ class ProjectDateFilterBackend(BaseFilterBackend):
         if updated_after:
             queryset = queryset.filter(updated__gte=updated_after)
 
+        last_changed_before = self.parse_query_datetime(request, 'last_changed_before')
+        if last_changed_before:
+            queryset = queryset.filter(last_changed__lte=last_changed_before)
+
+        last_changed_after = self.parse_query_datetime(request, 'last_changed_after')
+        if last_changed_after:
+            queryset = queryset.filter(last_changed__gte=last_changed_after)
+
         return queryset
 
     def parse_query_datetime(self, request, key):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -51,7 +51,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     authors = UserSerializer(many=True, read_only=True)
     guests = UserSerializer(many=True, read_only=True)
 
-    last_changed = serializers.DateTimeField()
+    last_changed = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = Project

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -51,6 +51,8 @@ class ProjectSerializer(serializers.ModelSerializer):
     authors = UserSerializer(many=True, read_only=True)
     guests = UserSerializer(many=True, read_only=True)
 
+    last_changed = serializers.DateTimeField()
+
     class Meta:
         model = Project
         fields = (
@@ -67,6 +69,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'guests',
             'created',
             'updated',
+            'last_changed',
             'site',
             'views',
             'progress_total',


### PR DESCRIPTION
This PR replaced `updated` with a on-the-fly computed `last_update`. After fix for the progress bar https://github.com/rdmorganiser/rdmo/pull/1015 changing a value will not change the progress and therefore will not update the project and will not update `Project.updated`. So we need to compute it from the project and all values (as in the old `projects` view). 