### PR TITLE
Add max length validation to translated fields

### DIFF
--- a/rdmo/core/serializers.py
+++ b/rdmo/core/serializers.py
@@ -59,12 +59,16 @@ class TranslationSerializerMixin:
                 field_name = f'{field}_{lang_field}'
                 model_field = meta.model._meta.get_field(field_name)
 
+                validators = []
+                if hasattr(model_field, 'max_length') and model_field.max_length is not None:
+                    validators.append(MaxLengthValidator(model_field.max_length))
+
                 self.fields[f'{field}_{lang_code}'] = serializers.CharField(
                     source=field_name,
                     required=not model_field.blank,
                     allow_null=model_field.null,
                     allow_blank=model_field.blank,
-                    validators=[MaxLengthValidator(model_field.max_length)]
+                    validators=validators
                 )
 
 

--- a/rdmo/core/serializers.py
+++ b/rdmo/core/serializers.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
+from django.core.validators import MaxLengthValidator
 from django.db.models import Max
 
 from rest_framework import serializers
@@ -62,7 +63,9 @@ class TranslationSerializerMixin:
                     source=field_name,
                     required=not model_field.blank,
                     allow_null=model_field.null,
-                    allow_blank=model_field.blank)
+                    allow_blank=model_field.blank,
+                    validators=[MaxLengthValidator(model_field.max_length)]
+                )
 
 
 class ThroughModelSerializerMixin:

--- a/rdmo/questions/tests/test_viewset_page.py
+++ b/rdmo/questions/tests/test_viewset_page.py
@@ -347,3 +347,19 @@ def test_detail_export_full(db, client):
     assert 'http://example.com/terms/domain/conditions' in uris
     assert 'http://example.com/terms/options/one_two_three' in uris
     assert 'http://example.com/terms/options/one_two_three/one' in uris
+
+def test_update_page_field_validation_short_title(db, client):
+    username = password = 'editor'
+    client.login(username=username, password=password)
+    instance = Page.objects.first()
+    very_long_title = 'short_title, ' * 10
+
+    url = reverse(urlnames['detail'], args=[instance.pk])
+    data = {
+        'uri_prefix': instance.uri_prefix,
+        'uri_path': instance.uri_path,
+        'short_title_en': very_long_title,
+    }
+    response = client.put(url, data, content_type='application/json')
+    assert response.status_code == 400
+    assert response.json() == {'short_title_en': ['Ensure this value has at most 32 characters (it has 129).']}

--- a/rdmo/questions/tests/test_viewset_section.py
+++ b/rdmo/questions/tests/test_viewset_section.py
@@ -292,3 +292,20 @@ def test_detail_export_full(db, client):
     assert 'http://example.com/terms/domain/conditions' in uris
     assert 'http://example.com/terms/options/one_two_three' in uris
     assert 'http://example.com/terms/options/one_two_three/one' in uris
+
+
+def test_update_section_field_validation_short_title(db: object, client: object) -> None:
+    username = password = 'editor'
+    client.login(username=username, password=password)
+    instance = Section.objects.first()
+    very_long_title = 'short_title, ' * 10
+
+    url = reverse(urlnames['detail'], args=[instance.pk])
+    data = {
+        'uri_prefix': instance.uri_prefix,
+        'uri_path': instance.uri_path,
+        'short_title_de': very_long_title,
+    }
+    response = client.put(url, data, content_type='application/json')
+    assert response.status_code == 400
+    assert response.json() == {'short_title_de': ['Ensure this value has at most 32 characters (it has 129).']}


### PR DESCRIPTION
<!--- These comments are hidden when you submit the pull request, --->
<!--- so you do not need to remove them. --->

<!--- Before opening a pull request, go over all the following points: --->
<!--- * I have read the contributor guide (CONTRIBUTING.md) --->
<!--- * My code follows the code style of this project --->
<!--- * I added tests to cover my changes --->
<!--- * If needed, I updated the documentation --->
<!--- * If needed, I added translations if they are needed --->
<!--- * If needed, I added migration files and checked for potential conflicts --->

<!--- This project only accepts pull requests related to open issues. --->
<!--- If suggesting a new feature or change, please discuss it in an issue first. --->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. --->

<!--- Please provide a general summary of your changes in the title of the pull request --->

## Description
<!--- Describe your changes in detail --->

<!--- Please link to a related issue here --->
Related issue: #1244

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --->

Currently, translated fields are not validated for the max length. This PR adds it.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

## Screenshots (if appropriate)

<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
