### PR TITLE
test: mock pypandoc.convert_text when testing export views

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,3 +54,20 @@ def files(settings, tmp_path):
 def json_data():
     json_file = Path(settings.BASE_DIR) / 'import' / 'catalogs.json'
     return {'elements': json.loads(json_file.read_text())}
+
+
+@pytest.fixture
+def mocked_convert_text(mocker):
+    """Mock the pypandoc.convert_text function.
+
+    `mocked_convert_text` can be used in tests of the export views.
+    Use it to assert pypandoc would have been called with:
+    mocked_convert_text.assert_called(), mocked_convert_text.assert_called_once() or
+    mocked_convert_text.assert_called_once_with().
+
+    See:
+    - <https://pytest-mock.readthedocs.io/en/latest/usage.html>
+    - <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.MagicMock>
+    """
+    from rdmo.core.utils import pypandoc  # noqa: F401
+    return mocker.patch("pypandoc.convert_text")

--- a/rdmo/conditions/tests/test_viewset_condition.py
+++ b/rdmo/conditions/tests/test_viewset_condition.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -64,18 +62,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['condition']
 
 
 def test_export_search(db, client):
@@ -285,16 +277,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Condition.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['condition']

--- a/rdmo/conditions/tests/test_viewset_condition_multisite.py
+++ b/rdmo/conditions/tests/test_viewset_condition_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -32,18 +30,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['condition']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -245,16 +237,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Condition.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['condition']

--- a/rdmo/core/tests/test_utils.py
+++ b/rdmo/core/tests/test_utils.py
@@ -1,8 +1,12 @@
+from http import HTTPStatus
 from typing import Optional
 
 import pytest
 
