### PR TITLE
ci: fix warning about missing optional dependency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           sudo apt update
           sudo apt install --yes libldap2-dev libsasl2-dev
       - run: python -m pip install --upgrade pip
-      - run: python -m pip install .[allauth,shibboleth,ci,dev,gunicorn,ldap,mysql,postgres,pytest]
+      - run: python -m pip install .[allauth,ci,dev,gunicorn,ldap,mysql,postgres,pytest]
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
## Description

There was a warning in CI, when trying to install the missing dependency group `shibboleth` via:

`python -m pip install .[shibboleth]`

## Types of Changes
- [x] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
