### PR TITLE
2.3.0 fix local storage

### DIFF
--- a/rdmo/core/assets/js/utils/config.js
+++ b/rdmo/core/assets/js/utils/config.js
@@ -1,4 +1,4 @@
-import { set, unset, toNumber, isNaN } from 'lodash'
+import { set, unset } from 'lodash'
 
 const updateConfig = (config, path, value) => {
   const newConfig = {...config}
@@ -26,15 +26,10 @@ const getConfigFromLocalStorage = (prefix) => {
           return [path, true]
         } else if (lsValue === 'false') {
           return [path, false]
+        } else {
+          return [path, lsValue]
         }
 
-        // check if the value is number or a string
-        const numberValue = toNumber(lsValue)
-        if (isNaN(numberValue)) {
-          return [path, lsValue]
-        } else {
-          return [path, numberValue]
-        }
       } else {
         return null
       }

--- a/rdmo/core/assets/js/utils/config.js
+++ b/rdmo/core/assets/js/utils/config.js
@@ -17,23 +17,9 @@ const getConfigFromLocalStorage = (prefix) => {
 
   return Object.entries(ls)
     .filter(([lsPath,]) => lsPath.startsWith(prefix))
-    .map(([lsPath, lsValue]) => {
-      if (lsPath.startsWith(prefix)) {
-        const path = lsPath.replace(`${prefix}.`, '')
-
-        // check if it is literal 'true' or 'false'
-        if (lsValue === 'true') {
-          return [path, true]
-        } else if (lsValue === 'false') {
-          return [path, false]
-        } else {
-          return [path, lsValue]
-        }
-
-      } else {
-        return null
-      }
-    })
+    .map(([lsPath, lsValue]) => (
+      lsPath.startsWith(prefix) ? [lsPath.replace(`${prefix}.`, ''), lsValue] : null
+    ))
 }
 
 const setConfigInLocalStorage = (prefix, path, value) => {

--- a/rdmo/management/assets/js/components/common/Checkboxes.js
+++ b/rdmo/management/assets/js/components/common/Checkboxes.js
@@ -1,18 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Checkbox = ({ label, value, onChange }) => (
-  <span className="checkbox">
-    <label>
-        <input type="checkbox" checked={value} onChange={() => onChange(!value)} />
-        { label }
-    </label>
-  </span>
-)
+const Checkbox = ({ label, value, onChange }) => {
+  const checked = [true, 'true'].includes(value)  // values are stored as string in the local storage
+
+  return (
+    <span className="checkbox">
+      <label>
+          <input type="checkbox" checked={checked} onChange={() => onChange(!checked)} />
+          { label }
+      </label>
+    </span>
+  )
+}
 
 Checkbox.propTypes = {
   label: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  value: PropTypes.bool.isRequired,
+  value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
   onChange: PropTypes.func.isRequired
 }
 

--- a/rdmo/projects/assets/js/projects/components/helper/ProjectFilters.js
+++ b/rdmo/projects/assets/js/projects/components/helper/ProjectFilters.js
@@ -18,7 +18,7 @@ const ProjectFilters = ({ catalogs, config, configActions, isManager, projectsAc
     setEndDate
   } = useDatePicker()
 
-  const showFilters = get(config, 'showFilters', false)
+  const showFilters = [true, 'true'].includes(get(config, 'showFilters', false))
   const toggleFilters = () => configActions.updateConfig('showFilters', !showFilters)
 
   const resetAllFilters = () => {


### PR DESCRIPTION
This PR removes the (faulty) conversion to `Number` and to `Boolean` conversion when retrieving something from the local storage. The checkboxes in the management interface and the `showAll` flag in projects therefore need to check for `'true'` as well.

The `useLsState` hook works when storing an objects since it uses JSON serialization. Maybe we should only use JSON in the LS in the future and have less keys.