### PR TITLE
fix: missing permission check for visibility in template

### DIFF
--- a/rdmo/projects/templates/projects/project_detail_header_visibility.html
+++ b/rdmo/projects/templates/projects/project_detail_header_visibility.html
@@ -1,6 +1,8 @@
 {% load i18n %}
+{% load rules %}
 {% load core_tags %}
 
+{% has_perm 'projects.change_visibility_object' request.user project as can_change_visibility %}
 {% if can_change_visibility  %}
 <p class="pull-right">
     <a href="{% url 'project_update_visibility' project.pk %}" title="{% trans 'Update project visibility' %}">


### PR DESCRIPTION
## Description
Project overview is missing the edit button for the visibility as the template does not include the corresponding permission check. This PR aims at fixing this issue.

## How has this been tested?
Tested in the UI.
