### PR TITLE
fix style: rename classes to QuerySet

### DIFF
--- a/rdmo/questions/managers.py
+++ b/rdmo/questions/managers.py
@@ -10,7 +10,7 @@ from rdmo.core.managers import (
 )
 
 
-class CatalogQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, models.QuerySet):
+class CatalogQuerySet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, models.QuerySet):
 
     def filter_catalog(self, catalog):
         return self.filter(models.Q(catalogs=None) | models.Q(catalogs=catalog))
@@ -22,7 +22,7 @@ class CatalogQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, Availabi
 class CatalogManager(CurrentSiteManagerMixin, GroupsManagerMixin, AvailabilityManagerMixin, models.Manager):
 
     def get_queryset(self):
-        return CatalogQuestionSet(self.model, using=self._db)
+        return CatalogQuerySet(self.model, using=self._db)
 
     def filter_catalog(self, catalog):
         return self.get_queryset().filter_catalog(catalog)

--- a/rdmo/tasks/managers.py
+++ b/rdmo/tasks/managers.py
@@ -10,7 +10,7 @@ from rdmo.core.managers import (
 )
 
 
-class TaskQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, QuerySet):
+class TaskQuerySet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, QuerySet):
 
     def filter_catalog(self, catalog):
         return self.filter(Q(catalogs=None) | Q(catalogs=catalog))
@@ -23,8 +23,8 @@ class TaskQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, Availabilit
 
 class TaskManager(CurrentSiteManagerMixin, GroupsManagerMixin, AvailabilityManagerMixin, Manager):
 
-    def get_queryset(self) -> TaskQuestionSet:
-        return TaskQuestionSet(self.model, using=self._db)
+    def get_queryset(self) -> TaskQuerySet:
+        return TaskQuerySet(self.model, using=self._db)
 
     def filter_catalog(self, catalog):
         return self.get_queryset().filter_catalog(catalog)

--- a/rdmo/views/managers.py
+++ b/rdmo/views/managers.py
@@ -10,7 +10,7 @@ from rdmo.core.managers import (
 )
 
 
-class ViewQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, QuerySet):
+class ViewQuerySet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, QuerySet):
 
     def filter_catalog(self, catalog):
         return self.filter(Q(catalogs=None) | Q(catalogs=catalog))
@@ -23,8 +23,8 @@ class ViewQuestionSet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, Availabilit
 
 class ViewManager(CurrentSiteManagerMixin, GroupsManagerMixin, AvailabilityManagerMixin, Manager):
 
-    def get_queryset(self) -> ViewQuestionSet:
-        return ViewQuestionSet(self.model, using=self._db)
+    def get_queryset(self) -> ViewQuerySet:
+        return ViewQuerySet(self.model, using=self._db)
 
     def filter_catalog(self, catalog):
         return self.get_queryset().filter_catalog(catalog)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --->

<!--- Please link to a related issue here --->
No related issue.
Fixes a typo in the naming of `QuerySet` classes.
