### PR TITLE
ci: replace custom lint job with pre-commit/action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,22 +28,17 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
         cache: pip
-    - run: python -m pip install --upgrade pip
-    - run: python -m pip install --editable .[dev]
-    - name: Set up pre-commit cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: lint-${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Run linters via pre-commit (ruff, eslint)
-      run: pre-commit run --all-files --color=always
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files --color=always
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ concurrency:
 env:
   PYTHONDONTWRITEBYTECODE: 1
   FORCE_COLOR: 1 # colored output by pytest etc.
-  CLICOLOR_FORCE: 1 # colored output by ruff
 
 jobs:
 


### PR DESCRIPTION
## Description

This PR replaces the custom lint job with the official [pre-commit/action](https://github.com/pre-commit/action), which takes care of caching as well.

## Types of Changes
- [x] Other (please describe): CI

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.