### PR TITLE
Refactor upload accept

### DIFF
--- a/rdmo/core/assets/js/components/UploadDropZone.js
+++ b/rdmo/core/assets/js/components/UploadDropZone.js
@@ -40,7 +40,7 @@ const UploadDropZone = ({ acceptedTypes, onImportFile }) => {
 }
 
 UploadDropZone.propTypes = {
-  acceptedTypes: PropTypes.arrayOf(PropTypes.string),
+  acceptedTypes: PropTypes.object,
   onImportFile: PropTypes.func.isRequired,
 }
 

--- a/rdmo/projects/assets/js/projects/actions/projectsActions.js
+++ b/rdmo/projects/assets/js/projects/actions/projectsActions.js
@@ -47,9 +47,9 @@ export function fetchProjectsError(error) {
 export function fetchCatalogs() {
   return function(dispatch) {
     dispatch(fetchCatalogsInit())
-    const action = (dispatch) => ProjectsApi.fetchCatalogs()
-          .then(catalogs => {
-            dispatch(fetchCatalogsSuccess({ catalogs }))})
+    const action = (dispatch) => ProjectsApi.fetchCatalogs().then(catalogs => {
+      dispatch(fetchCatalogsSuccess(catalogs))
+    })
 
     return dispatch(action)
       .catch(error => dispatch(fetchCatalogsError(error)))
@@ -71,9 +71,9 @@ export function fetchCatalogsError(error) {
 export function fetchAllowedFileTypes() {
   return function(dispatch) {
     dispatch(fetchAllowedFileTypesInit())
-    const action = (dispatch) => ProjectsApi.fetchAllowedFileTypes()
-          .then(allowedTypes => {
-            dispatch(fetchAllowedFileTypesSuccess({ allowedTypes }))})
+    const action = (dispatch) => ProjectsApi.fetchAllowedFileTypes().then(allowedTypes => {
+      dispatch(fetchAllowedFileTypesSuccess(allowedTypes))
+    })
 
     return dispatch(action)
       .catch(error => dispatch(fetchAllowedFileTypesError(error)))
@@ -95,9 +95,9 @@ export function fetchAllowedFileTypesError(error) {
 export function fetchImportUrls() {
   return function(dispatch) {
     dispatch(fetchImportUrlsInit())
-    const action = (dispatch) => ProjectsApi.fetchDirectImportUrls()
-          .then(importUrls => {
-            dispatch(fettchImportUrlsSuccess({ importUrls }))})
+    const action = (dispatch) => ProjectsApi.fetchDirectImportUrls().then(importUrls => {
+      dispatch(fettchImportUrlsSuccess(importUrls))
+    })
 
     return dispatch(action)
       .catch(error => dispatch(fetchImportUrlsError(error)))
@@ -109,7 +109,7 @@ export function fetchImportUrlsInit() {
 }
 
 export function fettchImportUrlsSuccess(importUrls) {
-  return {type: FETCH_IMPORT_URLS_SUCCESS, importUrls }
+  return {type: FETCH_IMPORT_URLS_SUCCESS, importUrls}
 }
 
 export function fetchImportUrlsError(error) {
@@ -119,9 +119,9 @@ export function fetchImportUrlsError(error) {
 export function fetchInvitations() {
   return function(dispatch) {
     dispatch(fetchInvitationsInit())
-    const action = (dispatch) => ProjectsApi.fetchInvites()
-          .then(invites => {
-            dispatch(fetchInvitationsSuccess({ invites }))})
+    const action = (dispatch) => ProjectsApi.fetchInvites().then(invites => {
+      dispatch(fetchInvitationsSuccess(invites))
+    })
 
     return dispatch(action)
       .catch(error => dispatch(fetchInvitationsError(error)))

--- a/rdmo/projects/assets/js/projects/actions/projectsActions.js
+++ b/rdmo/projects/assets/js/projects/actions/projectsActions.js
@@ -96,7 +96,7 @@ export function fetchImportUrls() {
   return function(dispatch) {
     dispatch(fetchImportUrlsInit())
     const action = (dispatch) => ProjectsApi.fetchDirectImportUrls().then(importUrls => {
-      dispatch(fettchImportUrlsSuccess(importUrls))
+      dispatch(fetchImportUrlsSuccess(importUrls))
     })
 
     return dispatch(action)
@@ -108,7 +108,7 @@ export function fetchImportUrlsInit() {
   return {type: FETCH_IMPORT_URLS_INIT}
 }
 
-export function fettchImportUrlsSuccess(importUrls) {
+export function fetchImportUrlsSuccess(importUrls) {
   return {type: FETCH_IMPORT_URLS_SUCCESS, importUrls}
 }
 

--- a/rdmo/projects/assets/js/projects/components/helper/ProjectImport.js
+++ b/rdmo/projects/assets/js/projects/components/helper/ProjectImport.js
@@ -34,7 +34,7 @@ const ProjectImport = ({ allowedTypes, handleImport, importUrls}) => {
 }
 
 ProjectImport.propTypes = {
-  allowedTypes: PropTypes.arrayOf(PropTypes.string),
+  allowedTypes: PropTypes.object,
   handleImport: PropTypes.func.isRequired,
   importUrls: PropTypes.arrayOf(PropTypes.object).isRequired
 }

--- a/rdmo/projects/assets/js/projects/reducers/projectsReducer.js
+++ b/rdmo/projects/assets/js/projects/reducers/projectsReducer.js
@@ -26,27 +26,27 @@ export default function projectsReducer(state = initialState, action) {
     case FETCH_PROJECTS_ERROR:
       return {...state, errors: action.error.errors}
     case FETCH_INVITATIONS_INIT:
-      return {...state, ...action.invites}
+      return {...state}
     case FETCH_INVITATIONS_SUCCESS:
-      return {...state, ...action.invites}
+      return {...state, invites: action.invites}
     case FETCH_INVITATIONS_ERROR:
       return {...state, errors: action.error.errors}
     case FETCH_CATALOGS_INIT:
-      return {...state, ...action.catalogs}
+      return {...state}
     case FETCH_CATALOGS_SUCCESS:
-      return {...state, ...action.catalogs}
+      return {...state, catalogs: action.catalogs}
     case FETCH_CATALOGS_ERROR:
       return {...state, errors: action.error.errors}
     case FETCH_FILETYPES_INIT:
-      return {...state, ...action.allowedTypes}
+      return {...state}
     case FETCH_FILETYPES_SUCCESS:
-      return {...state, ...action.allowedTypes}
+      return {...state, allowedTypes: action.allowedTypes}
     case FETCH_FILETYPES_ERROR:
       return {...state, errors: action.error.errors}
     case FETCH_IMPORT_URLS_INIT:
-      return {...state, ...action.importUrls}
+      return {...state}
     case FETCH_IMPORT_URLS_SUCCESS:
-      return {...state, ...action.importUrls}
+      return {...state, importUrls: action.importUrls}
     case FETCH_IMPORT_URLS_ERROR:
       return {...state, errors: action.error.errors}
     default:

--- a/rdmo/projects/imports.py
+++ b/rdmo/projects/imports.py
@@ -88,7 +88,10 @@ class Import(Plugin):
 
 class RDMOXMLImport(Import):
 
-    accept = '.xml'
+    accept = {
+        'application/xml': ['.xml'],
+        'text/xml': ['.xml']
+    }
 
     def check(self):
         file_type, encoding = mimetypes.guess_type(self.file_name)
@@ -230,6 +233,9 @@ class RDMOXMLImport(Import):
 
 
 class URLImport(RDMOXMLImport):
+
+    accept = False
+    upload = False
 
     class Form(forms.Form):
         url = forms.URLField(label=_('Import project from this URL'), required=True)

--- a/rdmo/projects/imports.py
+++ b/rdmo/projects/imports.py
@@ -89,8 +89,7 @@ class Import(Plugin):
 class RDMOXMLImport(Import):
 
     accept = {
-        'application/xml': ['.xml'],
-        'text/xml': ['.xml']
+        'application/xml': ['.xml']
     }
 
     def check(self):

--- a/rdmo/projects/tests/test_viewset_project.py
+++ b/rdmo/projects/tests/test_viewset_project.py
@@ -578,7 +578,10 @@ def test_upload_accept(db, client, username, password):
 
     if password:
         assert response.status_code == 200
-        assert response.json() == '.xml'
+        assert response.json() == {
+            'application/xml': ['.xml'],
+            'text/xml': ['.xml']
+        }
     else:
         assert response.status_code == 401
 

--- a/rdmo/projects/tests/test_viewset_project.py
+++ b/rdmo/projects/tests/test_viewset_project.py
@@ -579,8 +579,7 @@ def test_upload_accept(db, client, username, password):
     if password:
         assert response.status_code == 200
         assert response.json() == {
-            'application/xml': ['.xml'],
-            'text/xml': ['.xml']
+            'application/xml': ['.xml']
         }
     else:
         assert response.status_code == 401

--- a/rdmo/projects/utils.py
+++ b/rdmo/projects/utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from pathlib import Path
 
 from django.conf import settings
@@ -278,13 +279,16 @@ def set_context_querystring_with_filter_and_page(context: dict) -> dict:
 
 
 def get_upload_accept():
-    accept = set()
+    accept = defaultdict(set)
     for import_plugin in get_plugins('PROJECT_IMPORTS').values():
         if import_plugin.accept:
-            accept.add(import_plugin.accept)
-        else:
-            return None
-    return ','.join(accept)
+            for key, values in import_plugin.accept.items():
+                accept[key].update(values)
+        elif import_plugin.upload is True:
+            # if one of the plugins does not have the accept field, but is marked as upload plugin
+            # all file types are allowed
+            return {}
+    return accept
 
 
 def compute_set_prefix_from_set_value(set_value, value):

--- a/rdmo/projects/utils.py
+++ b/rdmo/projects/utils.py
@@ -290,7 +290,8 @@ def get_upload_accept():
             # legacy fallback for pre 2.3.0 RDMO, e.g. `accept = '.xml'`
             suffix = import_plugin.accept
             mime_type, encoding = mimetypes.guess_type(f'example{suffix}')
-            accept[mime_type].update([suffix])
+            if mime_type:
+                accept[mime_type].update([suffix])
 
         elif import_plugin.upload is True:
             # if one of the plugins does not have the accept field, but is marked as upload plugin

--- a/rdmo/projects/views/project.py
+++ b/rdmo/projects/views/project.py
@@ -87,7 +87,9 @@ class ProjectDetailView(ObjectPermissionMixin, DetailView):
         context['snapshots'] = project.snapshots.all()
         context['invites'] = project.invites.all()
         context['membership'] = Membership.objects.filter(project=project, user=self.request.user).first()
-        context['upload_accept'] = get_upload_accept()
+        context['upload_accept'] = ','.join([
+            suffix for suffixes in get_upload_accept().values() for suffix in suffixes
+        ])
         return context
 
 


### PR DESCRIPTION
This PR refactors the accept field for import plugins to match the format of react-dropzone, e.g.:

```
    accept = {
        'application/xml': ['.xml']
    }
```

The old style `accept = '.xml'` should still work. In this case `mimetypes` guesses the mime_type.

It also contains minor renaming in `projectActions`.