### PR TITLE
2.3.0 more fixes

### DIFF
--- a/rdmo/core/assets/js/api/BaseApi.js
+++ b/rdmo/core/assets/js/api/BaseApi.js
@@ -15,7 +15,15 @@ function ValidationError(errors) {
   this.errors = errors
 }
 
-function BadRequestError(errors) {
+function BadRequestError(statusText, status, errors) {
+  this.status = status
+  this.statusText = statusText
+  this.errors = errors
+}
+
+function NotFoundError(statusText, status, errors) {
+  this.status = status
+  this.statusText = statusText
   this.errors = errors
 }
 
@@ -29,14 +37,17 @@ class BaseApi {
         return response.json()
       } else if (response.status === 400) {
         return response.json().then(errors => {
-          throw new BadRequestError(errors)
+          throw new BadRequestError(response.statusText, response.status, errors)
+        })
+      } else if (response.status === 404) {
+        return response.json().then(errors => {
+          throw new NotFoundError(response.statusText, response.status, errors)
         })
       } else {
         throw new ApiError(response.statusText, response.status)
       }
     })
   }
-
 
   static post(url, data) {
     return fetch(baseUrl + url, {

--- a/rdmo/core/pandoc.py
+++ b/rdmo/core/pandoc.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from tempfile import mkstemp
+from tempfile import NamedTemporaryFile
 
 from django.apps import apps
 from django.conf import settings
@@ -19,12 +19,18 @@ def get_pandoc_version():
     return parse_version(pypandoc.get_pandoc_version())
 
 
+def create_tmp_file(suffix):
+    # create a temporary file, return the file path, and close it immediately
+    with NamedTemporaryFile('wb+', suffix=suffix, delete=False) as fp:
+        return Path(fp.name)
+
+
 def get_pandoc_content(html, metadata, export_format, context):
     pandoc_args = get_pandoc_args(export_format, context)
 
     if metadata:
-        # create a temporary file for the metadata
-        (metadata_tmp_fd, metadata_tmp_file_name) = mkstemp(suffix='.json')
+        # create a temporary file for the metadata and close it immediately
+        metadata_tmp_file_name = create_tmp_file('.json')
 
         # save metadata
         log.info('Save metadata file %s %s', metadata_tmp_file_name, str(metadata))
@@ -34,8 +40,8 @@ def get_pandoc_content(html, metadata, export_format, context):
         # add metadata file to pandoc args
         pandoc_args.append('--metadata-file=' + metadata_tmp_file_name)
 
-    # create a temporary file
-    (tmp_fd, tmp_file_name) = mkstemp(f'.{export_format}')
+    # create a temporary file and close it immediately
+    tmp_file_name = create_tmp_file(f'.{export_format}')
 
     # convert the file using pandoc
     log.info('Export %s document using args %s.', export_format, pandoc_args)

--- a/rdmo/core/xml.py
+++ b/rdmo/core/xml.py
@@ -261,6 +261,9 @@ def convert_elements(elements, version: Version):
     if version < parse('2.1.0'):
         elements = convert_additional_input(elements)
 
+    if version < parse('2.3.0'):
+        elements = convert_autocomplete(elements)
+
     return elements
 
 
@@ -402,6 +405,17 @@ def convert_additional_input(elements):
                 element['additional_input'] = 'text'
             else:
                 element['additional_input'] = ''
+
+    return elements
+
+
+def convert_autocomplete(elements):
+    for uri, element in elements.items():
+        if element['model'] == 'questions.question':
+            if element['widget_type'] == 'autocomplete':
+                element['widget_type'] = 'select'
+            elif element['widget_type'] == 'freeautocomplete':
+                element['widget_type'] = 'select_creatable'
 
     return elements
 

--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -72,6 +72,7 @@ export function fetchPage(pageId, back) {
       updateLocation('done')
       dispatch(fetchNavigation(null))
       dispatch(fetchPageSuccess(null, true))
+      dispatch(removeFromPending(pendingId))
     } else {
       const promise = isNil(pageId) ? PageApi.fetchContinue(projectId)
                                     : PageApi.fetchPage(projectId, pageId, back)
@@ -90,7 +91,11 @@ export function fetchPage(pageId, back) {
         })
         .catch((error) => {
           dispatch(removeFromPending(pendingId))
-          dispatch(fetchPageError(error))
+          if (error.errors.done) {
+            dispatch(fetchPage('done'))
+          } else {
+            dispatch(fetchPageError(error))
+          }
         })
     }
   }

--- a/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
@@ -145,9 +145,11 @@ const PageHead = ({ templates, page, sets, values, disabled, currentSet,
             }
           </>
         ) : (
-          <button role="button" className="btn btn-success" title={labels.add} onClick={createModal.open}>
-            <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(page.verbose_name)}
-          </button>
+          !disabled && (
+            <button role="button" className="btn btn-success" title={labels.add} onClick={createModal.open}>
+              <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(page.verbose_name)}
+            </button>
+          )
         )
       }
 

