### PR TITLE
Fix get_option in the Export base class

### DIFF
--- a/rdmo/projects/exports.py
+++ b/rdmo/projects/exports.py
@@ -76,7 +76,7 @@ class Export(Plugin):
         value = self.get_value(path, set_prefix=set_prefix, set_index=set_index, collection_index=collection_index)
         if value and value.option:
             # lookup option dict in class
-            return options.get(value.option.path, default)
+            return options.get(value.option.uri_path, default)
         else:
             return default
 


### PR DESCRIPTION
`path` was renamed to `uri_path` in RDMO 2.3.2.