### PR TITLE
chore: remove redundant ruff config setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ exclude = ["*assets*", "*tests*"]
 version = {attr = "rdmo.__version__"}
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "B",    # flake8-bugbear


### PR DESCRIPTION
## Description

This PR removes `target-version = "py38"`. As it is unneeded, when requires-python = ">=3.8" is defined. This is recommended by the ruff docs.

Ref: https://docs.astral.sh/ruff/settings/#target-version

## Types of Changes
- [x] Build related changes

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.