### PR TITLE
Fix: remove views from projects if catalog is changed

### DIFF
--- a/rdmo/projects/handlers.py
+++ b/rdmo/projects/handlers.py
@@ -1,0 +1,25 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from rdmo.projects.models import Project
+from rdmo.views.models import View
+
+
+@receiver(post_save, sender=Project)
+def update_views_on_catalog_change(sender, instance, **kwargs):
+    # remove views that are no longer available
+    view_candidates = instance.views.exclude(catalogs__in=[instance.catalog]) \
+                                    .exclude(catalogs=None)
+
+    for view in view_candidates:
+        instance.views.remove(view)
+
+    # add views that are now available
+    view_candidates = View.objects.exclude(id__in=[v.id for v in instance.views.all()]) \
+                                  .filter_current_site() \
+                                  .filter_catalog(instance.catalog)
+                                #   .filter_group(self.request.user) \
+                                #   .filter_availability(self.request.user).exists()
+
+    for view in view_candidates:
+        instance.views.add(view)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --->
As described in #1198, if the project's catalog is changed, views that are no longer available are not remove. This PR implements this.

In addition, it sketches the addition of now available views to the project. However, as the user is not available, this is not yet working. If we find a solution, we might similarly, add this if the view is changed in the management interface which currently also implements the removal only.

As the buildin signal post_save does not contain the request object, we may need to move to a custom signal in order to enable filtering based on groups and availability for the user.

ToBeDone:

- [ ] Add tests
- [ ] Decide on automatically adding views to projects (maybe also enabled by setting?)
- [ ] Change to custom signal/include filtering of views based on user permissions
- [ ] Implement adding of views to other signals. 

<!--- Please link to a related issue here --->
Related issue: #1198

