### PR TITLE
Markdown templates

### DIFF
--- a/rdmo/core/assets/js/components/Html.js
+++ b/rdmo/core/assets/js/components/Html.js
@@ -10,19 +10,21 @@ const Html = ({ html = '' }) => {
 
   // if html contains a <script> tag, and settings.TEMPLATES_EXECUTE_SCRIPT_TAGS is True,
   // it will be executed using the method in https://macarthur.me/posts/script-tags-in-react/
-  useLayoutEffect(() => {
-    if (ref.current && executeScriptTags) {
-      // create a range objectm, set it contain the referenced node
-      // and create a new fragment with the html code within that range
-      const range = document.createRange()
-      range.selectNode(ref.current)
-      const documentFragment = range.createContextualFragment(html)
+  if (executeScriptTags) {
+    useLayoutEffect(() => {
+      if (ref.current) {
+        // create a range objectm, set it contain the referenced node
+        // and create a new fragment with the html code within that range
+        const range = document.createRange()
+        range.selectNode(ref.current)
+        const documentFragment = range.createContextualFragment(html)
 
-      // remove the rendered html and inject it again, triggering a re-run of the JS code
-      ref.current.innerHTML = ''
-      ref.current.append(documentFragment)
-    }
-  }, [html])
+        // remove the rendered html and inject it again, triggering a re-run of the JS code
+        ref.current.innerHTML = ''
+        ref.current.append(documentFragment)
+      }
+    }, [html])
+  }
 
   return !isEmpty(html) && (
     <div ref={ref} dangerouslySetInnerHTML={{ __html: html }} />

--- a/rdmo/core/assets/js/components/Html.js
+++ b/rdmo/core/assets/js/components/Html.js
@@ -2,13 +2,16 @@ import React, { useRef, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 import { isEmpty } from 'lodash'
 
+import { executeScriptTags } from 'rdmo/core/assets/js/utils/meta'
+
+
 const Html = ({ html = '' }) => {
   const ref = useRef()
 
-  // if html contains any element with `data-execute="true"`, it will be executed
-  // using the method in https://macarthur.me/posts/script-tags-in-react/
+  // if html contains a <script> tag, and settings.TEMPLATES_EXECUTE_SCRIPT_TAGS is True,
+  // it will be executed using the method in https://macarthur.me/posts/script-tags-in-react/
   useLayoutEffect(() => {
-    if (ref.current && !isEmpty(ref.current.querySelectorAll('[data-execute="true"]'))) {
+    if (ref.current && executeScriptTags) {
       // create a range objectm, set it contain the referenced node
       // and create a new fragment with the html code within that range
       const range = document.createRange()

--- a/rdmo/core/assets/js/components/Html.js
+++ b/rdmo/core/assets/js/components/Html.js
@@ -1,10 +1,28 @@
-import React from 'react'
+import React, { useRef, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 import { isEmpty } from 'lodash'
 
 const Html = ({ html = '' }) => {
+  const ref = useRef()
+
+  // if html contains any element with `data-execute="true"`, it will be executed
+  // using the method in https://macarthur.me/posts/script-tags-in-react/
+  useLayoutEffect(() => {
+    if (ref.current && !isEmpty(ref.current.querySelectorAll('[data-execute="true"]'))) {
+      // create a range objectm, set it contain the referenced node
+      // and create a new fragment with the html code within that range
+      const range = document.createRange()
+      range.selectNode(ref.current)
+      const documentFragment = range.createContextualFragment(html)
+
+      // remove the rendered html and inject it again, triggering a re-run of the JS code
+      ref.current.innerHTML = ''
+      ref.current.append(documentFragment)
+    }
+  }, [html])
+
   return !isEmpty(html) && (
-    <div dangerouslySetInnerHTML={{ __html: html }} />
+    <div ref={ref} dangerouslySetInnerHTML={{ __html: html }} />
   )
 }
 

--- a/rdmo/core/assets/js/utils/meta.js
+++ b/rdmo/core/assets/js/utils/meta.js
@@ -8,4 +8,4 @@ export const siteId = Number(document.querySelector('meta[name="site_id"]').cont
 
 export const language = document.querySelector('meta[name="language"]').content
 
-export const executeScriptTags = document.querySelector('meta[name="execute_script_tags"]').content === 'true'
+export const executeScriptTags = document.querySelector('meta[name="execute_script_tags"]')?.content === 'true'

--- a/rdmo/core/assets/js/utils/meta.js
+++ b/rdmo/core/assets/js/utils/meta.js
@@ -7,3 +7,5 @@ export const staticUrl = document.querySelector('meta[name="staticurl"]').conten
 export const siteId = Number(document.querySelector('meta[name="site_id"]').content)
 
 export const language = document.querySelector('meta[name="language"]').content
+
+export const executeScriptTags = document.querySelector('meta[name="execute_script_tags"]').content === 'true'

--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -309,6 +309,10 @@ EXPORT_CONTENT_DISPOSITION = 'attachment'
 
 EXPORT_MIN_REQUIRED_VERSION = '2.1.0'
 
+MARKDOWN_TEMPLATES: dict[str, str] = {
+    # for example: 'not_empty': 'core/text_blocks/template_for_not_empty.html',
+}
+
 PROJECT_TABLE_PAGE_SIZE = 20
 
 PROJECT_VISIBILITY = True

--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -415,3 +415,7 @@ REPLACE_MISSING_TRANSLATION = False
 
 # necessary since django 3.2, explicitly set primary key type to avoid warnings
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+MARKDOWN_TEMPLATES: dict[str, str] = {
+    # for example: 'not_empty': 'core/text_blocks/template_for_not_empty.html',
+}

--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -220,7 +220,8 @@ SETTINGS_EXPORT = [
     'PROJECT_SEND_ISSUE',
     'NESTED_PROJECTS',
     'PROJECT_VIEWS_SYNC',
-    'PROJECT_TASKS_SYNC'
+    'PROJECT_TASKS_SYNC',
+    'TEMPLATES_EXECUTE_SCRIPT_TAGS'
 ]
 
 SETTINGS_API = [
@@ -250,6 +251,8 @@ TEMPLATES_API = [
     'projects/project_interview_questionset_help.html',
     'projects/project_interview_sidebar.html',
 ]
+
+TEMPLATES_EXECUTE_SCRIPT_TAGS = False
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'info@example.com'
@@ -419,7 +422,3 @@ REPLACE_MISSING_TRANSLATION = False
 
 # necessary since django 3.2, explicitly set primary key type to avoid warnings
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-
-MARKDOWN_TEMPLATES: dict[str, str] = {
-    # for example: 'not_empty': 'core/text_blocks/template_for_not_empty.html',
-}

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
-from django.template.loader import get_template
+from django.template.loader import get_template, render_to_string
 from django.utils.dateparse import parse_date
 from django.utils.encoding import force_str
 from django.utils.formats import get_format
@@ -267,6 +267,18 @@ def markdown2html(markdown_string):
         f'<span class="show-less" onclick="showLess(this)"> ({hide_string})</span></p>',
         html
     )
+    html = inject_textblocks(html)
+    return html
+
+
+def inject_textblocks(html):
+    '''textblocks (e.g. for help texts) can be injected into free text fields as small templates via Markdown'''
+    for textblock_id in re.findall(r'{{(.*?)}}', html):      # strings between curly brackets
+        template_path:  str = settings.MARKDOWN_TEMPLATES[textblock_id]
+        html                = re.sub(   '{{' + textblock_id + '}}',
+                                        render_to_string(template_path),
+                                        html
+                                    )
     return html
 
 

--- a/rdmo/core/utils.py
+++ b/rdmo/core/utils.py
@@ -267,18 +267,19 @@ def markdown2html(markdown_string):
         f'<span class="show-less" onclick="showLess(this)"> ({hide_string})</span></p>',
         html
     )
+
+    # textblocks (e.g. for help texts) can be injected into free text fields as small templates via Markdown
     html = inject_textblocks(html)
+
     return html
 
 
 def inject_textblocks(html):
-    '''textblocks (e.g. for help texts) can be injected into free text fields as small templates via Markdown'''
-    for textblock_id in re.findall(r'{{(.*?)}}', html):      # strings between curly brackets
-        template_path:  str = settings.MARKDOWN_TEMPLATES[textblock_id]
-        html                = re.sub(   '{{' + textblock_id + '}}',
-                                        render_to_string(template_path),
-                                        html
-                                    )
+    # loop over all strings between curly brackets, e.g. {{ test }}
+    for template_code in re.findall(r'{{(.*?)}}', html):
+        template_name = settings.MARKDOWN_TEMPLATES.get(template_code.strip())
+        if template_name:
+            html = re.sub('{{' + template_code + '}}', render_to_string(template_name), html)
     return html
 
 

--- a/rdmo/projects/templates/projects/project_interview.html
+++ b/rdmo/projects/templates/projects/project_interview.html
@@ -4,7 +4,8 @@
 {% load core_tags %}
 
 {% block head %}
-    <meta name='project' content="{{ project.id }}" />
+    <meta name="project" content="{{ project.id }}" />
+    <meta name="execute_script_tags" content="{{ settings.TEMPLATES_EXECUTE_SCRIPT_TAGS|lower }}" />
 {% endblock %}
 
 {% block css %}

--- a/rdmo/projects/templates/projects/project_interview.html
+++ b/rdmo/projects/templates/projects/project_interview.html
@@ -4,8 +4,8 @@
 {% load core_tags %}
 
 {% block head %}
-    <meta name="project" content="{{ project.id }}" />
-    <meta name="execute_script_tags" content="{{ settings.TEMPLATES_EXECUTE_SCRIPT_TAGS|lower }}" />
+    <meta name='project' content="{{ project.id }}" />
+    <meta name='execute_script_tags' content="{{ settings.TEMPLATES_EXECUTE_SCRIPT_TAGS|lower }}" />
 {% endblock %}
 
 {% block css %}


### PR DESCRIPTION
This PR is the sequel to https://github.com/rdmorganiser/rdmo/pull/1174. It refactors some code and adds code to execute the JS in templates. The feature can be tested with `{{test}}` in a help text of a question and:

```
<p>
    TEST!
</p>
<script>
    (function() {
        const elements = document.getElementsByTagName('p');
        setTimeout(function() {
            for (const element of elements) {
              element.style["color"] = "red";
            }
        }, 1000)
    })()
</script>
```

in `local_app/templates/local/test.html` and 

```
INSTALLED_APPS += ['local_app']
MARKDOWN_TEMPLATES = {
    'test': 'local/test.html'
}
TEMPLATES_EXECUTE_SCRIPT_TAGS = True
```

in `config/settings/local.py`.

@MyPyDavid I am not 100% convinced about the approach in `HTML.js`, please check. The source is https://macarthur.me/posts/script-tags-in-react/.