### PR TITLE
Fix xml renderer

### DIFF
--- a/rdmo/core/renderers.py
+++ b/rdmo/core/renderers.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 
 from django.utils.encoding import smart_str
@@ -37,7 +38,10 @@ class BaseXMLRenderer(BaseRenderer):
 
         xml.startElement(tag, attrs)
         if text is not None:
-            xml.characters(smart_str(text))
+            smart_text = smart_str(text)
+            # remove control chars, cp. https://github.com/django/django/blob/main/django/utils/xmlutils.py#L25
+            smart_text = re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', smart_text)
+            xml.characters(smart_text)
         xml.endElement(tag)
 
     def render_document(self, xml, data):

--- a/rdmo/core/tests/test_renderers.py
+++ b/rdmo/core/tests/test_renderers.py
@@ -1,0 +1,25 @@
+from ..renderers import BaseXMLRenderer
+
+
+class TestRenderer(BaseXMLRenderer):
+
+    def render_document(self, xml, data):
+        xml.startElement('rdmo', {
+            'xmlns:dc': "http://purl.org/dc/elements/1.1/",
+            'version': self.version,
+            'created': self.created
+        })
+        self.render_text_element(xml, 'text', {}, data['text'])
+        xml.endElement('rdmo')
+
+
+def test_render():
+    renderer = TestRenderer()
+    xml = renderer.render({'text': 'test'})
+    assert '<text>test</text>' in xml
+
+
+def test_render_ascii_code():
+    renderer = TestRenderer()
+    xml = renderer.render({'text': 'te' + b'\x02'.decode() + 'st'})
+    assert '<text>test</text>' in xml


### PR DESCRIPTION
This PR prevents crashing (i.e. 500) of the XML export when ASCII control sequences are present. It just removes the chars from the list here: https://github.com/django/django/blob/main/django/utils/xmlutils.py#L25 before calling `characters(...)`.

The sequences can be injected using `./manage.py shell_plus`:

```python
task = Task.objects.get(id=4)
task.comment = b'\x02'.decode() + 'heyho'
task.save()
```