### PR TITLE
Close temporary files

### DIFF
--- a/rdmo/core/pandoc.py
+++ b/rdmo/core/pandoc.py
@@ -23,8 +23,9 @@ def get_pandoc_content(html, metadata, export_format, context):
     pandoc_args = get_pandoc_args(export_format, context)
 
     if metadata:
-        # create a temporary file for the metadata
+        # create a temporary file for the metadata and close it immediately
         (metadata_tmp_fd, metadata_tmp_file_name) = mkstemp(suffix='.json')
+        os.close(metadata_tmp_fd)
 
         # save metadata
         log.info('Save metadata file %s %s', metadata_tmp_file_name, str(metadata))
@@ -34,8 +35,9 @@ def get_pandoc_content(html, metadata, export_format, context):
         # add metadata file to pandoc args
         pandoc_args.append('--metadata-file=' + metadata_tmp_file_name)
 
-    # create a temporary file
+    # create a temporary file and close it immediately
     (tmp_fd, tmp_file_name) = mkstemp(f'.{export_format}')
+    os.close(tmp_fd)
 
     # convert the file using pandoc
     log.info('Export %s document using args %s.', export_format, pandoc_args)


### PR DESCRIPTION
I found that `mkstemp` returns an open file, so that we have a lot of open files when testing ... which my Linux could not handle. This bug was only introduced with my refactoring of the pandoc stuff.