### PR TITLE
chore: remove obsolete warnings filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,12 +210,6 @@ filterwarnings = [
   # fail on RemovedInDjango50Warning exception
   "error::django.utils.deprecation.RemovedInDjango50Warning",
 
-  # ignore warnings raised from within coreapi 2.3.3
-  "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-
-  # ignore warning from rest_framework about coreapi
-  "ignore:CoreAPI compatibility is deprecated and will be removed in DRF 3.17:rest_framework.RemovedInDRF317Warning",
-
   # ignore warnings raised by widget_tweaks.py
   "ignore:'maxsplit' is passed as positional argument",
 


### PR DESCRIPTION
## Description

Remove obsolete warnings filter. These filters were set, when coreapi (django-rest-swagger) was used and it warned constantly about being deprecated. After #1248 and then #1303 have been merged, this is not necessary anymore.

## Motivation and Context

Clean up pyproject.toml clutter.

## How has this been tested?

I ran this change in my fork without problems.
