### PR TITLE
Update attribute admin

### DIFF
--- a/rdmo/domain/models.py
+++ b/rdmo/domain/models.py
@@ -58,7 +58,7 @@ class Attribute(MPTTModel):
         verbose_name_plural = _('Attributes')
 
     def __str__(self):
-        return self.path
+        return self.uri
 
     def save(self, *args, **kwargs):
         self.path = self.build_path(self.key, self.parent)


### PR DESCRIPTION
This *tiny* change just uses the `uri` instead of `path` when representing an `Attribute` as string. This is especially helpful in `ValueAdmin`... 