### PR TITLE
Add snapshot exports and PROJECT_SNAPSHOT_EXPORTS to settings

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -203,6 +203,7 @@ SETTINGS_EXPORT = [
     'PROJECT_ISSUES',
     'PROJECT_VIEWS',
     'PROJECT_EXPORTS',
+    'PROJECT_SNAPSHOT_EXPORTS',
     'PROJECT_IMPORTS',
     'PROJECT_IMPORTS_LIST',
     'PROJECT_SEND_ISSUE',
@@ -293,6 +294,8 @@ PROJECT_EXPORTS = [
     ('csvsemicolon', _('CSV (semicolon separated)'), 'rdmo.projects.exports.CSVSemicolonExport'),
     ('json', _('JSON'), 'rdmo.projects.exports.JSONExport'),
 ]
+
+PROJECT_SNAPSHOT_EXPORTS = []
 
 PROJECT_IMPORTS = [
     ('xml', _('RDMO XML'), 'rdmo.projects.imports.RDMOXMLImport'),

--- a/rdmo/core/static/core/css/base.scss
+++ b/rdmo/core/static/core/css/base.scss
@@ -97,9 +97,12 @@ a {
 
 .btn-link {
     color: $link-color;
+    padding: 0;
+    text-decoration: none;
 
     &:hover {
         color: $link-color-hover;
+        text-decoration: none;
     }
 }
 

--- a/rdmo/projects/exports.py
+++ b/rdmo/projects/exports.py
@@ -157,15 +157,17 @@ class RDMOXMLExport(Export):
 
     def render(self):
         if self.project:
-            content_disposition = f'filename="{self.project.title}.xml"'
+            content_disposition = f'attachment; filename="{self.project.title}.xml"'
             serializer = ProjectExportSerializer(self.project)
 
         else:
-            content_disposition = f'filename="{self.snapshot.title}.xml"'
+            content_disposition = f'attachment; filename="{self.snapshot.title}.xml"'
             serializer = SnapshotExportSerializer(self.snapshot)
 
         xmldata = XMLRenderer().render(serializer.data)
         response = HttpResponse(prettify_xml(xmldata), content_type="application/xml")
+
         if settings.EXPORT_CONTENT_DISPOSITION == 'attachment':
             response['Content-Disposition'] = content_disposition
+
         return response

--- a/rdmo/projects/exports.py
+++ b/rdmo/projects/exports.py
@@ -10,7 +10,8 @@ from rdmo.views.templatetags import view_tags
 from rdmo.views.utils import ProjectWrapper
 
 from .renderers import XMLRenderer
-from .serializers.export import ProjectSerializer as ExportSerializer
+from .serializers.export import ProjectSerializer as ProjectExportSerializer
+from .serializers.export import SnapshotSerializer as SnapshotExportSerializer
 
 
 class Export(Plugin):
@@ -155,11 +156,16 @@ class JSONExport(AnswersExportMixin, Export):
 class RDMOXMLExport(Export):
 
     def render(self):
-        serializer = ExportSerializer(self.project)
+        if self.project:
+            content_disposition = f'filename="{self.project.title}.xml"'
+            serializer = ProjectExportSerializer(self.project)
+
+        else:
+            content_disposition = f'filename="{self.snapshot.title}.xml"'
+            serializer = SnapshotExportSerializer(self.snapshot)
+
         xmldata = XMLRenderer().render(serializer.data)
         response = HttpResponse(prettify_xml(xmldata), content_type="application/xml")
-
         if settings.EXPORT_CONTENT_DISPOSITION == 'attachment':
-            response['Content-Disposition'] = f'attachment; filename="{self.project.title}.xml"'
-
+            response['Content-Disposition'] = content_disposition
         return response

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -99,6 +99,7 @@ rules.add_perm('projects.view_snapshot_object', is_project_member | is_site_mana
 rules.add_perm('projects.add_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
 rules.add_perm('projects.change_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
 rules.add_perm('projects.rollback_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
+rules.add_perm('projects.export_snapshot_object', is_project_owner | is_project_manager | is_site_manager)
 
 rules.add_perm('projects.view_value_object', is_project_member | is_site_manager)
 rules.add_perm('projects.add_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)

--- a/rdmo/projects/templates/projects/project_detail_snapshots.html
+++ b/rdmo/projects/templates/projects/project_detail_snapshots.html
@@ -54,6 +54,24 @@
                             title="{% trans 'Rollback to snapshot' %}">
                         </a>
                         {% endif %}
+
+                        {% has_perm 'projects.export_project_object' request.user project as can_export_project %}
+                        {% if settings.PROJECT_SNAPSHOT_EXPORTS and can_export_project %}
+                        <span class="dropdown">
+                            <button class="btn-link fa fa-download" title="{% trans 'Export snapshot' %}"
+                                    data-toggle="dropdown"></button>
+
+                            <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                {% for key, label, class in settings.PROJECT_SNAPSHOT_EXPORTS %}
+                                <li>
+                                    <a href="{% url 'snapshot_export' project.id snapshot.id key %}" target="_blank">
+                                        {{ label }}
+                                    </a>
+                                </li>
+                                {% endfor %}
+                            {% endif %}
+                            </ul>
+                        </span>
                     </td>
                 </tr>
                 {% endfor %}

--- a/rdmo/projects/urls/__init__.py
+++ b/rdmo/projects/urls/__init__.py
@@ -35,6 +35,7 @@ from ..views import (
     ProjectViewExportView,
     ProjectViewView,
     SnapshotCreateView,
+    SnapshotExportView,
     SnapshotRollbackView,
     SnapshotUpdateView,
 )
@@ -109,6 +110,8 @@ urlpatterns = [
             SnapshotUpdateView.as_view(), name='snapshot_update'),
     re_path(r'^(?P<project_id>[0-9]+)/snapshots/(?P<pk>[0-9]+)/rollback/$',
             SnapshotRollbackView.as_view(), name='snapshot_rollback'),
+    re_path(r'^(?P<project_id>[0-9]+)/snapshots/(?P<pk>[0-9]+)/export/(?P<format>[a-z-]+)/$',
+            SnapshotExportView.as_view(), name='snapshot_export'),
 
     re_path(r'^(?P<pk>[0-9]+)/answers/$',
             ProjectAnswersView.as_view(), name='project_answers'),

--- a/rdmo/projects/views/__init__.py
+++ b/rdmo/projects/views/__init__.py
@@ -25,4 +25,4 @@ from .project_update import (
     ProjectUpdateViewsView,
 )
 from .project_view import ProjectViewExportView, ProjectViewView
-from .snapshot import SnapshotCreateView, SnapshotRollbackView, SnapshotUpdateView
+from .snapshot import SnapshotCreateView, SnapshotExportView, SnapshotRollbackView, SnapshotUpdateView

--- a/testing/config/settings/base.py
+++ b/testing/config/settings/base.py
@@ -71,6 +71,10 @@ PROJECT_SEND_INVITE = True
 
 PROJECT_REMOVE_VIEWS = True
 
+PROJECT_SNAPSHOT_EXPORTS = [
+    ('xml', _('RDMO XML'), 'rdmo.projects.exports.RDMOXMLExport'),
+]
+
 EMAIL_RECIPIENTS_CHOICES = [
     ('email@example.com', 'Emmi Email <email@example.com>'),
 ]


### PR DESCRIPTION
This PR adds `PROJECT_SNAPSHOT_EXPORTS` to settings and enables the user to export single snapshots using project export plugins from this list. Those plugins need to be slightly refactored to handle snapshots instead of projects.