### PR TITLE
Fix legacy import for autocomplete and (partially) revert xml test file

### DIFF
--- a/rdmo/core/xml.py
+++ b/rdmo/core/xml.py
@@ -261,6 +261,9 @@ def convert_elements(elements, version: Version):
     if version < parse('2.1.0'):
         elements = convert_additional_input(elements)
 
+    if version < parse('2.3.0'):
+        elements = convert_autocomplete(elements)
+
     return elements
 
 
@@ -402,6 +405,17 @@ def convert_additional_input(elements):
                 element['additional_input'] = 'text'
             else:
                 element['additional_input'] = ''
+
+    return elements
+
+
+def convert_autocomplete(elements):
+    for uri, element in elements.items():
+        if element['model'] == 'questions.question':
+            if element['widget_type'] == 'autocomplete':
+                element['widget_type'] = 'select'
+            elif element['widget_type'] == 'freeautocomplete':
+                element['widget_type'] = 'select_creatable'
 
     return elements
 

--- a/testing/xml/elements/legacy/questions.xml
+++ b/testing/xml/elements/legacy/questions.xml
@@ -326,7 +326,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option dc:uri="http://example.com/terms/options/one_two_three/one"/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -810,7 +810,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -1248,7 +1248,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -1562,7 +1562,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -1910,7 +1910,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -2224,7 +2224,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -3722,7 +3722,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id>simple_1</default_external_id>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -3935,7 +3935,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option dc:uri="http://example.com/terms/options/one_two_three/three"/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>


### PR DESCRIPTION
This PR fixes the import of questions with the old `autocomplete` and `freeautocomplete` widget types. It also reverts some of the changes to the text xml files ... :roll_eyes: 