### PR TITLE
Show default and optional for questions in the management (#982)

### DIFF
--- a/rdmo/core/static/core/css/base.scss
+++ b/rdmo/core/static/core/css/base.scss
@@ -137,6 +137,14 @@ code {
         color: rgb(96, 96, 96);
         background-color: rgba(96, 96, 96, 0.1);
     }
+    &.code-default {
+        color: rgb(96, 96, 96);
+        background-color: rgba(96, 96, 96, 0.1);
+    }
+    &.code-optional {
+        color: white;
+        background-color: rgb(119.085, 119.085, 119.085);
+    }
     &.code-import {
         color: black;
         background-color: rgba(96, 96, 96, 0.1);

--- a/rdmo/management/assets/js/components/common/Links.js
+++ b/rdmo/management/assets/js/components/common/Links.js
@@ -205,7 +205,7 @@ const CodeLink = ({ className, uri, href, onClick, order }) => {
         <code className={className}>{uri}</code>
       </Link>
       {!isNil(order) ? (
-        <>{' '}<code className="code-order ng-binding">{order}</code></>
+        <>{' '}<code className="code-order">{order}</code></>
       ) : null}
     </>
   )

--- a/rdmo/management/assets/js/components/element/Question.js
+++ b/rdmo/management/assets/js/components/element/Question.js
@@ -45,9 +45,19 @@ const Question = ({ config, question, elementActions, display='list', indent=0,
       </div>
       <div>
         <p>
-          <strong className={question.is_optional ? 'text-muted' : ''}>{gettext('Question')}{': '}</strong>
+          <strong>{gettext('Question')}{': '}</strong>
           <span dangerouslySetInnerHTML={{ __html: question.text }}></span>
         </p>
+        {
+          question.is_optional && <p>
+            <code className="code-optional" title={gettext('This is an optional question.')}>{gettext('optional')}</code>
+          </p>
+        }
+        {
+          (question.default_text || question.default_option || question.default_external_id) && <p>
+            <code className="code-default" title={gettext('This question has a default answer.')}>{gettext('default')}</code>
+          </p>
+        }
         {
           get(config, 'display.uri.questions', true) && <p>
             <CodeLink


### PR DESCRIPTION
Fixes #982.

![image](https://github.com/user-attachments/assets/e69594b6-f3d4-4039-aee5-6b6ea33c2421)

(Removes the barely visible gray title for optional questions).
