### PR TITLE
Improve warnings in management (#1070)

### DIFF
--- a/rdmo/core/serializers.py
+++ b/rdmo/core/serializers.py
@@ -194,7 +194,9 @@ class ElementModelSerializerMixin(serializers.ModelSerializer):
 class ElementWarningSerializerMixin(serializers.ModelSerializer):
 
     def get_warning(self, obj):
-        return any(get_language_warning(obj, field_name) for field_name in self.Meta.warning_fields)
+        return {
+            'missing_languages': any(get_language_warning(obj, field_name) for field_name in self.Meta.warning_fields)
+        }
 
 
 class ReadOnlyObjectPermissionSerializerMixin:

--- a/rdmo/management/assets/js/actions/elementActions.js
+++ b/rdmo/management/assets/js/actions/elementActions.js
@@ -19,7 +19,7 @@ import ViewsFactory from '../factories/ViewsFactory'
 
 import { elementTypes } from '../constants/elements'
 import { updateLocation } from '../utils/location'
-import { canMoveElement, findDescendants, moveElement } from '../utils/elements'
+import { canMoveElement, findDescendants, moveElement, updateWarning } from '../utils/elements'
 
 export function fetchElements(elementType) {
   const pendingId = `fetchElements/${elementType}`
@@ -122,7 +122,7 @@ export function fetchElement(elementType, elementId, elementAction=null) {
       case 'catalogs':
         if (elementAction == 'nested') {
           action = () => QuestionsApi.fetchCatalog(elementId, 'nested')
-            .then(element => ({ element }))
+            .then(element => ({ element: updateWarning(element) }))
         } else {
           action = () => Promise.all([
             QuestionsApi.fetchCatalog(elementId),

--- a/rdmo/management/assets/js/components/element/Question.js
+++ b/rdmo/management/assets/js/components/element/Question.js
@@ -99,6 +99,33 @@ const Question = ({ config, question, elementActions, display='list', indent=0,
             </p>
           ))
         }
+        {
+          question.warning && (
+            <ul className="list-unstyled mb-0">
+            {
+              question.warning.no_attribute && (
+                <li className="text-danger">
+                  {gettext('Error: No attribute is set for this question!')}
+                </li>
+              )
+            }
+            {
+              question.warning.double_attribute && (
+                <li className="text-danger">
+                  {gettext('Error: The attribute for this question is used several times (in this catalog).')}
+                </li>
+              )
+            }
+            {
+              question.warning.missing_languages && (
+                <li className="text-warning">
+                  {gettext('Warning: Some of the language specific fields are not set properly.')}
+                </li>
+              )
+            }
+            </ul>
+          )
+        }
         <ElementErrors element={question} />
       </div>
     </div>

--- a/rdmo/management/assets/js/utils/elements.js
+++ b/rdmo/management/assets/js/utils/elements.js
@@ -161,6 +161,18 @@ function findDescendants(element, elementType) {
   }
 }
 
+function updateWarning(element) {
+  const questions = findDescendants(element, 'questions')
+  questions.forEach(question => {
+    if (isNil(question.attribute)) {
+      question.warning.no_attribute = true
+    } else if (questions.filter(q => q.attribute == question.attribute).length > 1) {
+      question.warning.double_attribute = true
+    }
+  })
+  return element
+}
+
 const buildUri = (element) => {
   if (isUndefined(element.uri_prefix) || isUndefined(element.model)) {
     return null
@@ -196,4 +208,5 @@ const buildPathForAttribute = (key, parentUri) => {
 
 
 
-export { compareElements, updateElement, resetElement, canMoveElement, moveElement, findDescendants, buildUri, buildPathForAttribute }
+export { compareElements, updateElement, resetElement, canMoveElement, moveElement, findDescendants,
+         updateWarning, buildUri, buildPathForAttribute }


### PR DESCRIPTION
This PR improves the warnings in management:

* check if a question does not have an attribute
* check if the `missing_language` flag is set (slight refactoring of `ElementWarningSerializerMixin`
* (only in the nested catalog view) check if a catalog is used twice