### PR TITLE
chore: ignore warnings in pytest settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,12 @@ filterwarnings = [
   "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
 
+  # ignore warning from rest_framework about coreapi
+  "ignore:CoreAPI compatibility is deprecated and will be removed in DRF 3.17:rest_framework.RemovedInDRF317Warning",
+
+  # ignore warning from django_filters
+  "ignore:Built-in schema generation is deprecated. Use drf-spectacular.:django_filters.RemovedInDjangoFilter25Warning",
+
   # ignore warnings raised from within django itself
   # django/core/files/storage/__init__.py
   "ignore:django.core.files.storage.get_storage_class is deprecated:django.utils.deprecation.RemovedInDjango51Warning",


### PR DESCRIPTION
## Description

This PR ignores two warnings that get caught 1000+ times in the test run.

The reason is the usage of `coreapi.AutoSchema` in the settings.
https://github.com/rdmorganiser/rdmo/blob/065d195043b7ac34a7b6b3180dac69829a3974bc/rdmo/core/settings.py#L169

This will be addressed in #1050 and the filters removed.

## Types of Changes
- [x] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