-from rdmo.core.utils import human2bytes, join_url, sanitize_url
+from rdmo.core.utils import human2bytes, join_url, render_to_format, sanitize_url
+from rdmo.projects.models import Project
+from rdmo.projects.utils import get_value_path
+from rdmo.views.utils import ProjectWrapper
 
 urls = (
     ('', ''),
@@ -23,6 +27,8 @@ human2bytes_test_values = (
     ("0", 0),
 )
 
+export_formats = ("invalid", "rtf", "odt", "docx", "html", "markdown", "tex", "pdf")
+
 
 @pytest.mark.parametrize('url,sanitized_url', urls)
 def test_sanitize_url(url, sanitized_url):
@@ -36,3 +42,49 @@ def test_join_url():
 @pytest.mark.parametrize('human,bytes', human2bytes_test_values)
 def test_human2bytes(human: Optional[str], bytes: float):
     assert human2bytes(human) == bytes
+
+
+@pytest.fixture(scope="module")
+def context(django_db_blocker):
+    """A fixture of a view context, to be used when testing 'render_to_format'.
+
+    Note: The fixture queries the database only once for the parametrized tests.
+    """
+    with django_db_blocker.unblock():
+        project = Project.objects.get(id=1)
+        project.catalog.prefetch_elements()
+        return {
+            "format": None, # will be defined in the test function
+            "project": project,
+            "project_wrapper": ProjectWrapper(project),
+            "title": project.title,
+            "resource_path": get_value_path(project)
+        }
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("export_format", export_formats)
+def test_render_to_format(rf, context, export_format):
+    """A test of the 'render_to_format' view with multiple export formats."""
+    context["format"] = export_format
+    title = context["project"].title
+
+    request = rf.get("/projects/project_answers_export")
+    response = render_to_format(
+        request,
+        export_format,
+        title,
+        "projects/project_answers_export.html",
+        context,
+    )
+
+    # an invalid export format should return an error message
+    if export_format == "invalid":
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "This format is not supported." in str(response.content)
+        return
+    # check for the requested export format in the headers
+    assert response.status_code == HTTPStatus.OK
+    assert export_format in response.headers["Content-Type"]
+    expected = f'filename="{title}.{export_format}"'
+    assert expected in response.headers["Content-Disposition"]

--- a/rdmo/domain/tests/test_viewset_attribute.py
+++ b/rdmo/domain/tests/test_viewset_attribute.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -54,18 +52,12 @@ def test_list(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['attribute']
 
 
 def test_export_search(db, client):
@@ -241,16 +233,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Attribute.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['attribute']

--- a/rdmo/options/tests/test_viewset_options.py
+++ b/rdmo/options/tests/test_viewset_options.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.db.models import Max
@@ -65,18 +63,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['option']
 
 
 def test_export_search(db, client):
@@ -182,16 +174,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Option.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['option']

--- a/rdmo/options/tests/test_viewset_optionsets.py
+++ b/rdmo/options/tests/test_viewset_optionsets.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -65,18 +63,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['optionset', 'option']
 
 
 def test_export_search(db, client):
@@ -289,16 +281,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = OptionSet.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['optionset', 'option']

--- a/rdmo/projects/tests/test_view_project.py
+++ b/rdmo/projects/tests/test_view_project.py
@@ -730,7 +730,7 @@ def test_project_view(db, client, username, password, project_id):
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('project_id', projects)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_project_view_export(db, client, username, password, project_id, export_format, files):
+def test_project_view_export(db, client, username, password, project_id, export_format, files, mocked_convert_text):
     client.login(username=username, password=password)
     project_views = Project.objects.get(pk=project_id).views.all()
 

--- a/rdmo/projects/tests/test_view_project.py
+++ b/rdmo/projects/tests/test_view_project.py
@@ -690,7 +690,7 @@ def test_project_answers(db, client, username, password, project_id):
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('project_id', projects)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_project_answers_export(db, client, username, password, project_id, export_format):
+def test_project_answers_export(db, client, username, password, project_id, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse('project_answers_export', args=[project_id, export_format])

--- a/rdmo/questions/tests/test_viewset_catalog.py
+++ b/rdmo/questions/tests/test_viewset_catalog.py
@@ -68,18 +68,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['catalog', 'section', 'page', 'questionset', 'question']
 
 
 def test_export_search(db, client):
@@ -238,19 +232,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Catalog.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['catalog', 'section', 'page', 'questionset', 'question']
 
 
 def test_detail_export_full(db, client):

--- a/rdmo/questions/tests/test_viewset_catalog_multisite.py
+++ b/rdmo/questions/tests/test_viewset_catalog_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.contrib.sites.models import Site
@@ -35,18 +33,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['catalog', 'section', 'page', 'questionset', 'question']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -197,19 +189,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Catalog.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['catalog', 'section', 'page', 'questionset', 'question']
 
 
 @pytest.mark.parametrize('username,password', users)

--- a/rdmo/questions/tests/test_viewset_page.py
+++ b/rdmo/questions/tests/test_viewset_page.py
@@ -69,18 +69,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['page', 'questionset', 'question']
 
 
 def test_export_search(db, client):
@@ -317,19 +311,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Page.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['page', 'questionset', 'question']
 
 
 def test_detail_export_full(db, client):

--- a/rdmo/questions/tests/test_viewset_page_multisite.py
+++ b/rdmo/questions/tests/test_viewset_page_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.db.models import Max
@@ -33,18 +31,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['page', 'questionset', 'question']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -273,16 +265,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Page.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['page', 'questionset', 'question']

--- a/rdmo/questions/tests/test_viewset_question.py
+++ b/rdmo/questions/tests/test_viewset_question.py
@@ -69,18 +69,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['question']
 
 
 def test_export_search(db, client):
@@ -352,19 +346,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Question.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['question']
 
 
 def test_detail_export_full(db, client):

--- a/rdmo/questions/tests/test_viewset_question_multisite.py
+++ b/rdmo/questions/tests/test_viewset_question_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.db.models import Max
@@ -33,18 +31,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['question']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -308,16 +300,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Question.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['question']

--- a/rdmo/questions/tests/test_viewset_questionset.py
+++ b/rdmo/questions/tests/test_viewset_questionset.py
@@ -69,18 +69,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['questionset', 'question']
 
 
 def test_export_search(db, client):
@@ -357,19 +351,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = QuestionSet.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['questionset', 'question']
 
 
 def test_detail_export_full(db, client):

--- a/rdmo/questions/tests/test_viewset_questionset_multisite.py
+++ b/rdmo/questions/tests/test_viewset_questionset_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.db.models import Max
@@ -33,18 +31,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['questionset', 'question']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -313,16 +305,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = QuestionSet.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['questionset', 'question']

--- a/rdmo/questions/tests/test_viewset_section.py
+++ b/rdmo/questions/tests/test_viewset_section.py
@@ -69,18 +69,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['section', 'page', 'questionset', 'question']
 
 
 def test_export_search(db, client):
@@ -262,19 +256,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Section.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['section', 'page', 'questionset', 'question']
 
 
 def test_detail_export_full(db, client):

--- a/rdmo/questions/tests/test_viewset_section_multisite.py
+++ b/rdmo/questions/tests/test_viewset_section_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.db.models import Max
@@ -33,18 +31,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['section', 'page', 'questionset', 'question']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -218,16 +210,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Section.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['section', 'page', 'questionset', 'question']

--- a/rdmo/tasks/tests/test_viewset_task.py
+++ b/rdmo/tasks/tests/test_viewset_task.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -64,18 +62,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['task']
 
 
 def test_export_search(db, client):
@@ -160,16 +152,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Task.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['task']

--- a/rdmo/tasks/tests/test_viewset_task_multisite.py
+++ b/rdmo/tasks/tests/test_viewset_task_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.contrib.sites.models import Site
@@ -35,18 +33,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['task']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -123,20 +115,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = Task.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['task']
-
 
 
 @pytest.mark.parametrize('username,password', users)

--- a/rdmo/views/tests/test_viewset_view.py
+++ b/rdmo/views/tests/test_viewset_view.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.urls import reverse
@@ -64,18 +62,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['view']
 
 
 def test_export_search(db, client):
@@ -152,16 +144,10 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = View.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['view']

--- a/rdmo/views/tests/test_viewset_view_multisite.py
+++ b/rdmo/views/tests/test_viewset_view_multisite.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as et
-
 import pytest
 
 from django.contrib.sites.models import Site
@@ -34,18 +32,12 @@ def test_index(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_export(db, client, username, password, export_format):
+def test_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
 
     url = reverse(urlnames['export']) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['list'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['view']
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -114,19 +106,13 @@ def test_delete(db, client, username, password):
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('export_format', export_formats)
-def test_detail_export(db, client, username, password, export_format):
+def test_detail_export(db, client, username, password, export_format, mocked_convert_text):
     client.login(username=username, password=password)
     instance = View.objects.first()
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
     assert response.status_code == status_map['detail'][username], response.content
-
-    if response.status_code == 200 and export_format == 'xml':
-        root = et.fromstring(response.content)
-        assert root.tag == 'rdmo'
-        for child in root:
-            assert child.tag in ['view']
 
 
 @pytest.mark.parametrize('username,password', users)


### PR DESCRIPTION
## Description

Resolves #1092 and #1113

## Tasks

- [x] add `mocked_convert_text` fixture, which should be used in combination with `export_format` fixture, when testing export views
- [x] add `mocked_convert_text` to all export view test functions
- [x] remove special treatment of XML export (e.g. `assert root.tag == 'rdmo'`)
- [x] add a new parametrized "unit test", that tests all export formats with one input, see https://github.com/rdmorganiser/rdmo/pull/1117#issuecomment-2285990209
- [x] test for invalid export format
- [x] assert status codes
- [x] assert Content-Type header
- [x] assert Content-Disposition header
- [ ] rebase branch 2.3.0
- [ ] squash commits

## Types of Changes
- [x] Refactoring (no functional changes, no api changes)

## Checklist

- [x] I have read the [contributor guide](https://github.com/rdmorganiser/rdmo/blob/main/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
