### PR TITLE
Add workaround for checkboxes to ValueConflictValidator

### DIFF
--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -796,9 +796,11 @@ angular.module('project_questions')
             if (question === null) {
                 // this is the id of a new valueset
                 value.value_type = 'text';
+                value.widget_type = 'text';
                 value.unit = '';
             } else {
                 value.value_type = question.value_type;
+                value.widget_type = question.widget_type;
                 value.unit = question.unit;
             }
 

--- a/rdmo/projects/tests/test_validator_conflict.py
+++ b/rdmo/projects/tests/test_validator_conflict.py
@@ -13,10 +13,14 @@ attribute_path = attribute__path='individual/single/text'
 
 
 def test_serializer_create(db):
-    class MockedView:
-        project = Project.objects.get(id=project_id)
-
     value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    class MockedRequest:
+        data = {}
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
 
     validator = ValueConflictValidator()
     serializer = ValueSerializer()
@@ -31,10 +35,14 @@ def test_serializer_create(db):
 
 
 def test_serializer_create_error(db):
-    class MockedView:
-        project = Project.objects.get(id=project_id)
-
     value = Value.objects.get(project_id=project_id, snapshot=None, attribute__path=attribute_path)
+
+    class MockedRequest:
+        data = {}
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
 
     validator = ValueConflictValidator()
     serializer = ValueSerializer()
@@ -121,3 +129,100 @@ def test_serializer_update_missing_updated(db):
         'set_index': value.set_index,
         'collection_index': value.collection_index,
     }, serializer)
+
+
+def test_serializer_create_checkbox(db):
+    value = Value.objects.get(
+        project_id=project_id,
+        snapshot=None,
+        attribute__path='individual/collection/checkbox',
+        collection_index=0
+    )
+    value2 = Value.objects.get(
+        project_id=project_id,
+        snapshot=None,
+        attribute__path='individual/collection/checkbox',
+        collection_index=2
+    )
+
+    class MockedRequest:
+        data = {
+            'widget_type': 'checkbox'
+        }
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    validator({
+        'attribute': value.attribute,
+        'set_prefix': value.set_prefix,
+        'set_index': value.set_index,
+        'collection_index': value.collection_index,
+        'option': value2.option
+    }, serializer)
+
+
+def test_serializer_create_checkbox_error(db):
+    value = Value.objects.get(
+        project_id=project_id,
+        snapshot=None,
+        attribute__path='individual/collection/checkbox',
+        collection_index=0
+    )
+
+    class MockedRequest:
+        data = {
+            'widget_type': 'checkbox'
+        }
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    with pytest.raises(RestFameworkValidationError):
+        validator({
+            'attribute': value.attribute,
+            'set_prefix': value.set_prefix,
+            'set_index': value.set_index,
+            'collection_index': value.collection_index,
+            'option': value.option
+        }, serializer)
+
+
+def test_serializer_create_checkbox_text(db):
+    value = Value.objects.get(
+        project_id=project_id,
+        snapshot=None,
+        attribute__path='individual/collection/checkbox',
+        collection_index=0
+    )
+
+    class MockedRequest:
+        data = {
+            'widget_type': 'text'
+        }
+
+    class MockedView:
+        request = MockedRequest()
+        project = Project.objects.get(id=project_id)
+
+    validator = ValueConflictValidator()
+    serializer = ValueSerializer()
+    serializer.context['view'] = MockedView()
+
+    with pytest.raises(RestFameworkValidationError):
+        validator({
+            'attribute': value.attribute,
+            'set_prefix': value.set_prefix,
+            'set_index': value.set_index,
+            'collection_index': value.collection_index
+        }, serializer)

--- a/rdmo/projects/validators.py
+++ b/rdmo/projects/validators.py
@@ -28,13 +28,21 @@ class ValueConflictValidator:
                     })
         else:
             # for a new value, check if there is already a value with the same attribute and indexes
+            get_kwargs = {
+                'attribute': data.get('attribute'),
+                'set_prefix': data.get('set_prefix'),
+                'set_index': data.get('set_index'),
+                'collection_index': data.get('collection_index')
+            }
+
+            # for checkboxes, check only values with the same option
+            # get the widget_type from the put request
+            widget_type = serializer.context['view'].request.data.get('widget_type')
+            if widget_type == 'checkbox':
+                get_kwargs['option'] = data.get('option')
+
             try:
-                serializer.context['view'].project.values.filter(snapshot=None).get(
-                    attribute=data.get('attribute'),
-                    set_prefix=data.get('set_prefix'),
-                    set_index=data.get('set_index'),
-                    collection_index=data.get('collection_index')
-                )
+                serializer.context['view'].project.values.filter(snapshot=None).get(**get_kwargs)
             except ObjectDoesNotExist:
                 return
             except MultipleObjectsReturned:


### PR DESCRIPTION
I investigated #903 further and I think I found a case when "normal" usage can lead to states which cannot be saved anymore:

* A user saves a checkbox with `collection_index=0`
* Later, an option is added to the option set before the first option
* Now, the value above value will have the wrong `collection_index`
* When the user then tries to save the new option with `collection_index=0` the conflict validator will trigger.

This PR tries to loosen the conflict validator for checkboxes:

* When **updating** the validator checks if the value comes from a checkbox, and then adds the option for the value to the query which checks if there is already a value in the database.
* Since validators for the value do not know about the question, the front end needs to submit `widget_type` just like it submits `value_type` and `units`, but `widget_type` does not need to be saved (or be part of the model).