### PR TITLE
pyproject.toml: Require gunicorn>=22 because of CVE-2024-1135

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
   "rdmo[pytest]",
 ]
 gunicorn = [
-  "gunicorn~=21.2",
+  "gunicorn>=22",
 ]
 ldap = [
   "django-auth-ldap~=4.5",


### PR DESCRIPTION
See https://docs.gunicorn.org/en/latest/news.html#id2