### PR TITLE
2.3.1 UI fixes

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -285,6 +285,7 @@ export function storeValue(value) {
       const widget_type = question && question.widget_type
 
       const valueIndex = getState().interview.values.findIndex((v) => compareValues(v, value, widget_type))
+      const valueText = value.text
       const valueFile = value.file
       const valueSuccess = value.success
 
@@ -312,6 +313,12 @@ export function storeValue(value) {
           value.success = setTimeout(() => {
             dispatch(updateValue(value, {success: false}, false))
           }, 1000)
+
+          // replace the text with the old text if it was trimmed by the backend
+          // (but not if a new text was inserted, e.g. by an optionset provider)
+          if (valueText.trim() == value.text) {
+            value.text = valueText
+          }
 
           // check if there is a file or if a filename is set (when the file was just erased)
           if (isNil(valueFile) && isNil(value.file_name)) {

--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -13,7 +13,7 @@ import { updateLocation } from '../utils/location'
 import { updateOptions } from '../utils/options'
 import { initPage } from '../utils/page'
 import { copyResolvedConditions, gatherSets, getDescendants, initSets } from '../utils/set'
-import { activateFirstValue, gatherDefaultValues, initValues, compareValues, isEmptyValue } from '../utils/value'
+import { gatherDefaultValues, initValues, compareValues, isEmptyValue } from '../utils/value'
 import { projectId } from '../utils/meta'
 
 import ValueFactory from '../factories/ValueFactory'
@@ -196,8 +196,6 @@ export function fetchValues(page) {
 
         initSets(sets, page)
         initValues(sets, values, page)
-
-        activateFirstValue(page, values)
 
         dispatch(removeFromPending(pendingId))
         dispatch(resolveConditions(page, sets))

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import { isNil, minBy } from 'lodash'
@@ -14,6 +14,9 @@ import PageManagement from './PageManagement'
 const Page = ({ config, settings, templates, overview, page, sets, values, fetchPage, fetchContact,
                 createValue, updateValue, deleteValue, copyValue,
                 activateSet, createSet, updateSet, deleteSet, copySet }) => {
+
+  // scroll to top whenever the page changes
+  useEffect(() => window.scrollTo(0, 0), [page.id])
 
   const currentSetPrefix = ''
   let currentSetIndex = page.is_collection ? get(config, 'page.currentSetIndex', 0) : 0

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -15,9 +15,6 @@ const Page = ({ config, settings, templates, overview, page, sets, values, fetch
                 createValue, updateValue, deleteValue, copyValue,
                 activateSet, createSet, updateSet, deleteSet, copySet }) => {
 
-  // scroll to top whenever the page changes
-  useEffect(() => window.scrollTo(0, 0), [page.id])
-
   const currentSetPrefix = ''
   let currentSetIndex = page.is_collection ? get(config, 'page.currentSetIndex', 0) : 0
   let currentSet = sets.find((set) => (set.set_prefix == currentSetPrefix && set.set_index == currentSetIndex))
@@ -27,6 +24,21 @@ const Page = ({ config, settings, templates, overview, page, sets, values, fetch
     currentSetIndex = get(minBy(sets, 'set_index'), 'set_index', 0)
     currentSet = sets.find((set) => (set.set_prefix == currentSetPrefix && set.set_index == currentSetIndex))
   }
+
+  // whenever the page or the currentSet changes
+  useEffect(() => {
+    // scroll to top
+    window.scrollTo(0, 0)
+
+    // focus the first text or textarea widget
+    const firstWidget = document.querySelector('.interview-widget')
+    if (firstWidget) {
+      const focusInput = firstWidget.querySelector('.text-input input[type="text"], .textarea-input textarea')
+      if (focusInput) {
+        focusInput.focus()
+      }
+    }
+  }, [page.id, currentSet])
 
   const isManager = (overview.is_superuser || overview.is_editor || overview.is_reviewer)
 

--- a/rdmo/projects/assets/js/interview/components/main/page/PageButtons.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/PageButtons.js
@@ -6,7 +6,7 @@ const PageButtons = ({ page, fetchPage }) => {
     <>
       <div className="interview-buttons">
         <div className="pull-right">
-          <button type="button" onClick={() => fetchPage(page.prev_page)} disabled={!page.prev_page}
+          <button type="button" onClick={() => fetchPage(page.prev_page, true)} disabled={!page.prev_page}
                   className="btn btn-default">
             {gettext('Back')}
           </button>

--- a/rdmo/projects/assets/js/interview/utils/value.js
+++ b/rdmo/projects/assets/js/interview/utils/value.js
@@ -1,4 +1,4 @@
-import { get, first, isNil, isEmpty, toString, sortBy } from 'lodash'
+import { isNil, isEmpty, toString } from 'lodash'
 
 import ValueFactory from '../factories/ValueFactory'
 
@@ -81,16 +81,6 @@ const initRange = (question, value) => {
   }
 }
 
-const activateFirstValue = (page, values) => {
-  const attribute = get(page, 'questions.0.attribute')
-  if (!isNil(attribute)) {
-    const value = first(sortBy(values.filter((value) => value.attribute == attribute), 'collection_index'))
-    if (!isNil(value)) {
-      value.focus = true
-    }
-  }
-}
-
 const compareValues = (a, b, widget_type = null) => {
   if (isNil(a.id) || isNil(b.id)) {
     if (widget_type === 'checkbox') {
@@ -115,4 +105,4 @@ const isEmptyValue = (value) => {
   )
 }
 
-export { isDefaultValue, gatherDefaultValues, initValues, initRange, activateFirstValue, compareValues, isEmptyValue }
+export { isDefaultValue, gatherDefaultValues, initValues, initRange, compareValues, isEmptyValue }


### PR DESCRIPTION
This PR contains 3 additional fixes for 2.3.1:

* The view jumps now always to the top when the page or the set/tab changes (#1347)
* If the first widget is a text or textarea it should be focussed (this was only working for the first tab of a page)
* Trailing whitespaces are not removed anymore when a value is automatically saved.
