### PR TITLE
Allow for links in select widgets in the interview

### DIFF
--- a/rdmo/core/static/core/css/base.scss
+++ b/rdmo/core/static/core/css/base.scss
@@ -500,8 +500,8 @@ li.has-warning > a.control-label > i {
 }
 
 // adjust background "hover" color in select2 to $link-color
-.select2-results__option--highlighted{
-    background-color: $link-color !important,
+.select2-results__option--highlighted {
+    background-color: $link-color !important
 }
 
 .cc-myself {

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectInput.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectInput.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { isEmpty, isNil } from 'lodash'
 import { useDebouncedCallback } from 'use-debounce'
-// import { convert } from 'html-to-text'
 
 import ProjectApi from '../../../api/ProjectApi'
 import { projectId } from '../../../utils/meta'
@@ -19,6 +18,7 @@ import { getValueOption } from '../../../utils/options'
 import OptionHelp from './common/OptionHelp'
 import OptionText from './common/OptionText'
 
+import SelectValueContainer from './SelectValueContainer'
 
 const SelectInput = ({ question, value, options, disabled, creatable, updateValue, buttons }) => {
 
@@ -104,7 +104,8 @@ const SelectInput = ({ question, value, options, disabled, creatable, updateValu
         <OptionText option={option} />
         <OptionHelp className="ml-10" option={option} />
       </span>
-    )
+    ),
+    components: { ValueContainer: SelectValueContainer }
   }
 
   return (

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectValueContainer.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectValueContainer.js
@@ -1,0 +1,44 @@
+import React, { useRef, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { components } from 'react-select'
+
+const SelectValueContainer = (props) => {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    const links = ref.current.querySelectorAll('a')
+    const handlers = []
+
+    links.forEach((link) => {
+      const handler = (e) => e.stopPropagation()
+
+      link.addEventListener('mousedown', handler)
+      link.setAttribute('target', '_blank')
+      link.setAttribute('rel', 'noopener noreferrer')
+
+      handlers.push({ link, handler })
+    })
+
+    return () => {
+      handlers.forEach(({ link, handler }) => {
+        link.removeEventListener('mousedown', handler)
+      })
+    }
+  }, [])
+
+  return (
+    <components.ValueContainer {...props}>
+      <span ref={ref} style={{ display: 'inline-flex', alignItems: 'center' }}>
+        {props.children}
+      </span>
+    </components.ValueContainer>
+  )
+}
+
+SelectValueContainer.propTypes = {
+  children: PropTypes.node
+}
+
+export default SelectValueContainer

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -424,6 +424,12 @@ $variant-background-color: #f5f5f5 !default;
         .react-select__menu {
             z-index: 10;
         }
+
+        .react-select__option--is-selected {
+          a {
+            color: white;
+          }
+        }
     }
 }
 


### PR DESCRIPTION
This PR slightly refactors the SelectInput component in the interview to allow clickable links in the option text and help when the select dropdown is closed.

This will enable the ORCID/GND/ROR/Wikidata plugins to show a link to the stored resource.