### PR TITLE
Add uri_path to factories

### DIFF
--- a/rdmo/management/assets/js/factories/OptionsFactory.js
+++ b/rdmo/management/assets/js/factories/OptionsFactory.js
@@ -13,7 +13,7 @@ class OptionsFactory {
     return {
       model: 'options.option',
       uri_prefix: config.settings.default_uri_prefix,
-      uri_path: parent.optionset ? `${parent.optionset.uri_path}/`: '',
+      uri_path: parent.optionset ? parent.optionset.uri_path : '',
       optionsets: parent.optionset ? [parent.optionset.id] : [],
       conditions: [],
       editors: config.settings.multisite ? [config.currentSite.id] : [],

--- a/rdmo/management/assets/js/factories/OptionsFactory.js
+++ b/rdmo/management/assets/js/factories/OptionsFactory.js
@@ -13,6 +13,7 @@ class OptionsFactory {
     return {
       model: 'options.option',
       uri_prefix: config.settings.default_uri_prefix,
+      uri_path: parent.optionset ? `${parent.optionset.uri_path}/`: '',
       optionsets: parent.optionset ? [parent.optionset.id] : [],
       conditions: [],
       editors: config.settings.multisite ? [config.currentSite.id] : [],

--- a/rdmo/management/assets/js/factories/QuestionsFactory.js
+++ b/rdmo/management/assets/js/factories/QuestionsFactory.js
@@ -15,7 +15,7 @@ class QuestionsFactory {
     return {
       model: 'questions.section',
       uri_prefix: config.settings.default_uri_prefix,
-      uri_path: parent.catalog ? `${parent.catalog.uri_path}/`: '',
+      uri_path: parent.catalog ? parent.catalog.uri_path : '',
       catalogs: parent.catalog ? [parent.catalog.id] : [],
       pages: [],
       editors: config.settings.multisite ? [config.currentSite.id] : [],
@@ -26,7 +26,7 @@ class QuestionsFactory {
     return {
       model: 'questions.page',
       uri_prefix: config.settings.default_uri_prefix,
-      uri_path: parent.section ? `${parent.section.uri_path}/`: '',
+      uri_path: parent.section ? parent.section.uri_path : '',
       sections: parent.section ? [parent.section.id] : [],
       questionsets: [],
       questions: [],
@@ -38,8 +38,8 @@ class QuestionsFactory {
     return {
       model: 'questions.questionset',
       uri_prefix: config.settings.default_uri_prefix,
-      uri_path: parent.page ? `${parent.page.uri_path}/`: (
-        parent.questionset ? `${parent.questionset.uri_path}/`: ''
+      uri_path: parent.page ? parent.page.uri_path : (
+        parent.questionset ? parent.questionset.uri_path : ''
       ),
       pages: parent.page ? [parent.page.id] : [],
       parents: parent.questionset ? [parent.questionset.id] : [],
@@ -53,8 +53,8 @@ class QuestionsFactory {
     return {
       model: 'questions.question',
       uri_prefix: config.settings.default_uri_prefix,
-      uri_path: parent.page ? `${parent.page.uri_path}/`: (
-        parent.questionset ? `${parent.questionset.uri_path}/`: ''
+      uri_path: parent.page ? parent.page.uri_path : (
+        parent.questionset ? parent.questionset.uri_path : ''
       ),
       widget_type: 'text',
       value_type: 'text',

--- a/rdmo/management/assets/js/factories/QuestionsFactory.js
+++ b/rdmo/management/assets/js/factories/QuestionsFactory.js
@@ -15,6 +15,7 @@ class QuestionsFactory {
     return {
       model: 'questions.section',
       uri_prefix: config.settings.default_uri_prefix,
+      uri_path: parent.catalog ? `${parent.catalog.uri_path}/`: '',
       catalogs: parent.catalog ? [parent.catalog.id] : [],
       pages: [],
       editors: config.settings.multisite ? [config.currentSite.id] : [],
@@ -25,6 +26,7 @@ class QuestionsFactory {
     return {
       model: 'questions.page',
       uri_prefix: config.settings.default_uri_prefix,
+      uri_path: parent.section ? `${parent.section.uri_path}/`: '',
       sections: parent.section ? [parent.section.id] : [],
       questionsets: [],
       questions: [],
@@ -36,6 +38,9 @@ class QuestionsFactory {
     return {
       model: 'questions.questionset',
       uri_prefix: config.settings.default_uri_prefix,
+      uri_path: parent.page ? `${parent.page.uri_path}/`: (
+        parent.questionset ? `${parent.questionset.uri_path}/`: ''
+      ),
       pages: parent.page ? [parent.page.id] : [],
       parents: parent.questionset ? [parent.questionset.id] : [],
       questionsets: [],
@@ -48,6 +53,9 @@ class QuestionsFactory {
     return {
       model: 'questions.question',
       uri_prefix: config.settings.default_uri_prefix,
+      uri_path: parent.page ? `${parent.page.uri_path}/`: (
+        parent.questionset ? `${parent.questionset.uri_path}/`: ''
+      ),
       widget_type: 'text',
       value_type: 'text',
       pages: parent.page ? [parent.page.id] : [],


### PR DESCRIPTION
I just had the idea that, if you create a question, the `uri_path` of the page is already in the form. This PR adds this. I am not sure, if we should add the `/` to the path already. If we don't just creating the element without editing will give a validation error (which is good I think), but then we always need to add the slash.