--- a/rdmo/projects/assets/js/projects/components/main/Projects.js
+++ b/rdmo/projects/assets/js/projects/components/main/Projects.js
@@ -140,7 +140,7 @@ const Projects = ({ config, configActions, currentUserObject, projectsActions, p
     owner: (_content, row) => (
       <>
         <p>
-          {row.owners.map(owner => `${owner.first_name} ${owner.last_name}`).join('; ')}
+          {row.owners.map(owner => owner.full_name).join('; ')}
         </p>
         {
           row.visibility && <p className="text-muted">{row.visibility}</p>

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -428,6 +428,10 @@ $variant-background-color: #f5f5f5 !default;
 
     .react-select {
         max-width: 100%;
+
+        .react-select__menu {
+            z-index: 10;
+        }
     }
 }
 

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from rdmo.accounts.utils import get_full_name
 from rdmo.domain.models import Attribute
 from rdmo.questions.models import Catalog
 from rdmo.services.validators import ProviderValidator
@@ -27,6 +28,8 @@ from ...validators import ProjectParentValidator, ValueConflictValidator, ValueQ
 
 class UserSerializer(serializers.ModelSerializer):
 
+    full_name = serializers.SerializerMethodField()
+
     class Meta:
         model = get_user_model()
         fields = [
@@ -37,8 +40,12 @@ class UserSerializer(serializers.ModelSerializer):
                 'username',
                 'first_name',
                 'last_name',
+                'full_name',
                 'email'
             ]
+
+    def get_full_name(self, obj):
+        return get_full_name(obj)
 
 
 class ProjectSerializer(serializers.ModelSerializer):

--- a/rdmo/projects/tests/test_viewset_project_page.py
+++ b/rdmo/projects/tests/test_viewset_project_page.py
@@ -25,7 +25,9 @@ view_questionset_permission_map = {
 
 urlnames = {
     'list': 'v1-projects:project-page-list',
-    'detail': 'v1-projects:project-page-detail'
+    'detail': 'v1-projects:project-page-detail',
+    'continue': 'v1-projects:project-page-get-continue',
+
 }
 
 projects = [1, 2, 3, 4, 5, 12]
@@ -125,3 +127,34 @@ def test_detail_page_resolve_next_relevant_page(db, client, direction):
     # a get on the redirected url as a double check
     response_next_relevant = client.get(response_next.url)
     assert response_next_relevant.status_code == 200
+
+
+@pytest.mark.parametrize('username,password', users)
+@pytest.mark.parametrize('project_id', projects)
+def test_continue(db, client, username, password, project_id):
+    client.login(username=username, password=password)
+
+    url = reverse(urlnames['continue'], args=[project_id])
+    response = client.get(url)
+
+    if project_id in view_questionset_permission_map.get(username, []):
+        assert response.status_code == 200
+        assert response.json().get('id') == 1  # == catalog_id
+        assert response.json().get('prev_page') is None  # at start
+    else:
+        assert response.status_code == 404
+
+
+def test_continue_catalog_without_pages(db, client):
+    from rdmo.questions.models.page import Page
+    project_id = 1
+    username = 'owner'
+    Page.objects.all().delete()
+
+    client.login(username=username, password=username)
+
+    url = reverse(urlnames['continue'], args=[project_id])
+    response = client.get(url)
+
+    if project_id in view_questionset_permission_map.get(username, []):
+        assert response.status_code == 404

--- a/rdmo/projects/views/project_update.py
+++ b/rdmo/projects/views/project_update.py
@@ -33,7 +33,8 @@ class ProjectUpdateView(ObjectPermissionMixin, RedirectViewMixin, UpdateView):
     def get_form_kwargs(self):
         catalogs = Catalog.objects.filter_current_site() \
                                   .filter_group(self.request.user) \
-                                  .filter_availability(self.request.user)
+                                  .filter_availability(self.request.user) \
+                                  .order_by('order')
         projects = Project.objects.filter_user(self.request.user)
 
         form_kwargs = super().get_form_kwargs()
@@ -68,7 +69,8 @@ class ProjectUpdateCatalogView(ObjectPermissionMixin, RedirectViewMixin, UpdateV
     def get_form_kwargs(self):
         catalogs = Catalog.objects.filter_current_site() \
                                   .filter_group(self.request.user) \
-                                  .filter_availability(self.request.user)
+                                  .filter_availability(self.request.user) \
+                                  .order_by('order')
 
         form_kwargs = super().get_form_kwargs()
         form_kwargs.update({

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -645,7 +645,7 @@ class ProjectValueViewSet(ProjectNestedViewSetMixin, ModelViewSet):
         values = self.get_queryset().filter_set(set_value)
         values.delete()
 
-        return Response(status=204)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=['GET', 'POST'],
             permission_classes=(HasModelPermission | HasProjectPermission, ))
@@ -732,11 +732,20 @@ class ProjectPageViewSet(ProjectNestedViewSetMixin, RetrieveModelMixin, GenericV
                 return HttpResponseRedirect(url, status=303)
 
             # end of catalog, if no next relevant page is found
-            return Response(status=204)
+            return Response({
+                'detail': 'No Page matches the given query.',
+                'done': True
+            }, status=status.HTTP_404_NOT_FOUND)
 
 
     @action(detail=False, url_path='continue', permission_classes=(HasModelPermission | HasProjectPagePermission, ))
     def get_continue(self, request, pk=None, parent_lookup_project=None):
+        if not self.project.catalog.pages:
+            return Response({
+                'detail': 'No Page matches the given query.',
+                'done': True
+            }, status=status.HTTP_404_NOT_FOUND)
+
         try:
             continuation = Continuation.objects.get(project=self.project, user=self.request.user)
 

--- a/testing/xml/elements/legacy/questions.xml
+++ b/testing/xml/elements/legacy/questions.xml
@@ -326,7 +326,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option dc:uri="http://example.com/terms/options/one_two_three/one"/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -810,7 +810,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -1248,7 +1248,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -1562,7 +1562,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -1910,7 +1910,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -2224,7 +2224,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>option</value_type>
 		<maximum/>
 		<minimum/>
@@ -3722,7 +3722,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option/>
 		<default_external_id>simple_1</default_external_id>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
@@ -3935,7 +3935,7 @@
 		<verbose_name_plural lang="de"/>
 		<default_option dc:uri="http://example.com/terms/options/one_two_three/three"/>
 		<default_external_id/>
-		<widget_type>select_creatable</widget_type>
+		<widget_type>autocomplete</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>


### PR DESCRIPTION
This PR contains some more last-minute fixes for RDMO 2.3.0:

* Use the `full_name` from the server in the project table (fixes a visual bug if `first_name` and `last_name` are not set and is cleaner anyway)
* Fix the order of catalogs in the project update view
* Hide the "Add tab" button (when no tab is there) if `read_only` in the interview