### PR TITLE
Fix regex in webpack config for windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ const baseConfig = {
         ]
       },
       {
-        test: /(fonts|files)\/.*\.(svg|woff2?|ttf|eot|otf)(\?.*)?$/,
+        test: /(fonts|files)[\\/].*\.(svg|woff2?|ttf|eot|otf)(\?.*)?$/,
         loader: 'file-loader',
         type: 'javascript/auto',
         options: {


### PR DESCRIPTION
This epic PR fixed the webpack config to account for the different path seperator `\` on Windows.