### PR TITLE
Fix resolveCondition action and reducer

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -241,18 +241,15 @@ export function resolveConditions(page, sets) {
 export function resolveCondition(element, set) {
   const pendingId = `resolveCondition/${element.model}/${element.id}/${set.set_prefix}/${set.set_index}`
 
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(addToPending(pendingId))
     dispatch(resolveConditionInit())
 
     return ProjectApi.resolveCondition(projectId, set, element)
       .then((response) => {
         const elementType = elementTypes[element.model]
-        const setIndex = getState().interview.sets.indexOf(set)
-        const results = { ...set[elementType], [element.id]: response.result }
-
         dispatch(removeFromPending(pendingId))
-        dispatch(resolveConditionSuccess({ ...set, [elementType]: results }, setIndex))
+        dispatch(resolveConditionSuccess(set, elementType, element.id, response.result))
       })
       .catch((error) => {
         dispatch(removeFromPending(pendingId))
@@ -265,8 +262,8 @@ export function resolveConditionInit() {
   return {type: RESOLVE_CONDITION_INIT}
 }
 
-export function resolveConditionSuccess(set, setIndex) {
-  return {type: RESOLVE_CONDITION_SUCCESS, set, setIndex}
+export function resolveConditionSuccess(set, elementType, elementId, result) {
+  return {type: RESOLVE_CONDITION_SUCCESS, set, elementType, elementId, result}
 }
 
 export function resolveConditionError(error) {

--- a/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
+++ b/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
@@ -53,7 +53,12 @@ export default function interviewReducer(state = initialState, action) {
       return { ...state, page: action.page }
     case RESOLVE_CONDITION_SUCCESS:
       return { ...state, sets: state.sets.map(
-        (set, setIndex) => setIndex == action.setIndex ? action.set : set
+        (set) => (
+          (set.set_prefix == action.set.set_prefix) &&
+          (set.set_index == action.set.set_index)
+        ) ? {
+          ...set, [action.elementType]: {...set[action.elementType], [action.elementId]: action.result}
+        } : set
       )}
     case CREATE_VALUE:
       return { ...state, values: [...state.values, action.value] }


### PR DESCRIPTION
This PR solves the problem with multiple questions with conditions per page. The bug was caused by

```javascript
const setIndex = getState().interview.sets.indexOf(set)
```

because for the second element `set` would already have changed to the `setIndex` would be always `-1`. The fix is to use the reduce in a proper way.