### PR TITLE
chore: group rdmo extras in dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,7 @@ dev = [
   "setuptools>=73,<79",
   "twine>=5.1.1,<7.0",
   "wheel>=0.42,<0.46",
-  "rdmo[allauth]",
-  "rdmo[openapi]",
-  "rdmo[pytest]",
+  "rdmo[allauth,openapi,pytest]",
 ]
 gunicorn = [
   "gunicorn>=23.0,<24.0",


### PR DESCRIPTION
## Description

This PR groups the used rdmo extra groups in the dev extra group.

## Motivation and Context

Clean up pyproject.toml clutter.

## How has this been tested?

I tested this change in my fork.
