### PR TITLE
ci: switch to re-usable workflow from rdmorganiser/.github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,8 @@ env:
 jobs:
 
   lint:
-    name: Lint
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-        cache: pip
-    - name: Run linters via pre-commit (ruff, eslint)
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      with:
-        extra_args: --all-files --color=always
+    # Ref: https://github.com/rdmorganiser/.github/blob/main/.github/workflows/_lint.yml
+    uses: rdmorganiser/.github/.github/workflows/_lint.yml@main
 
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Description

This is a proposal to move the CI workflows, that can be used by multiple projects (e.g. rdmo, plugin a, plugin b, etc) to [rdmorganiser/.github](https://github.com/rdmorganiser/.github).

At the moment the only re-usable workflow is the `lint` workflow. It is available at the main branch. But if you like this approach, I will add a tag to the repo.

What do you think?

## Types of Changes
- [x] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).