### PR TITLE
Openapi fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.management import call_command
 
 from rdmo.accounts.utils import set_group_permissions
@@ -54,3 +55,15 @@ def files(settings, tmp_path):
 def json_data():
     json_file = Path(settings.BASE_DIR) / 'import' / 'catalogs.json'
     return {'elements': json.loads(json_file.read_text())}
+
+
+@pytest.fixture
+def login(client):
+    def force_login_user(username):
+        try:
+            user = User.objects.get(username=username)
+            client.force_login(user)
+        except User.DoesNotExist:
+            pass
+
+    return force_login_user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
   "twine>=5.1.1,<7.0",
   "wheel>=0.42,<0.46",
   "rdmo[allauth]",
+  "rdmo[openapi]",
   "rdmo[pytest]",
 ]
 gunicorn = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ pytest = [
   "pytest-xdist>=3.3,<4.0",
 ]
 openapi = [
-  "drf-spectacular>=0.28.0,<1.0.0"
+  "drf-spectacular[sidecar]>=0.28.0,<1.0.0"
 ]
 
 [project.urls]

--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -202,7 +202,10 @@ SPECTACULAR_SETTINGS = {
     },
     'PREPROCESSING_HOOKS': [
         'rdmo.core.schema.filter_endpoints'
-    ]
+    ],
+    'SWAGGER_UI_DIST': 'SIDECAR',
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
 }
 
 SETTINGS_EXPORT = [

--- a/testing/config/settings/base.py
+++ b/testing/config/settings/base.py
@@ -66,7 +66,8 @@ ACCOUNT_SIGNUP = True
 SOCIALACCOUNT = False
 
 INSTALLED_APPS += [
-    'drf_spectacular'
+    'drf_spectacular',
+    'drf_spectacular_sidecar'
 ]
 
 REST_FRAMEWORK.update({

--- a/testing/config/settings/base.py
+++ b/testing/config/settings/base.py
@@ -65,6 +65,17 @@ ACCOUNT = True
 ACCOUNT_SIGNUP = True
 SOCIALACCOUNT = False
 
+INSTALLED_APPS += [
+    'drf_spectacular'
+]
+
+REST_FRAMEWORK.update({
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
+    'DEFAULT_VERSION': 'v1',
+    'ALLOWED_VERSIONS': ('v1', ),
+})
+
 PROJECT_TABLE_PAGE_SIZE = 5
 
 PROJECT_SEND_ISSUE = True

--- a/testing/config/urls.py
+++ b/testing/config/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
 
     path('', include('rdmo.core.urls')),
     path('api/v1/', include('rdmo.core.urls.v1')),
-    # path('api/v1/', include('rdmo.core.urls.v1.openapi', namespace='v1')),
+    path('api/v1/', include('rdmo.core.urls.v1.openapi', namespace='v1')),
 
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
This PR enables the tests for the `openapi` endpoints again. I added the optional dependency to the `dev` setup, because ... why not? We already test with `allauth` which is optional as well. The only drawback would be that we somehow mess up the settings *without* `openapi`, but I am pretty sure that we will notice this using e.g. a test deployment.

I changed the setup to use `drf_spectacular_sidecar` to not use CDNs. (We just got rid of them ...).

I also added a `login` fixture which we can use to force login users in the tests. TBD.
