### PR TITLE
feat(interview): apply to all [2]

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -13,7 +13,7 @@ import { updateLocation } from '../utils/location'
 import { updateOptions } from '../utils/options'
 import { initPage } from '../utils/page'
 import { gatherSets, getDescendants, initSets } from '../utils/set'
-import { activateFirstValue, gatherDefaultValues, initValues } from '../utils/value'
+import { activateFirstValue, gatherDefaultValues, initValues, compareValues } from '../utils/value'
 import { projectId } from '../utils/meta'
 
 import ValueFactory from '../factories/ValueFactory'
@@ -453,9 +453,10 @@ export function createSet(attrs) {
     if (isNil(value)) {
       return createSetSuccess()
     } else {
-      return dispatch(storeValue(value)).then((action) => {
-        if (action.type === STORE_VALUE_SUCCESS) {
-          createSetSuccess(action.value)
+      return dispatch(storeValue(value)).then(() => {
+        const storedValue = getState().interview.values.find((v) => compareValues(v, value))
+        if (!isNil(storedValue)) {
+          createSetSuccess(storedValue)
         }
       })
     }

--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -272,7 +272,7 @@ export function storeValue(value) {
     return {type: NOOP}
   } else {
     return (dispatch, getState) => {
-      const valueIndex = getState().interview.values.map((v) => v.id).indexOf(value.id)
+      const valueIndex = getState().interview.values.findIndex((v) => compareValues(v, value))
       const valueFile = value.file
       const valueSuccess = value.success
 

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -72,6 +72,11 @@ const Page = ({ config, templates, overview, page, sets, values, fetchPage,
                       value.set_prefix == currentSetPrefix &&
                       value.set_index == currentSetIndex
                     ))}
+                    siblings={values.filter((value) => (
+                      value.attribute == element.attribute &&
+                      value.set_prefix == currentSetPrefix &&
+                      value.set_index != currentSetIndex
+                    ))}
                     disabled={overview.read_only}
                     isManager={isManager}
                     currentSet={currentSet}

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -67,6 +67,9 @@ const Page = ({ config, templates, overview, page, sets, values, fetchPage,
                     key={elementIndex}
                     templates={templates}
                     question={element}
+                    sets={sets.filter((set) => (
+                      set.set_prefix == currentSetPrefix
+                    ))}
                     values={values.filter((value) => (
                       value.attribute == element.attribute &&
                       value.set_prefix == currentSetPrefix &&

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -12,7 +12,7 @@ import PageButtons from './PageButtons'
 import PageHead from './PageHead'
 
 const Page = ({ config, templates, overview, page, sets, values, fetchPage,
-                createValue, updateValue, deleteValue,
+                createValue, updateValue, deleteValue, copyValue,
                 activateSet, createSet, updateSet, deleteSet }) => {
 
   const currentSetPrefix = ''
@@ -58,6 +58,7 @@ const Page = ({ config, templates, overview, page, sets, values, fetchPage,
                     createValue={createValue}
                     updateValue={updateValue}
                     deleteValue={deleteValue}
+                    copyValue={copyValue}
                   />
                 )
               } else {
@@ -77,6 +78,7 @@ const Page = ({ config, templates, overview, page, sets, values, fetchPage,
                     createValue={createValue}
                     updateValue={updateValue}
                     deleteValue={deleteValue}
+                    copyValue={copyValue}
                   />
                 )
               }
@@ -104,7 +106,8 @@ Page.propTypes = {
   activateSet: PropTypes.func.isRequired,
   createSet: PropTypes.func.isRequired,
   updateSet: PropTypes.func.isRequired,
-  deleteSet: PropTypes.func.isRequired
+  deleteSet: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default Page

--- a/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
@@ -28,6 +28,11 @@ const PageHead = ({ templates, page, sets, values, currentSet, activateSet, crea
     }
   }
 
+  const handleOpenCreateModal = (event) => {
+    event.preventDefault()
+    openCreateModal()
+  }
+
   const handleCreateSet = (text) => {
     createSet({
       attribute: page.attribute,
@@ -71,7 +76,7 @@ const PageHead = ({ templates, page, sets, values, currentSet, activateSet, crea
                 })
               }
               <li>
-                <a href="#" title={gettext('Add tab')} className="add-set" onClick={openCreateModal}>
+                <a href="" title={gettext('Add tab')} className="add-set" onClick={handleOpenCreateModal}>
                   <i className="fa fa-plus fa-btn"></i> {capitalize(page.verbose_name)}
                 </a>
               </li>

--- a/rdmo/projects/assets/js/interview/components/main/question/Question.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/Question.js
@@ -13,7 +13,7 @@ import QuestionWarning from './QuestionWarning'
 import QuestionWidget from './QuestionWidget'
 
 const Question = ({ templates, question, values, disabled, isManager,
-                    currentSet, createValue, updateValue, deleteValue }) => {
+                    currentSet, createValue, updateValue, deleteValue, copyValue }) => {
   return checkQuestion(question, currentSet) && (
     <div className={`interview-question col-md-${question.width || '12'}`}>
       <QuestionOptional question={question} />
@@ -31,6 +31,7 @@ const Question = ({ templates, question, values, disabled, isManager,
         createValue={createValue}
         updateValue={updateValue}
         deleteValue={deleteValue}
+        copyValue={copyValue}
       />
     </div>
   )
@@ -46,6 +47,7 @@ Question.propTypes = {
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
   deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default Question

--- a/rdmo/projects/assets/js/interview/components/main/question/Question.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/Question.js
@@ -12,7 +12,7 @@ import QuestionText from './QuestionText'
 import QuestionWarning from './QuestionWarning'
 import QuestionWidget from './QuestionWidget'
 
-const Question = ({ templates, question, values, disabled, isManager,
+const Question = ({ templates, question, values, siblings, disabled, isManager,
                     currentSet, createValue, updateValue, deleteValue, copyValue }) => {
   return checkQuestion(question, currentSet) && (
     <div className={`interview-question col-md-${question.width || '12'}`}>
@@ -26,6 +26,7 @@ const Question = ({ templates, question, values, disabled, isManager,
       <QuestionWidget
         question={question}
         values={values}
+        siblings={siblings}
         disabled={disabled}
         currentSet={currentSet}
         createValue={createValue}
@@ -41,6 +42,7 @@ Question.propTypes = {
   templates: PropTypes.object.isRequired,
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool.isRequired,
   isManager: PropTypes.bool.isRequired,
   currentSet: PropTypes.object.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/question/Question.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/Question.js
@@ -12,7 +12,7 @@ import QuestionText from './QuestionText'
 import QuestionWarning from './QuestionWarning'
 import QuestionWidget from './QuestionWidget'
 
-const Question = ({ templates, question, values, siblings, disabled, isManager,
+const Question = ({ templates, question, sets, values, siblings, disabled, isManager,
                     currentSet, createValue, updateValue, deleteValue, copyValue }) => {
   return checkQuestion(question, currentSet) && (
     <div className={`interview-question col-md-${question.width || '12'}`}>
@@ -25,6 +25,7 @@ const Question = ({ templates, question, values, siblings, disabled, isManager,
       <QuestionManagement question={question} isManager={isManager} />
       <QuestionWidget
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
         disabled={disabled}
@@ -41,6 +42,7 @@ const Question = ({ templates, question, values, siblings, disabled, isManager,
 Question.propTypes = {
   templates: PropTypes.object.isRequired,
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
@@ -17,7 +17,7 @@ const AddValue = ({ question, values, currentSet, disabled, createValue }) => {
   }
 
   return !disabled && question.is_collection && (
-    <button type="button" className="btn btn-success add-value-button" onClick={handleClick}>
+    <button type="button" className="btn btn-success btn-xs add-value-button" onClick={handleClick}>
       <i className="fa fa-plus fa-btn"></i> {capitalize(question.verbose_name)}
     </button>
   )

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 
 import { isEmptyValue } from '../../../utils/value'
 
-const QuestionCopyValue = ({ question, value, copyValue }) => {
+const QuestionCopyValue = ({ question, value, siblings, copyValue }) => {
   return (
-    question.set_collection && !isEmptyValue(value) && (
-      <button className="btn btn-link btn-apply-to-all" onClick={() => copyValue(value)}
+    question.set_collection &&
+    !question.is_collection &&
+    !isEmptyValue(value) &&
+    siblings.some((value) => isEmptyValue(value)) && (
+      <button className="btn btn-link btn-apply-to-all" onClick={() => copyValue(value, siblings)}
               title={gettext('Apply this answer to all tabs where this question is empty')}>
         <i className="fa fa-arrow-circle-right fa-btn"></i>
       </button>
@@ -17,6 +20,7 @@ const QuestionCopyValue = ({ question, value, copyValue }) => {
 QuestionCopyValue.propTypes = {
   question: PropTypes.object.isRequired,
   value: PropTypes.object.isRequired,
+  siblings: PropTypes.object.isRequired,
   copyValue: PropTypes.func.isRequired
 }
 

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { isEmptyValue } from '../../../utils/value'
+
+const QuestionCopyValue = ({ question, value, copyValue }) => {
+  return (
+    question.set_collection && !isEmptyValue(value) && (
+      <button className="btn btn-link btn-apply-to-all" onClick={() => copyValue(value)}
+              title={gettext('Apply this answer to all tabs where this question is empty')}>
+        <i className="fa fa-arrow-circle-right fa-btn"></i>
+      </button>
+    )
+  )
+}
+
+QuestionCopyValue.propTypes = {
+  question: PropTypes.object.isRequired,
+  value: PropTypes.object.isRequired,
+  copyValue: PropTypes.func.isRequired
+}
+
+export default QuestionCopyValue

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValue.js
@@ -20,7 +20,7 @@ const QuestionCopyValue = ({ question, value, siblings, copyValue }) => {
 QuestionCopyValue.propTypes = {
   question: PropTypes.object.isRequired,
   value: PropTypes.object.isRequired,
-  siblings: PropTypes.object.isRequired,
+  siblings: PropTypes.array.isRequired,
   copyValue: PropTypes.func.isRequired
 }
 

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { isEmptyValue } from '../../../utils/value'
+
+const QuestionCopyValues = ({ question, values, copyValue }) => {
+  const handleCopyValues = () => {
+    values.forEach((value) => copyValue(value))
+  }
+
+  console.log(values)
+
+  return (
+    question.set_collection && values.some((v) => !isEmptyValue(v)) && (
+      <button className="btn btn-link btn-apply-to-all" onClick={handleCopyValues}
+              title={gettext('Apply this answer to all tabs where this question is empty')}>
+        <i className="fa fa-arrow-circle-right fa-btn"></i>
+      </button>
+    )
+  )
+}
+
+QuestionCopyValues.propTypes = {
+  question: PropTypes.object.isRequired,
+  values: PropTypes.array.isRequired,
+  copyValue: PropTypes.func.isRequired
+}
+
+export default QuestionCopyValues

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
@@ -3,26 +3,35 @@ import PropTypes from 'prop-types'
 
 import { isEmptyValue } from '../../../utils/value'
 
-const QuestionCopyValues = ({ question, values, copyValue }) => {
+const QuestionCopyValues = ({ question, values, siblings, copyValue }) => {
   const handleCopyValues = () => {
     values.forEach((value) => copyValue(value))
   }
 
-  console.log(values)
+  const button = question.widget_type == 'checkbox' ? (
+    <button className="btn btn-link btn-apply-to-all" onClick={handleCopyValues}
+            title={gettext('Apply this answer to all tabs where this question is empty')}>
+      <i className="fa fa-arrow-circle-right fa-btn"></i>
+    </button>
+  ) : (
+    <button type="button" className="btn btn-primary btn-xs copy-value-button ml-10" onClick={handleCopyValues}>
+      <i className="fa fa-arrow-circle-right fa-btn"></i> {gettext('Apply to all')}
+    </button>
+  )
 
   return (
-    question.set_collection && values.some((v) => !isEmptyValue(v)) && (
-      <button className="btn btn-link btn-apply-to-all" onClick={handleCopyValues}
-              title={gettext('Apply this answer to all tabs where this question is empty')}>
-        <i className="fa fa-arrow-circle-right fa-btn"></i>
-      </button>
-    )
+    question.is_collection &&
+    question.set_collection &&
+    values.some((v) => !isEmptyValue(v)) &&
+    siblings.some((value) => isEmptyValue(value)) &&
+    button
   )
 }
 
 QuestionCopyValues.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   copyValue: PropTypes.func.isRequired
 }
 

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionCopyValues.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
 
 import { isEmptyValue } from '../../../utils/value'
 
-const QuestionCopyValues = ({ question, values, siblings, copyValue }) => {
+const QuestionCopyValues = ({ question, sets, values, siblings, currentSet, copyValue }) => {
   const handleCopyValues = () => {
     values.forEach((value) => copyValue(value))
   }
@@ -19,19 +20,37 @@ const QuestionCopyValues = ({ question, values, siblings, copyValue }) => {
     </button>
   )
 
+  const hasValues = values.some((value) => !isEmptyValue(value))
+
+  const hasEmptySiblings = sets.filter((set) => (
+      (set.set_prefix == currentSet.set_prefix) &&
+      (set.set_index != currentSet.set_index)
+    )).some((set) => {
+      // loop over all other sets and filter siblings accordingly
+      const setSiblings = siblings.filter((value) => (
+        (value.set_prefix == set.set_prefix) &&
+        (value.set_index == set.set_index)
+      ))
+
+      // check if this set has no sibling at all (for checkboxes) or if they are empty
+      return isEmpty(setSiblings) || setSiblings.some((value) => isEmptyValue(value))
+    })
+
   return (
     question.is_collection &&
     question.set_collection &&
-    values.some((v) => !isEmptyValue(v)) &&
-    siblings.some((value) => isEmptyValue(value)) &&
+    hasValues &&
+    hasEmptySiblings &&
     button
   )
 }
 
 QuestionCopyValues.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
+  currentSet: PropTypes.object.isRequired,
   copyValue: PropTypes.func.isRequired
 }
 

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionEraseValues.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionEraseValues.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const QuestionEraseValues = ({ values, disabled, deleteValue }) => {
+  const handleEraseValue = () => {
+    values.forEach((value) => deleteValue(value))
+  }
+
+  return !disabled && (
+    <button type="button" className="btn btn-link btn-erase-value" onClick={handleEraseValue}
+            title={gettext('Erase input')}>
+      <i className="fa fa-eraser fa-btn"></i>
+    </button>
+  )
+}
+
+QuestionEraseValues.propTypes = {
+  values: PropTypes.array.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  deleteValue: PropTypes.func.isRequired
+}
+
+export default QuestionEraseValues

--- a/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
+++ b/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
@@ -67,6 +67,9 @@ const QuestionSet = ({ templates, questionset, sets, values, disabled, isManager
                             key={elementIndex}
                             templates={templates}
                             question={element}
+                            sets={sets.filter((set) => (
+                              set.set_prefix == setPrefix
+                            ))}
                             values={values.filter((value) => (
                               value.attribute == element.attribute &&
                               value.set_prefix == set.set_prefix &&

--- a/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
+++ b/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
@@ -14,7 +14,7 @@ import QuestionSetRemoveSet from './QuestionSetRemoveSet'
 
 const QuestionSet = ({ templates, questionset, sets, values, disabled, isManager,
                        parentSet, createSet, updateSet, deleteSet,
-                       createValue, updateValue, deleteValue }) => {
+                       createValue, updateValue, deleteValue, copyValue }) => {
 
   const setPrefix = getChildPrefix(parentSet)
 
@@ -58,6 +58,7 @@ const QuestionSet = ({ templates, questionset, sets, values, disabled, isManager
                             createValue={createValue}
                             updateValue={updateValue}
                             deleteValue={deleteValue}
+                            copyValue={copyValue}
                           />
                         )
                       } else {
@@ -77,6 +78,7 @@ const QuestionSet = ({ templates, questionset, sets, values, disabled, isManager
                             createValue={createValue}
                             updateValue={updateValue}
                             deleteValue={deleteValue}
+                            copyValue={copyValue}
                           />
                         )
                       }
@@ -107,7 +109,8 @@ QuestionSet.propTypes = {
   deleteSet: PropTypes.func.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default QuestionSet

--- a/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
+++ b/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
@@ -72,6 +72,11 @@ const QuestionSet = ({ templates, questionset, sets, values, disabled, isManager
                               value.set_prefix == set.set_prefix &&
                               value.set_index == set.set_index
                             ))}
+                            siblings={values.filter((value) => (
+                              value.attribute == element.attribute &&
+                              value.set_prefix == set.set_prefix &&
+                              value.set_index != set.set_index
+                            ))}
                             disabled={disabled}
                             isManager={isManager}
                             currentSet={set}

--- a/rdmo/projects/assets/js/interview/components/main/widget/CheckboxInput.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/CheckboxInput.js
@@ -31,6 +31,7 @@ const CheckboxInput = ({ question, value, option, disabled, onCreate, onUpdate, 
         })
       } else {
         onUpdate(value, {
+          text: additionalInput,
           option: option.id,
           unit: question.unit,
           value_type: question.value_type

--- a/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
@@ -10,7 +10,7 @@ import QuestionSuccess from '../question/QuestionSuccess'
 
 import CheckboxInput from './CheckboxInput'
 
-const CheckboxWidget = ({ question, values, currentSet, disabled,
+const CheckboxWidget = ({ question, values, siblings, currentSet, disabled,
                           createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (option, additionalInput) => {
@@ -71,7 +71,7 @@ const CheckboxWidget = ({ question, values, currentSet, disabled,
             </div>
             <div className="buttons">
               <QuestionSuccess value={{ success }} />
-              <QuestionCopyValues question={question} values={values} copyValue={copyValue} />
+              <QuestionCopyValues question={question} values={values} siblings={siblings} copyValue={copyValue} />
             </div>
           </div>
         </div>
@@ -83,6 +83,7 @@ const CheckboxWidget = ({ question, values, currentSet, disabled,
 CheckboxWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
@@ -10,7 +10,7 @@ import QuestionSuccess from '../question/QuestionSuccess'
 
 import CheckboxInput from './CheckboxInput'
 
-const CheckboxWidget = ({ question, values, siblings, currentSet, disabled,
+const CheckboxWidget = ({ question, sets, values, siblings, currentSet, disabled,
                           createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (option, additionalInput) => {
@@ -71,7 +71,14 @@ const CheckboxWidget = ({ question, values, siblings, currentSet, disabled,
             </div>
             <div className="buttons">
               <QuestionSuccess value={{ success }} />
-              <QuestionCopyValues question={question} values={values} siblings={siblings} copyValue={copyValue} />
+              <QuestionCopyValues
+                question={question}
+                sets={sets}
+                values={values}
+                siblings={siblings}
+                currentSet={currentSet}
+                copyValue={copyValue}
+              />
             </div>
           </div>
         </div>
@@ -82,6 +89,7 @@ const CheckboxWidget = ({ question, values, siblings, currentSet, disabled,
 
 CheckboxWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
@@ -4,12 +4,14 @@ import { maxBy } from 'lodash'
 
 import { gatherOptions } from '../../../utils/options'
 
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
 
 import CheckboxInput from './CheckboxInput'
 
-const CheckboxWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const CheckboxWidget = ({ question, values, currentSet, disabled,
+                          createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (option, additionalInput) => {
     const lastValue = maxBy(values, (v) => v.collection_index)
@@ -69,6 +71,7 @@ const CheckboxWidget = ({ question, values, currentSet, disabled, createValue, u
             </div>
             <div className="buttons">
               <QuestionSuccess value={{ success }} />
+              <QuestionCopyValues question={question} values={values} copyValue={copyValue} />
             </div>
           </div>
         </div>
@@ -84,7 +87,8 @@ CheckboxWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default CheckboxWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/CheckboxWidget.js
@@ -5,6 +5,7 @@ import { maxBy } from 'lodash'
 import { gatherOptions } from '../../../utils/options'
 
 import QuestionCopyValues from '../question/QuestionCopyValues'
+import QuestionEraseValues from '../question/QuestionEraseValues'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
 
@@ -71,6 +72,11 @@ const CheckboxWidget = ({ question, sets, values, siblings, currentSet, disabled
             </div>
             <div className="buttons">
               <QuestionSuccess value={{ success }} />
+              <QuestionEraseValues
+                values={values}
+                disabled={disabled}
+                deleteValue={deleteValue}
+              />
               <QuestionCopyValues
                 question={question}
                 sets={sets}

--- a/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
@@ -12,7 +12,8 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import DateInput from './DateInput'
 
-const DateWidget = ({ question, values, siblings, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const DateWidget = ({ question, sets, values, siblings, currentSet, disabled,
+                      createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -55,8 +56,10 @@ const DateWidget = ({ question, values, siblings, currentSet, disabled, createVa
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -65,6 +68,7 @@ const DateWidget = ({ question, values, siblings, currentSet, disabled, createVa
 
 DateWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionEraseValue from '../question/QuestionEraseValue'
@@ -10,7 +11,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import DateInput from './DateInput'
 
-const DateWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const DateWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -33,6 +34,7 @@ const DateWidget = ({ question, values, currentSet, disabled, createValue, updat
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -48,6 +50,7 @@ const DateWidget = ({ question, values, currentSet, disabled, createValue, updat
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        copyValue={copyValue}
       />
     </div>
   )
@@ -60,7 +63,8 @@ DateWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default DateWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionEraseValue from '../question/QuestionEraseValue'
@@ -11,7 +12,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import DateInput from './DateInput'
 
-const DateWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const DateWidget = ({ question, values, siblings, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -34,7 +35,7 @@ const DateWidget = ({ question, values, currentSet, disabled, createValue, updat
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -52,6 +53,12 @@ const DateWidget = ({ question, values, currentSet, disabled, createValue, updat
         createValue={createValue}
         copyValue={copyValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -59,6 +66,7 @@ const DateWidget = ({ question, values, currentSet, disabled, createValue, updat
 DateWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
@@ -14,7 +14,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RadioInput from './RadioInput'
 
-const RadioWidget = ({ question, values, siblings, currentSet, disabled,
+const RadioWidget = ({ question, sets, values, siblings, currentSet, disabled,
                        createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -59,8 +59,10 @@ const RadioWidget = ({ question, values, siblings, currentSet, disabled,
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -69,6 +71,7 @@ const RadioWidget = ({ question, values, siblings, currentSet, disabled,
 
 RadioWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
@@ -5,6 +5,7 @@ import { gatherOptions } from '../../../utils/options'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -13,7 +14,8 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RadioInput from './RadioInput'
 
-const RadioWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const RadioWidget = ({ question, values, siblings, currentSet, disabled,
+                       createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -37,7 +39,7 @@ const RadioWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -55,6 +57,12 @@ const RadioWidget = ({ question, values, currentSet, disabled, createValue, upda
         createValue={createValue}
         copyValue={copyValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -62,6 +70,7 @@ const RadioWidget = ({ question, values, currentSet, disabled, createValue, upda
 RadioWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { gatherOptions } from '../../../utils/options'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -12,7 +13,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RadioInput from './RadioInput'
 
-const RadioWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const RadioWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -36,6 +37,7 @@ const RadioWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -51,6 +53,7 @@ const RadioWidget = ({ question, values, currentSet, disabled, createValue, upda
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        copyValue={copyValue}
       />
     </div>
   )
@@ -63,7 +66,8 @@ RadioWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default RadioWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { initRange } from '../../../utils/value'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -12,7 +13,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RangeInput from './RangeInput'
 
-const RangeWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const RangeWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (value) => {
     initRange(question, value)
@@ -46,6 +47,7 @@ const RangeWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -61,6 +63,7 @@ const RangeWidget = ({ question, values, currentSet, disabled, createValue, upda
         currentSet={currentSet}
         disabled={disabled}
         createValue={handleCreateValue}
+        copyValue={copyValue}
       />
     </div>
   )
@@ -73,7 +76,8 @@ RangeWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default RangeWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
@@ -14,7 +14,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RangeInput from './RangeInput'
 
-const RangeWidget = ({ question, values, siblings, currentSet, disabled,
+const RangeWidget = ({ question, sets, values, siblings, currentSet, disabled,
                        createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (value) => {
@@ -69,8 +69,10 @@ const RangeWidget = ({ question, values, siblings, currentSet, disabled,
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -79,6 +81,7 @@ const RangeWidget = ({ question, values, siblings, currentSet, disabled,
 
 RangeWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
@@ -5,6 +5,7 @@ import { initRange } from '../../../utils/value'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -13,7 +14,8 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import RangeInput from './RangeInput'
 
-const RangeWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const RangeWidget = ({ question, values, siblings, currentSet, disabled,
+                       createValue, updateValue, deleteValue, copyValue }) => {
 
   const handleCreateValue = (value) => {
     initRange(question, value)
@@ -47,7 +49,7 @@ const RangeWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -65,6 +67,12 @@ const RangeWidget = ({ question, values, currentSet, disabled, createValue, upda
         createValue={handleCreateValue}
         copyValue={copyValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -72,6 +80,7 @@ const RangeWidget = ({ question, values, currentSet, disabled, createValue, upda
 RangeWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
@@ -14,7 +14,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import SelectInput from './SelectInput'
 
-const SelectWidget = ({ question, values, siblings, currentSet, disabled, creatable,
+const SelectWidget = ({ question, sets, values, siblings, currentSet, disabled, creatable,
                         createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -59,8 +59,10 @@ const SelectWidget = ({ question, values, siblings, currentSet, disabled, creata
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -69,6 +71,7 @@ const SelectWidget = ({ question, values, siblings, currentSet, disabled, creata
 
 SelectWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { gatherOptions } from '../../../utils/options'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionEraseValue from '../question/QuestionEraseValue'
 import QuestionError from '../question/QuestionError'
@@ -13,7 +14,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 import SelectInput from './SelectInput'
 
 const SelectWidget = ({ question, values, currentSet, disabled, creatable,
-                        createValue, updateValue, deleteValue }) => {
+                        createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -38,6 +39,7 @@ const SelectWidget = ({ question, values, currentSet, disabled, creatable,
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -66,7 +68,8 @@ SelectWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default SelectWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
@@ -5,6 +5,7 @@ import { gatherOptions } from '../../../utils/options'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionEraseValue from '../question/QuestionEraseValue'
 import QuestionError from '../question/QuestionError'
@@ -13,7 +14,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import SelectInput from './SelectInput'
 
-const SelectWidget = ({ question, values, currentSet, disabled, creatable,
+const SelectWidget = ({ question, values, siblings, currentSet, disabled, creatable,
                         createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -39,7 +40,7 @@ const SelectWidget = ({ question, values, currentSet, disabled, creatable,
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -56,6 +57,12 @@ const SelectWidget = ({ question, values, currentSet, disabled, creatable,
         disabled={disabled}
         createValue={createValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -63,6 +70,7 @@ const SelectWidget = ({ question, values, currentSet, disabled, creatable,
 SelectWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   creatable: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionRemoveValue from '../question/QuestionRemoveValue'
@@ -10,7 +11,7 @@ import QuestionSuccess from '../question/QuestionSuccess'
 
 import TextInput from './TextInput'
 
-const TextWidget = ({ question, values, currentSet, disabled,
+const TextWidget = ({ question, values, siblings, currentSet, disabled,
                       createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -33,7 +34,7 @@ const TextWidget = ({ question, values, currentSet, disabled,
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -50,6 +51,12 @@ const TextWidget = ({ question, values, currentSet, disabled,
         disabled={disabled}
         createValue={createValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -57,6 +64,7 @@ const TextWidget = ({ question, values, currentSet, disabled,
 TextWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionRemoveValue from '../question/QuestionRemoveValue'
@@ -9,7 +10,8 @@ import QuestionSuccess from '../question/QuestionSuccess'
 
 import TextInput from './TextInput'
 
-const TextWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const TextWidget = ({ question, values, currentSet, disabled,
+                      createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -31,6 +33,7 @@ const TextWidget = ({ question, values, currentSet, disabled, createValue, updat
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -58,7 +61,8 @@ TextWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default TextWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
@@ -11,7 +11,7 @@ import QuestionSuccess from '../question/QuestionSuccess'
 
 import TextInput from './TextInput'
 
-const TextWidget = ({ question, values, siblings, currentSet, disabled,
+const TextWidget = ({ question, sets, values, siblings, currentSet, disabled,
                       createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -53,8 +53,10 @@ const TextWidget = ({ question, values, siblings, currentSet, disabled,
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -63,6 +65,7 @@ const TextWidget = ({ question, values, siblings, currentSet, disabled,
 
 TextWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
@@ -11,7 +11,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import TextareaInput from './TextareaInput'
 
-const TextareaWidget = ({ question, values, siblings, currentSet, disabled,
+const TextareaWidget = ({ question, sets, values, siblings, currentSet, disabled,
                           createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -53,8 +53,10 @@ const TextareaWidget = ({ question, values, siblings, currentSet, disabled,
       />
       <QuestionCopyValues
         question={question}
+        sets={sets}
         values={values}
         siblings={siblings}
+        currentSet={currentSet}
         copyValue={copyValue}
       />
     </div>
@@ -63,6 +65,7 @@ const TextareaWidget = ({ question, values, siblings, currentSet, disabled,
 
 TextareaWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -9,7 +10,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import TextareaInput from './TextareaInput'
 
-const TextareaWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const TextareaWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -31,6 +32,7 @@ const TextareaWidget = ({ question, values, currentSet, disabled, createValue, u
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -58,7 +60,8 @@ TextareaWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default TextareaWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionSuccess from '../question/QuestionSuccess'
@@ -10,7 +11,8 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import TextareaInput from './TextareaInput'
 
-const TextareaWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const TextareaWidget = ({ question, values, siblings, currentSet, disabled,
+                          createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -32,7 +34,7 @@ const TextareaWidget = ({ question, values, currentSet, disabled, createValue, u
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -49,6 +51,12 @@ const TextareaWidget = ({ question, values, currentSet, disabled, createValue, u
         disabled={disabled}
         createValue={createValue}
       />
+      <QuestionCopyValues
+        question={question}
+        values={values}
+        siblings={siblings}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
@@ -56,6 +64,7 @@ const TextareaWidget = ({ question, values, currentSet, disabled, createValue, u
 TextareaWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
@@ -12,7 +12,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import YesNoInput from './YesNoInput'
 
-const YesNoWidget = ({ question, values, siblings, currentSet, disabled,
+const YesNoWidget = ({ question, sets, values, siblings, currentSet, disabled,
                        createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
@@ -53,13 +53,21 @@ const YesNoWidget = ({ question, values, siblings, currentSet, disabled,
         disabled={disabled}
         createValue={createValue}
       />
-      <QuestionCopyValues question={question} values={values} siblings={siblings} copyValue={copyValue} />
+      <QuestionCopyValues
+        question={question}
+        sets={sets}
+        values={values}
+        siblings={siblings}
+        currentSet={currentSet}
+        copyValue={copyValue}
+      />
     </div>
   )
 }
 
 YesNoWidget.propTypes = {
   question: PropTypes.object.isRequired,
+  sets: PropTypes.array.isRequired,
   values: PropTypes.array.isRequired,
   siblings: PropTypes.array,
   disabled: PropTypes.bool,

--- a/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
+import QuestionCopyValue from '../question/QuestionCopyValue'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionEraseValue from '../question/QuestionEraseValue'
@@ -10,7 +11,7 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import YesNoInput from './YesNoInput'
 
-const YesNoWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue }) => {
+const YesNoWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -33,6 +34,7 @@ const YesNoWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
+                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -60,7 +62,8 @@ YesNoWidget.propTypes = {
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,
   updateValue: PropTypes.func.isRequired,
-  deleteValue: PropTypes.func.isRequired
+  deleteValue: PropTypes.func.isRequired,
+  copyValue: PropTypes.func.isRequired
 }
 
 export default YesNoWidget

--- a/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import QuestionAddValue from '../question/QuestionAddValue'
 import QuestionCopyValue from '../question/QuestionCopyValue'
+import QuestionCopyValues from '../question/QuestionCopyValues'
 import QuestionDefault from '../question/QuestionDefault'
 import QuestionError from '../question/QuestionError'
 import QuestionEraseValue from '../question/QuestionEraseValue'
@@ -11,7 +12,8 @@ import QuestionRemoveValue from '../question/QuestionRemoveValue'
 
 import YesNoInput from './YesNoInput'
 
-const YesNoWidget = ({ question, values, currentSet, disabled, createValue, updateValue, deleteValue, copyValue }) => {
+const YesNoWidget = ({ question, values, siblings, currentSet, disabled,
+                       createValue, updateValue, deleteValue, copyValue }) => {
   return (
     <div className="interview-widgets">
       {
@@ -34,7 +36,7 @@ const YesNoWidget = ({ question, values, currentSet, disabled, createValue, upda
                       disabled={disabled}
                       deleteValue={deleteValue}
                     />
-                    <QuestionCopyValue question={question} value={value} copyValue={copyValue} />
+                    <QuestionCopyValue question={question} value={value} siblings={siblings} copyValue={copyValue} />
                     <QuestionDefault question={question} value={value} />
                   </div>
                 }
@@ -51,6 +53,7 @@ const YesNoWidget = ({ question, values, currentSet, disabled, createValue, upda
         disabled={disabled}
         createValue={createValue}
       />
+      <QuestionCopyValues question={question} values={values} siblings={siblings} copyValue={copyValue} />
     </div>
   )
 }
@@ -58,6 +61,7 @@ const YesNoWidget = ({ question, values, currentSet, disabled, createValue, upda
 YesNoWidget.propTypes = {
   question: PropTypes.object.isRequired,
   values: PropTypes.array.isRequired,
+  siblings: PropTypes.array,
   disabled: PropTypes.bool,
   currentSet: PropTypes.object.isRequired,
   createValue: PropTypes.func.isRequired,

--- a/rdmo/projects/assets/js/interview/containers/Main.js
+++ b/rdmo/projects/assets/js/interview/containers/Main.js
@@ -53,6 +53,7 @@ const Main = ({ config, settings, templates, user, project, interview, configAct
               createSet={interviewActions.createSet}
               updateSet={interviewActions.updateSet}
               deleteSet={interviewActions.deleteSet}
+              copyValue={interviewActions.copyValue}
             />
           )
         }

--- a/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
+++ b/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
@@ -67,7 +67,7 @@ export default function interviewReducer(state = initialState, action) {
         return { ...state, values: [...state.values, action.value] }
       }
     case DELETE_VALUE_SUCCESS:
-      return {...state, values: state.values.filter((value) => value !== action.value)}
+      return {...state, values: state.values.filter((value) => value.id !== action.value.id)}
     case CREATE_SET:
       return { ...state, values: action.values, sets: action.sets }
     case DELETE_SET_SUCCESS:

--- a/rdmo/projects/assets/js/interview/utils/page.js
+++ b/rdmo/projects/assets/js/interview/utils/page.js
@@ -20,36 +20,36 @@ const initQuestionSet = (questionset) => {
   // aggregate questionsets from descendants
   questionset.questionsets = questionset.elements.reduce((questionsets, element) => {
     if (element.model == 'questions.questionset') {
-      return questionsets.concat(element.questionsets)
+      return [...questionsets, element, ...element.questionsets] // add this questionset and all it's questionsets
     } else {
-      return questionsets
+      return questionsets  // do nothing
     }
   }, [])
 
-  // aggregate optionsets from descendants
+  // aggregate questions from descendants
   questionset.questions = questionset.elements.reduce((questions, element) => {
     if (element.model == 'questions.questionset') {
-      return questions.concat(element.questions)
+      return questions.concat(element.questions)  // add the questions of this questionset
     } else {
-      return [...questions, element]
+      return [...questions, element]  // add this question
     }
   }, [])
 
   // aggregate optionsets from descendants
   questionset.optionsets = questionset.elements.reduce((optionsets, element) => {
     if (element.model == 'questions.questionset') {
-      return optionsets.concat(element.optionsets)
+      return optionsets.concat(element.optionsets)  // add all optionsets of the questions of this questionset
     } else {
-      return [...optionsets, ...element.optionsets]
+      return [...optionsets, ...element.optionsets]  // add all optionsets of this question
     }
   }, [])
 
   // aggregate attributes from descendants
   questionset.attributes = questionset.elements.reduce((attributes, element) => {
     if (element.model == 'questions.questionset') {
-      return attributes.concat(element.attributes)
+      return attributes.concat(element.attributes)  // add all attributes of this questionset and its questions
     } else {
-      return [...attributes, element.attribute]
+      return [...attributes, element.attribute]  // add the attribute of this question
     }
   }, [questionset.attribute]).filter((a) => !isNil(a))
 }

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -45,8 +45,8 @@ const initValues = (sets, values, element, setPrefix) => {
       // check if there is any value for this question and set
       if (isNil(values.find((value) => (
         (value.attribute === question.attribute) &&
-        (value.set_prefix == set.set_prefix) &&
-        (value.set_index == set.set_index)
+        (value.set_prefix === set.set_prefix) &&
+        (value.set_index === set.set_index)
       )))) {
         // if there is no value, create one, but not for checkboxes
         if (question.widget_class !== 'checkbox') {

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -87,10 +87,14 @@ const activateFirstValue = (page, values) => {
 }
 
 const compareValues = (a, b) => {
-  return (a.attribute == b.attribute) &&
-         (a.set_prefix == b.set_prefix) &&
-         (a.set_index == b.set_index) &&
-         (a.collection_index == b.collection_index)
+  if (isNil(a.id) || isNil(b.id)) {
+    return (a.attribute == b.attribute) &&
+           (a.set_prefix == b.set_prefix) &&
+           (a.set_index == b.set_index) &&
+           (a.collection_index == b.collection_index)
+  } else {
+    return a.id == b.id
+  }
 }
 
 export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue, compareValues }

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -39,28 +39,33 @@ const initValues = (sets, values, element, setPrefix) => {
     setPrefix = ''
   }
 
+  // loop over all sets of the current set prefix and over all questions
   sets.filter((set) => set.set_prefix === setPrefix).forEach((set) => {
     element.elements.filter((e) => (e.model === 'questions.question')).forEach((question) => {
+      // check if there is any value for this question and set
       if (isNil(values.find((value) => (
         (value.attribute === question.attribute) &&
         (value.set_prefix == set.set_prefix) &&
         (value.set_index == set.set_index)
       )))) {
-        const value = ValueFactory.create({
-          attribute: question.attribute,
-          set_prefix: set.set_prefix,
-          set_index: set.set_index,
-          set_collection: question.set_collection,
-          text: question.default_text,
-          option: question.default_option,
-          external_id: question.default_external_id
-        })
+        // if there is no value, create one, but not for checkboxes
+        if (question.widget_class !== 'checkbox') {
+          const value = ValueFactory.create({
+            attribute: question.attribute,
+            set_prefix: set.set_prefix,
+            set_index: set.set_index,
+            set_collection: question.set_collection,
+            text: question.default_text,
+            option: question.default_option,
+            external_id: question.default_external_id
+          })
 
-        if (question.widget_class === 'range') {
-          initRange(question, value)
+          if (question.widget_class === 'range') {
+            initRange(question, value)
+          }
+
+          values.push(value)
         }
-
-        values.push(value)
       }
     })
 

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -97,4 +97,10 @@ const compareValues = (a, b) => {
   }
 }
 
-export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue, compareValues }
+const isEmptyValue = (value) => {
+  return isNil(value.id) || (
+    isEmpty(value.text) && isNil(value.option) && isEmpty(value.external_id)
+  )
+}
+
+export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue, compareValues, isEmptyValue }

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -86,4 +86,11 @@ const activateFirstValue = (page, values) => {
   }
 }
 
-export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue }
+const compareValues = (a, b) => {
+  return (a.attribute == b.attribute) &&
+         (a.set_prefix == b.set_prefix) &&
+         (a.set_index == b.set_index) &&
+         (a.collection_index == b.collection_index)
+}
+
+export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue, compareValues }

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -180,8 +180,7 @@
         display: flex;
         gap: 10px;
 
-        .btn-erase-value,
-        .btn-remove-value,
+        .btn.btn-link,
         .success-indicator {
             opacity: 0.8;
             line-height: 20px;
@@ -190,13 +189,11 @@
             padding-right: 0;
         }
 
-        .btn-erase-value:hover,
-        .btn-remove-value:hover {
+        .btn.btn-link:hover {
             opacity: 1;
         }
 
-        .btn-erase-value:focus,
-        .btn-remove-value:focus {
+        .btn.btn-link:focus {
             outline: 0;
         }
 


### PR DESCRIPTION
This PR adds the possibility to make projects to all users (#152)
* Visible projects can be accessed read only and can be used as template
* In a multi site setup, project visibility can be restricted to sites
* Project visibility can also be restricted to groups
* For now site manager can set the visibility, but this might be changed in the future

To that purpose, it adds a copyValue action to the new interface, which can be used to copy values to different tabs of a page.

It also makes the add value button for questions a bit smaller.