### PR TITLE
refactor: prefer admin_client fixture over client.login

### DIFF
--- a/rdmo/conditions/tests/test_admin.py
+++ b/rdmo/conditions/tests/test_admin.py
@@ -1,9 +1,7 @@
 from django.urls import reverse
 
 
-def test_condition_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_condition_search(admin_client):
     url = reverse('admin:conditions_condition_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200

--- a/rdmo/domain/tests/test_admin.py
+++ b/rdmo/domain/tests/test_admin.py
@@ -1,9 +1,7 @@
 from django.urls import reverse
 
 
-def test_attribute_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_attribute_search(admin_client):
     url = reverse('admin:domain_attribute_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200

--- a/rdmo/options/tests/test_admin.py
+++ b/rdmo/options/tests/test_admin.py
@@ -1,17 +1,13 @@
 from django.urls import reverse
 
 
-def test_optionset_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_optionset_search(admin_client):
     url = reverse('admin:options_optionset_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
 
 
-def test_option_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_option_search(admin_client):
     url = reverse('admin:options_option_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200

--- a/rdmo/questions/tests/test_admin.py
+++ b/rdmo/questions/tests/test_admin.py
@@ -1,41 +1,31 @@
 from django.urls import reverse
 
 
-def test_catalog_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_catalog_search(admin_client):
     url = reverse('admin:questions_catalog_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
 
 
-def test_section_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_section_search(admin_client):
     url = reverse('admin:questions_section_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
 
 
-def test_page_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_page_search(admin_client):
     url = reverse('admin:questions_page_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
 
 
-def test_questionset_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_questionset_search(admin_client):
     url = reverse('admin:questions_questionset_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
 
 
-def test_question_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_question_search(admin_client):
     url = reverse('admin:questions_question_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200

--- a/rdmo/tasks/tests/test_admin.py
+++ b/rdmo/tasks/tests/test_admin.py
@@ -1,9 +1,7 @@
 from django.urls import reverse
 
 
-def test_task_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_task_search(admin_client):
     url = reverse('admin:tasks_task_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200

--- a/rdmo/views/tests/test_admin.py
+++ b/rdmo/views/tests/test_admin.py
@@ -1,9 +1,7 @@
 from django.urls import reverse
 
 
-def test_view_search(db, client):
-    client.login(username='admin', password='admin')
-
+def test_view_search(admin_client):
     url = reverse('admin:views_view_changelist') + '?q=test'
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
## Description

pytest-django offers a [admin_client fixture](https://pytest-django.readthedocs.io/en/latest/helpers.html#admin-client-django-test-client-logged-in-as-admin), i.e. a client logged in as an admin user.

Using this fixture reduces the number of "logins" needed in the test suite, offering a tiny performance boost.

It is not "the" rdmo admin (admin:admin), but that was not used in the tests before. So not a problem.

## Types of Changes
- [x] Refactoring (no functional changes, no api changes)

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
