### PR TITLE
Fix addValueSet in project_questions

### DIFF
--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -1387,6 +1387,8 @@ angular.module('project_questions')
                     service.removeValueSet(qs, sp, si);
                 });
             }
+
+            service.postSave();
         });
 
         // if this is the top level questionset,

--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -995,93 +995,97 @@ angular.module('project_questions')
                     service.next();
                 }
             } else {
-                // check if we need to refresh the site
-                angular.forEach([service.page].concat(service.questionsets), function(questionset) {
+                service.postSave();
+            }
+        });
+    };
+
+    service.postSave = function() {
+        // check if we need to refresh the site
+        angular.forEach([service.page].concat(service.questionsets), function(questionset) {
+            angular.forEach(questionset.elements, function(element) {
+                if (element.model == 'questions.question') {
+                    var question = element;
+                    angular.forEach(question.optionsets, function(optionset) {
+                        if (optionset.has_refresh) {
+                            return service.initView(service.page.id, false);
+                        }
+                    });
+                }
+            });
+        });
+
+        // update progress
+        if (service.project.read_only !== true) {
+            resources.projects.postAction({
+                id: service.project.id,
+                detail_action: 'progress'
+            }, function(response) {
+                service.progress = response
+            });
+        }
+
+        // update navigation
+        if (service.project.read_only !== true) {
+            resources.projects.query({
+                id: service.project.id,
+                detail_id: service.page.section.id,
+                detail_action: 'navigation'
+            }, function(response) {
+                service.navigation = service.initNavigation(response)
+            });
+        }
+
+        // re-evaluate conditions
+        angular.forEach([service.page].concat(service.questionsets), function(questionset) {
+            angular.forEach(service.valuesets[questionset.id], function(valuesets) {
+                angular.forEach(valuesets, function(valueset) {
                     angular.forEach(questionset.elements, function(element) {
-                        if (element.model == 'questions.question') {
-                            var question = element;
-                            angular.forEach(question.optionsets, function(optionset) {
-                                if (optionset.has_refresh) {
-                                    return service.initView(service.page.id, false);
+                        if (element.model == 'questions.questionset') {
+                            var qs = element;
+                            if (qs.has_conditions) {
+                                promises.push(resources.projects.get({
+                                    id: service.project.id,
+                                    detail_action: 'resolve',
+                                    questionset: qs.id,
+                                    set_prefix: valueset.set_prefix,
+                                    set_index: valueset.set_index
+                                }, function(response) {
+                                    valueset.hidden.questionsets[qs.id] = !response.result;
+                                }).$promise);
+                            }
+                        } else {
+                            var q = element;
+                            if (q.has_conditions) {
+                                promises.push(resources.projects.get({
+                                    id: service.project.id,
+                                    detail_action: 'resolve',
+                                    question: q.id,
+                                    set_prefix: valueset.set_prefix,
+                                    set_index: valueset.set_index
+                                }, function(response) {
+                                    valueset.hidden.questions[q.id] = !response.result;
+                                }).$promise);
+                            }
+                            angular.forEach(q.optionsets, function(optionset) {
+                                if (optionset.has_conditions) {
+                                    promises.push(resources.projects.get({
+                                        id: service.project.id,
+                                        detail_action: 'resolve',
+                                        optionset: optionset.id,
+                                        set_prefix: valueset.set_prefix,
+                                        set_index: valueset.set_index
+                                    }, function(response) {
+                                        valueset.hidden.optionsets[optionset.id] = !response.result;
+                                    }).$promise);
                                 }
                             });
                         }
                     });
                 });
-
-                // update progress
-                if (service.project.read_only !== true) {
-                    resources.projects.postAction({
-                        id: service.project.id,
-                        detail_action: 'progress'
-                    }, function(response) {
-                        service.progress = response
-                    });
-                }
-
-                // update navigation
-                if (service.project.read_only !== true) {
-                    resources.projects.query({
-                        id: service.project.id,
-                        detail_id: service.page.section.id,
-                        detail_action: 'navigation'
-                    }, function(response) {
-                        service.navigation = service.initNavigation(response)
-                    });
-                }
-
-                // re-evaluate conditions
-                angular.forEach([service.page].concat(service.questionsets), function(questionset) {
-                    angular.forEach(service.valuesets[questionset.id], function(valuesets) {
-                        angular.forEach(valuesets, function(valueset) {
-                            angular.forEach(questionset.elements, function(element) {
-                                if (element.model == 'questions.questionset') {
-                                    var qs = element;
-                                    if (qs.has_conditions) {
-                                        promises.push(resources.projects.get({
-                                            id: service.project.id,
-                                            detail_action: 'resolve',
-                                            questionset: qs.id,
-                                            set_prefix: valueset.set_prefix,
-                                            set_index: valueset.set_index
-                                        }, function(response) {
-                                            valueset.hidden.questionsets[qs.id] = !response.result;
-                                        }).$promise);
-                                    }
-                                } else {
-                                    var q = element;
-                                    if (q.has_conditions) {
-                                        promises.push(resources.projects.get({
-                                            id: service.project.id,
-                                            detail_action: 'resolve',
-                                            question: q.id,
-                                            set_prefix: valueset.set_prefix,
-                                            set_index: valueset.set_index
-                                        }, function(response) {
-                                            valueset.hidden.questions[q.id] = !response.result;
-                                        }).$promise);
-                                    }
-                                    angular.forEach(q.optionsets, function(optionset) {
-                                        if (optionset.has_conditions) {
-                                            promises.push(resources.projects.get({
-                                                id: service.project.id,
-                                                detail_action: 'resolve',
-                                                optionset: optionset.id,
-                                                set_prefix: valueset.set_prefix,
-                                                set_index: valueset.set_index
-                                            }, function(response) {
-                                                valueset.hidden.optionsets[optionset.id] = !response.result;
-                                            }).$promise);
-                                        }
-                                    });
-                                }
-                            });
-                        });
-                    });
-                });
-            }
+            });
         });
-    };
+    }
 
     service.changed = function(value, autosave=false) {
         value.changed = true;
@@ -1234,7 +1238,9 @@ angular.module('project_questions')
             var last_set_index = valuesets[0].set_index;
             set_index = last_set_index + 1;
         }
-        service.valuesets[questionset.id][set_prefix].push(factories.valuesets(set_prefix, set_index));
+
+        var valueset = factories.valuesets(set_prefix, set_index);
+        service.valuesets[questionset.id][set_prefix].push(valueset);
 
         // loop over questions to initialize them with at least one value, and init checkboxes and widgets
         angular.forEach(questionset.elements, function(element) {
@@ -1257,6 +1263,10 @@ angular.module('project_questions')
                 // for a checkbox, transform the values for the question to different checkboxes
                 if (question.widget_class === 'checkbox') {
                     service.values[question.attribute][set_prefix][set_index] = service.initCheckbox(question, service.values[question.attribute][set_prefix][set_index]);
+                }
+
+                if (question.has_conditions) {
+                    valueset.hidden.questions[question.id] = true
                 }
 
                 angular.forEach(service.values[question.attribute][set_prefix][set_index], function(value) {
@@ -1285,7 +1295,9 @@ angular.module('project_questions')
             if (angular.isUndefined(service.values[questionset.attribute][set_prefix][set_index][0])) {
                 service.values[questionset.attribute][set_prefix][set_index].push(value);
             }
-            service.storeValue(value, null, set_prefix, set_index, 0)
+            service.storeValue(value, null, set_prefix, set_index, 0).then(function(value) {
+                service.postSave();
+            })
         }
 
         // recursively loop over child questionsets and sets

--- a/rdmo/projects/static/projects/js/project_questions/services.js
+++ b/rdmo/projects/static/projects/js/project_questions/services.js
@@ -884,14 +884,14 @@ angular.module('project_questions')
                 if (response.status == 500) {
                     service.error = response;
                 } else if (response.status == 400) {
-                    service.error = true;
+                    service.error = response;
                     if (angular.isDefined(response.data.text)) {
                         value.errors = response.data.text
                     } else {
                         value.errors = Object.keys(response.data);
                     }
                 } else if (response.status == 404) {
-                    service.error = true;
+                    service.error = response;
                     value.errors = ['not_found']
                 }
             })
@@ -944,8 +944,8 @@ angular.module('project_questions')
         service.error = null; // reset error before saving
         if (service.settings.project_questions_autosave) {
             service.save(false, true).then(function() {
-                if (service.error !== null) {
-                    // pass, dont jump
+                if (service.error !== null && service.error.status !== 400) {
+                    // pass, dont jump (but not on a validation error)
                 } else if (angular.isDefined(page)) {
                     service.initView(page.id);
                 } else if (angular.isDefined(section)) {

--- a/rdmo/projects/templates/projects/project_questions_save_error.html
+++ b/rdmo/projects/templates/projects/project_questions_save_error.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load core_tags %}
 
-    <div class="text-danger" ng-show="service.error.statusText && service.error.status">
+    <div class="text-danger" ng-show="service.error.statusText && service.error.status != 400">
         <p>
             {% trans 'An error occurred while saving the answer. Please contact support if this problem persists.' %}
         </p>


### PR DESCRIPTION
~~Run refresh check, progress and navigation update, and conditions check when a new value set is added.~~

This PR adds `updateProgress` and `updateView` to `service.js`. The idea is, that:

* `updateProgress` is called on each `service.save` and `service.addValueSet` and `service.removeValueSet`, and 
* `updateView` on `service.save`, but only when `service.initView` is not called. It contains the check if an optionset needs a refresh, the update of the navigation, and the re-evaluation of the conditions (and was named `postSave` for a few days).