### PR TITLE
Add permissions object to projects API and cache is_site_manager

### DIFF
--- a/rdmo/accounts/models.py
+++ b/rdmo/accounts/models.py
@@ -3,6 +3,7 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from rdmo.core.models import Model as RDMOTimeStampedModel
@@ -205,16 +206,9 @@ class Role(models.Model):
     def __str__(self):
         return self.user.username
 
-    def is_site_manager(self, site_id):
-        # checks if the user is manager for the given site and caches the result in the
-        # role instance, since the check is performed most project permissions
-        if not hasattr(self, '_site_manager_cache'):
-            self._site_manager_cache = {}
-
-        if site_id not in self._site_manager_cache:
-            self._site_manager_cache[site_id] = self.manager.filter(id=site_id).exists()
-
-        return self._site_manager_cache[site_id]
+    @cached_property
+    def is_site_manager(self):
+        return self.manager.filter(id=settings.SITE_ID).exists()
 
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)

--- a/rdmo/accounts/models.py
+++ b/rdmo/accounts/models.py
@@ -205,6 +205,17 @@ class Role(models.Model):
     def __str__(self):
         return self.user.username
 
+    def is_site_manager(self, site_id):
+        # checks if the user is manager for the given site and caches the result in the
+        # role instance, since the check is performed most project permissions
+        if not hasattr(self, '_site_manager_cache'):
+            self._site_manager_cache = {}
+
+        if site_id not in self._site_manager_cache:
+            self._site_manager_cache[site_id] = self.manager.filter(id=site_id).exists()
+
+        return self._site_manager_cache[site_id]
+
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def post_save_user(sender, **kwargs):

--- a/rdmo/accounts/tests/test_models.py
+++ b/rdmo/accounts/tests/test_models.py
@@ -1,0 +1,25 @@
+import pytest
+
+from django.contrib.auth import get_user_model
+
+normal_users = (
+    ('user', 'user', 'user@example.com'),
+)
+
+site_managers = (
+    ('site', 'site', 'site@example.com'),
+)
+
+
+@pytest.mark.parametrize('username,password,email', normal_users)
+def test_is_site_manager_returns_false_for_normal_users(db, client, username, password, email):
+    client.login(username=username, password=password)
+    user = get_user_model().objects.get(username=username, email=email)
+    assert user.role.is_site_manager is False
+
+
+@pytest.mark.parametrize('username,password,email', site_managers)
+def test_is_site_manager_returns_true_for_site_managers(db, client, username, password, email):
+    client.login(username=username, password=password)
+    user = get_user_model().objects.get(username=username, email=email)
+    assert user.role.is_site_manager is True

--- a/rdmo/accounts/tests/test_utils.py
+++ b/rdmo/accounts/tests/test_utils.py
@@ -1,10 +1,8 @@
 import pytest
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
 
-from rdmo.accounts.models import Role
-from rdmo.accounts.utils import delete_user, get_full_name, get_user_from_db_or_none, is_site_manager
+from rdmo.accounts.utils import delete_user, get_full_name, get_user_from_db_or_none
 
 normal_users = (
     ('user', 'user', 'user@example.com'),
@@ -29,29 +27,6 @@ def test_get_full_name_returns_username(db, username, password, email):
     user.first_name = ''
     user.save()
     assert get_full_name(user) == username
-
-
-def test_is_site_manager_returns_true_for_superuser(admin_user):
-    assert is_site_manager(admin_user) is True
-
-
-def test_is_site_manager_returns_false_for_not_authenticated_user():
-    assert is_site_manager(AnonymousUser()) is False
-
-
-@pytest.mark.parametrize('username,password,email', site_managers)
-def test_is_site_manager_returns_true_for_site_managers(db, client, username, password, email):
-    client.login(username=username, password=password)
-    user = get_user_model().objects.get(username=username, email=email)
-    assert is_site_manager(user) is True
-
-
-@pytest.mark.parametrize('username,password,email', site_managers)
-def test_is_site_manager_returns_false_when_role_doesnotexist_(db, client, username, password, email):
-    client.login(username=username, password=password)
-    Role.objects.all().delete()
-    user = get_user_model().objects.get(username=username, email=email)
-    assert is_site_manager(user) is False
 
 
 @pytest.mark.parametrize('username,password,email', users)

--- a/rdmo/accounts/utils.py
+++ b/rdmo/accounts/utils.py
@@ -25,7 +25,7 @@ def is_site_manager(user):
             return True
         else:
             try:
-                return user.role.manager.filter(pk=settings.SITE_ID).exists()
+                return user.role.is_site_manager(settings.SITE_ID)
             except Role.DoesNotExist:
                 return False
     else:

--- a/rdmo/accounts/utils.py
+++ b/rdmo/accounts/utils.py
@@ -1,12 +1,10 @@
 import logging
 
-from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 
-from .models import Role
 from .settings import GROUPS
 
 log = logging.getLogger(__name__)
@@ -17,19 +15,6 @@ def get_full_name(user) -> str:
         return f'{user.first_name} {user.last_name}'
     else:
         return user.username
-
-
-def is_site_manager(user):
-    if user.is_authenticated:
-        if user.is_superuser:
-            return True
-        else:
-            try:
-                return user.role.is_site_manager(settings.SITE_ID)
-            except Role.DoesNotExist:
-                return False
-    else:
-        return False
 
 
 def set_group_permissions():

--- a/rdmo/accounts/viewsets.py
+++ b/rdmo/accounts/viewsets.py
@@ -10,7 +10,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 
 from .serializers.v1 import UserSerializer
-from .utils import is_site_manager
 
 
 class UserViewSetMixin:
@@ -19,7 +18,7 @@ class UserViewSetMixin:
         if user.is_authenticated:
             if user.has_perm('auth.view_user'):
                 return get_user_model().objects.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return get_user_model().objects.filter(role__member__id__in=user.role.manager.all()).distinct()
         return get_user_model().objects.none()
 

--- a/rdmo/projects/managers.py
+++ b/rdmo/projects/managers.py
@@ -5,7 +5,6 @@ from django.db.models import Q
 from mptt.models import TreeManager
 from mptt.querysets import TreeQuerySet
 
-from rdmo.accounts.utils import is_site_manager
 from rdmo.core.managers import CurrentSiteManagerMixin
 
 
@@ -27,7 +26,7 @@ class ProjectQuerySet(TreeQuerySet):
                 visibility_filter = Q(visibility__isnull=False) & sites_filter & groups_filter
 
                 # create a filter for all projects of this site (unless filter_for_user is set)
-                if (user.has_perm('projects.view_project') or is_site_manager(user)) and not filter_for_user:
+                if (user.has_perm('projects.view_project') or user.role.is_site_manager) and not filter_for_user:
                     current_site_filter = Q(site=settings.SITE_ID)
                 else:
                     current_site_filter = Q()
@@ -62,7 +61,7 @@ class MembershipQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_membership'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project
@@ -81,7 +80,7 @@ class IssueQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_integration'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project
@@ -100,7 +99,7 @@ class IntegrationQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_issue'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project
@@ -119,7 +118,7 @@ class InviteQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_invite'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project
@@ -138,7 +137,7 @@ class SnapshotQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_snapshot'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project
@@ -157,7 +156,7 @@ class ValueQuerySet(models.QuerySet):
         if user.is_authenticated:
             if user.has_perm('projects.view_value'):
                 return self.all()
-            elif is_site_manager(user):
+            elif user.role.is_site_manager:
                 return self.filter_current_site()
             else:
                 from .models import Project

--- a/rdmo/projects/managers.py
+++ b/rdmo/projects/managers.py
@@ -211,6 +211,30 @@ class ProjectManager(CurrentSiteManagerMixin, TreeManager):
         return self.get_queryset().filter_catalogs(catalogs=catalogs, exclude_catalogs=exclude_catalogs,
                                                    exclude_null=exclude_null)
 
+    def prefetch_ancestors(self, projects):
+        # collect the constraints for all projects
+        filters = Q()
+        for project in projects:
+            filters |= (Q(tree_id=project.tree_id) & Q(lft__lt=project.lft) & Q(rght__gt=project.rght))
+
+        # Fetch all ancestors in one query
+        ancestors = self.filter(filters).order_by('tree_id', 'lft')
+
+        # Index by descendant id
+        prefetched_ancestors = {
+            project.id: [] for project in projects
+        }
+        for ancestor in ancestors:
+            for project in projects:
+                if ancestor.tree_id == project.tree_id and ancestor.lft < project.lft and ancestor.rght > project.rght:
+                    prefetched_ancestors[project.id].append(ancestor)
+
+        # add the project as last ancestor
+        for project in projects:
+            prefetched_ancestors[project.id].append(project)
+
+        return prefetched_ancestors
+
 
 class MembershipManager(CurrentSiteManagerMixin, models.Manager):
 

--- a/rdmo/projects/permissions.py
+++ b/rdmo/projects/permissions.py
@@ -71,6 +71,12 @@ class HasProjectPagePermission(HasProjectPermission):
         return ('projects.view_page_object', )
 
 
+class HasProjectLeavePermission(HasProjectPermission):
+
+    def get_required_object_permissions(self, method, model_cls):
+        return ('projects.leave_project_object', )
+
+
 class HasProjectProgressModelPermission(HasModelPermission):
 
     def get_required_permissions(self, method, model_cls):

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -61,7 +61,7 @@ def is_visible(user, project):
 @rules.predicate
 def is_site_manager(user, project):
     if user.is_authenticated:
-        return user.role.manager.filter(pk=project.site.pk).exists()
+        return user.role.is_site_manager(project.site.id)
     else:
         return False
 
@@ -70,7 +70,7 @@ def is_site_manager(user, project):
 def is_site_manager_for_current_site(user, request):
     if user.is_authenticated:
         current_site = get_current_site(request)
-        return user.role.manager.filter(pk=current_site.pk).exists()
+        return user.role.is_site_manager(current_site.id)
     else:
         return False
 

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist
 
 import rules
@@ -60,23 +59,11 @@ def is_visible(user, project):
 
 @rules.predicate
 def is_site_manager(user, project):
-    if user.is_authenticated:
-        return user.role.is_site_manager(project.site.id)
-    else:
-        return False
-
-
-@rules.predicate
-def is_site_manager_for_current_site(user, request):
-    if user.is_authenticated:
-        current_site = get_current_site(request)
-        return user.role.is_site_manager(current_site.id)
-    else:
-        return False
+    return user.is_authenticated and user.role.is_site_manager
 
 
 # Add rule for check in template
-rules.add_rule('projects.can_view_all_projects', is_site_manager_for_current_site | is_superuser)
+rules.add_rule('projects.can_view_all_projects', is_site_manager | is_superuser)
 
 rules.add_perm('projects.add_project', can_add_project)
 rules.add_perm('projects.view_project_object', is_project_member | is_visible | is_site_manager)

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -28,6 +28,7 @@ from ...validators import ProjectParentValidator, ValueConflictValidator, ValueQ
 class ProjectUserSerializer(serializers.ModelSerializer):
 
     full_name = serializers.SerializerMethodField()
+    socialaccounts = serializers.SerializerMethodField()
 
     class Meta:
         model = get_user_model()
@@ -40,11 +41,18 @@ class ProjectUserSerializer(serializers.ModelSerializer):
                 'first_name',
                 'last_name',
                 'full_name',
-                'email'
+                'email',
+                'socialaccounts'
             ]
 
-    def get_full_name(self, obj) -> str:
+    def get_full_name(self, obj):
         return get_full_name(obj)
+
+    def get_socialaccounts(self, obj):
+        return [{
+            'provider': socialaccount.provider,
+            'uid': socialaccount.uid
+        } for socialaccount in obj.socialaccount_set.all()]
 
 
 class ProjectAncestorSerializer(serializers.ModelSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -119,6 +119,15 @@ class ProjectSerializer(serializers.ModelSerializer):
             ProjectParentValidator()
         ]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.instance:
+            # this prefetches the ancestors of all instances for the serializer in one
+            # query and caches them in the instance
+            projects = self.instance if isinstance(self.instance, list) else [self.instance]
+            self._prefetched_ancestors = Project.objects.prefetch_ancestors(projects)
+
     def validate_views(self, value):
         """Block updates to views if syncing is enabled."""
         if settings.PROJECT_VIEWS_SYNC and value:
@@ -175,7 +184,8 @@ class ProjectSerializer(serializers.ModelSerializer):
             }
 
     def get_ancestors(self, obj):
-        return ProjectAncestorSerializer(obj.get_ancestors(include_self=True), many=True).data
+        ancestors = self._prefetched_ancestors.get(obj.id, obj.get_ancestors())
+        return ProjectAncestorSerializer(ancestors, many=True).data
 
 
 class ProjectCopySerializer(ProjectSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -49,12 +49,27 @@ class ProjectUserSerializer(serializers.ModelSerializer):
 
 class ProjectAncestorSerializer(serializers.ModelSerializer):
 
+    permissions = serializers.SerializerMethodField()
+
     class Meta:
         model = Project
         fields = (
             'id',
-            'title'
+            'title',
+            'permissions'
         )
+
+    def get_permissions(self, obj):
+        request = self.context.get('request')
+        view = self.context.get('view')
+        if view.action == 'list':
+            return {}
+        else:
+            return {
+                'can_view_project': request.user.has_perm('projects.view_project_object', obj),
+                'can_change_project': request.user.has_perm('projects.change_project_object', obj),
+                'can_delete_project': request.user.has_perm('projects.delete_project_object', obj)
+            }
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -185,7 +200,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_ancestors(self, obj):
         ancestors = self._prefetched_ancestors.get(obj.id, obj.get_ancestors())
-        return ProjectAncestorSerializer(ancestors, many=True).data
+        return ProjectAncestorSerializer(ancestors, many=True, context=self.context).data
 
 
 class ProjectCopySerializer(ProjectSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -47,6 +47,16 @@ class ProjectUserSerializer(serializers.ModelSerializer):
         return get_full_name(obj)
 
 
+class ProjectAncestorSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Project
+        fields = (
+            'id',
+            'title'
+        )
+
+
 class ProjectSerializer(serializers.ModelSerializer):
 
     class CatalogField(serializers.PrimaryKeyRelatedField):
@@ -71,6 +81,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     guests = ProjectUserSerializer(many=True, read_only=True)
 
     permissions = serializers.SerializerMethodField()
+    ancestors = serializers.SerializerMethodField()
 
     last_changed = serializers.DateTimeField(read_only=True)
 
@@ -98,7 +109,8 @@ class ProjectSerializer(serializers.ModelSerializer):
             'progress_total',
             'progress_count',
             'visibility',
-            'permissions'
+            'permissions',
+            'ancestors'
         )
         read_only_fields = (
             'snapshots',
@@ -161,6 +173,9 @@ class ProjectSerializer(serializers.ModelSerializer):
                 'can_change_value': request.user.has_perm('projects.change_value_object', obj),
                 'can_delete_value': request.user.has_perm('projects.delete_value_object', obj)
             }
+
+    def get_ancestors(self, obj):
+        return ProjectAncestorSerializer(obj.get_ancestors(include_self=True), many=True).data
 
 
 class ProjectCopySerializer(ProjectSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -70,6 +70,8 @@ class ProjectSerializer(serializers.ModelSerializer):
     authors = ProjectUserSerializer(many=True, read_only=True)
     guests = ProjectUserSerializer(many=True, read_only=True)
 
+    permissions = serializers.SerializerMethodField()
+
     last_changed = serializers.DateTimeField(read_only=True)
 
     visibility = serializers.CharField(source='visibility.get_help_display', read_only=True)
@@ -95,7 +97,8 @@ class ProjectSerializer(serializers.ModelSerializer):
             'views',
             'progress_total',
             'progress_count',
-            'visibility'
+            'visibility',
+            'permissions'
         )
         read_only_fields = (
             'snapshots',
@@ -109,6 +112,55 @@ class ProjectSerializer(serializers.ModelSerializer):
         if settings.PROJECT_VIEWS_SYNC and value:
             raise serializers.ValidationError(_('Editing views is disabled.'))
         return value
+
+    def get_permissions(self, obj):
+        request = self.context.get('request')
+        view = self.context.get('view')
+
+        if view.action == 'list':
+            return {
+                'can_view_project': request.user.has_perm('projects.view_project_object', obj),
+                'can_change_project': request.user.has_perm('projects.change_project_object', obj),
+                'can_delete_project': request.user.has_perm('projects.delete_project_object', obj)
+            }
+        else:
+            return {
+                'can_view_project': request.user.has_perm('projects.view_project_object', obj),
+                'can_change_project': request.user.has_perm('projects.change_project_object', obj),
+                'can_delete_project': request.user.has_perm('projects.delete_project_object', obj),
+                'can_leave_project': request.user.has_perm('projects.leave_project_object', obj),
+                'can_export_project': request.user.has_perm('projects.export_project_object', obj),
+                'can_import_project': request.user.has_perm('projects.import_project_object', obj),
+                'can_view_visibility': request.user.has_perm('projects.view_visibility_object', obj),
+                'can_add_visibility': request.user.has_perm('projects.add_visibility_object', obj),
+                'can_change_visibility': request.user.has_perm('projects.change_visibility_object', obj),
+                'can_delete_visibility': request.user.has_perm('projects.delete_visibility_object', obj),
+                'can_view_membership': request.user.has_perm('projects.view_membership_object', obj),
+                'can_add_membership': request.user.has_perm('projects.add_membership_object', obj),
+                'can_change_membership': request.user.has_perm('projects.change_membership_object', obj),
+                'can_delete_membership': request.user.has_perm('projects.delete_membership_object', obj),
+                'can_view_invite': request.user.has_perm('projects.view_invite_object', obj),
+                'can_add_invite': request.user.has_perm('projects.add_invite_object', obj),
+                'can_change_invite': request.user.has_perm('projects.change_invite_object', obj),
+                'can_delete_invite': request.user.has_perm('projects.delete_invite_object', obj),
+                'can_view_integration': request.user.has_perm('projects.view_integration_object', obj),
+                'can_add_integration': request.user.has_perm('projects.add_integration_object', obj),
+                'can_change_integration': request.user.has_perm('projects.change_integration_object', obj),
+                'can_delete_integration': request.user.has_perm('projects.delete_integration_object', obj),
+                'can_view_issue': request.user.has_perm('projects.view_issue_object', obj),
+                'can_add_issue': request.user.has_perm('projects.add_issue_object', obj),
+                'can_change_issue': request.user.has_perm('projects.change_issue_object', obj),
+                'can_delete_issue': request.user.has_perm('projects.delete_issue_object', obj),
+                'can_view_snapshot': request.user.has_perm('projects.view_snapshot_object', obj),
+                'can_add_snapshot': request.user.has_perm('projects.add_snapshot_object', obj),
+                'can_change_snapshot': request.user.has_perm('projects.change_snapshot_object', obj),
+                'can_rollback_snapshot': request.user.has_perm('projects.rollback_snapshot_object', obj),
+                'can_export_snapshot': request.user.has_perm('projects.export_snapshot_object', obj),
+                'can_view_value': request.user.has_perm('projects.view_value_object', obj),
+                'can_add_value': request.user.has_perm('projects.add_value_object', obj),
+                'can_change_value': request.user.has_perm('projects.change_value_object', obj),
+                'can_delete_value': request.user.has_perm('projects.delete_value_object', obj)
+            }
 
 
 class ProjectCopySerializer(ProjectSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
@@ -45,10 +48,10 @@ class ProjectUserSerializer(serializers.ModelSerializer):
                 'socialaccounts'
             ]
 
-    def get_full_name(self, obj):
+    def get_full_name(self, obj) -> str:
         return get_full_name(obj)
 
-    def get_socialaccounts(self, obj):
+    def get_socialaccounts(self, obj) -> list[dict[str, str]]:
         return [{
             'provider': socialaccount.provider,
             'uid': socialaccount.uid
@@ -67,7 +70,7 @@ class ProjectAncestorSerializer(serializers.ModelSerializer):
             'permissions'
         )
 
-    def get_permissions(self, obj):
+    def get_permissions(self, obj) -> Mapping[str, bool]:
         request = self.context.get('request')
         view = self.context.get('view')
         if view.action == 'list':
@@ -150,6 +153,9 @@ class ProjectSerializer(serializers.ModelSerializer):
             # query and caches them in the instance
             projects = self.instance if isinstance(self.instance, list) else [self.instance]
             self._prefetched_ancestors = Project.objects.prefetch_ancestors(projects)
+        else:
+            # prevent AttributeError for create
+            self._prefetched_ancestors = {}
 
     def validate_views(self, value):
         """Block updates to views if syncing is enabled."""
@@ -157,7 +163,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(_('Editing views is disabled.'))
         return value
 
-    def get_permissions(self, obj):
+    def get_permissions(self, obj) -> dict[str, bool]:
         request = self.context.get('request')
         view = self.context.get('view')
 
@@ -206,7 +212,7 @@ class ProjectSerializer(serializers.ModelSerializer):
                 'can_delete_value': request.user.has_perm('projects.delete_value_object', obj)
             }
 
-    def get_ancestors(self, obj):
+    def get_ancestors(self, obj) -> list[dict[str, Any]]:
         ancestors = self._prefetched_ancestors.get(obj.id, obj.get_ancestors())
         return ProjectAncestorSerializer(ancestors, many=True, context=self.context).data
 

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -270,6 +270,34 @@ class ProjectMembershipUpdateSerializer(serializers.ModelSerializer):
         )
 
 
+class ProjectMembershipListSerializer(serializers.ModelSerializer):
+
+    user = ProjectUserSerializer(read_only=True)
+
+    class Meta:
+        model = Membership
+        fields = (
+            'id',
+            'user',
+            'role'
+        )
+
+
+class ProjectMembershipHierarchySerializer(serializers.ModelSerializer):
+
+    user = ProjectUserSerializer(read_only=True)
+    project = ProjectAncestorSerializer(read_only=True)
+
+    class Meta:
+        model = Membership
+        fields = (
+            'id',
+            'user',
+            'role',
+            'project'
+        )
+
+
 class ProjectIntegrationOptionSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/rdmo/projects/tests/test_viewset_project_membership.py
+++ b/rdmo/projects/tests/test_viewset_project_membership.py
@@ -54,14 +54,18 @@ def test_list(db, client, username, password, project_id):
     if project_id in view_membership_permission_map.get(username, []):
         assert response.status_code == 200
 
+        response_data = response.json()
+
         if username == 'user':
-            assert sorted([item['id'] for item in response.json()]) == memberships_visible
-            assert all('email' in i for i in response.json())
+            assert sorted([item['id'] for item in response_data]) == memberships_visible
+            assert all('user' in item for item in response_data)
+            assert all('email' in item['user'] for item in response_data)
         else:
             values_list = Membership.objects.filter(project_id=project_id) \
                                             .order_by('id').values_list('id', flat=True)
-            assert sorted([item['id'] for item in response.json()]) == list(values_list)
-            assert all("email" in i for i in response.json())
+            assert sorted([item['id'] for item in response_data]) == list(values_list)
+            assert all('user' in item for item in response_data)
+            assert all('email' in item['user'] for item in response_data)
     else:
         assert response.status_code == 404
 

--- a/rdmo/projects/tests/test_viewset_project_membership_hierarchy.py
+++ b/rdmo/projects/tests/test_viewset_project_membership_hierarchy.py
@@ -1,0 +1,50 @@
+import pytest
+
+from django.urls import reverse
+
+users = (
+    ('owner', 'owner'),
+    ('manager', 'manager'),
+    ('author', 'author'),
+    ('guest', 'guest'),
+    ('api', 'api'),
+    ('user', 'user'),
+    ('site', 'site'),
+    ('anonymous', None),
+)
+
+view_membership_permission_map = {
+    'owner': [1, 2, 3, 4, 5, 12],
+    'manager': [1, 3, 5, 12],
+    'author': [1, 3, 5, 12],
+    'guest': [1, 3, 5, 12],
+    'user': [12],
+    'api': [1, 2, 3, 4, 5, 12],
+    'site': [1, 2, 3, 4, 5, 12]
+}
+
+urlnames = {
+    'hierarchy': 'v1-projects:project-membership-hierarchy'
+}
+
+projects = [1, 2, 3, 4, 5, 12]
+
+project_memberships = {
+    3: {5},
+    5: {5, 6, 7, 8}
+}
+
+
+@pytest.mark.parametrize('username,password', users)
+@pytest.mark.parametrize('project_id', projects)
+def test_hierarchy(db, client, username, password, project_id):
+    client.login(username=username, password=password)
+
+    url = reverse(urlnames['hierarchy'], args=[project_id])
+    response = client.get(url)
+
+    if project_id in view_membership_permission_map.get(username, []):
+        assert response.status_code == 200
+        assert {m['user']['id'] for m in response.json()} == project_memberships.get(project_id, set())
+    else:
+        assert response.status_code == 404

--- a/rdmo/projects/tests/test_viewset_project_membership_leave.py
+++ b/rdmo/projects/tests/test_viewset_project_membership_leave.py
@@ -1,0 +1,76 @@
+import pytest
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from ..models import Membership
+
+users = (
+    ('owner', 'owner'),
+    ('manager', 'manager'),
+    ('author', 'author'),
+    ('guest', 'guest'),
+    ('user', 'user'),
+    ('site', 'site'),
+    ('anonymous', None),
+)
+
+leave_project_permission_map = {
+    'owner': [1, 2, 3, 4, 5, 12],
+    'manager': [1, 3],
+    'author': [1, 3],
+    'guest': [1, 3]
+}
+
+urlnames = {
+    'leave': 'v1-projects:project-membership-leave',
+}
+
+projects = [1, 2, 3, 4, 5, 12]
+memberships = [1, 2, 3, 4]
+memberships_visible = [16]
+
+
+@pytest.mark.parametrize('username,password', users)
+@pytest.mark.parametrize('project_id', projects)
+def test_leave(db, client, username, password, project_id):
+    client.login(username=username, password=password)
+
+    url = reverse(urlnames['leave'], args=[project_id])
+    response = client.delete(url)
+
+    # store if the membership exists
+    membership_existed = Membership.objects.filter(project_id=project_id, user__username=username).exists()
+
+    if project_id in leave_project_permission_map.get(username, []):
+        if username == 'owner':
+            assert response.status_code == 400  # last owner is not allowed to leave
+        else:
+            assert response.status_code == 204
+
+            if membership_existed:
+                assert not Membership.objects.filter(project_id=project_id, user__username=username).exists()
+    else:
+        assert response.status_code == 404
+
+
+@pytest.mark.parametrize('project_id', projects)
+def test_project_leave_post_last_owner(db, client, project_id):
+    client.login(username='owner', password='owner')
+
+    # store if the membership exists
+    membership_existed = Membership.objects.filter(project_id=project_id, user__username='owner').exists()
+
+    # add user as the second owner
+    Membership.objects.create(project_id=project_id, user=User.objects.get(username='user'), role='owner')
+
+    url = reverse(urlnames['leave'], args=[project_id])
+    response = client.delete(url)
+
+    if project_id in leave_project_permission_map.get('owner', []):
+        assert response.status_code == 204
+
+        if membership_existed:
+            assert not Membership.objects.filter(project_id=project_id, user__username='owner').exists()
+    else:
+        assert response.status_code == 404

--- a/rdmo/projects/views/membership.py
+++ b/rdmo/projects/views/membership.py
@@ -7,7 +7,6 @@ from django.urls import reverse
 from django.views.generic import DeleteView, UpdateView
 from django.views.generic.edit import FormView
 
-from rdmo.accounts.utils import is_site_manager
 from rdmo.core.views import ObjectPermissionMixin, RedirectViewMixin
 
 from ..forms import MembershipCreateForm
@@ -36,7 +35,7 @@ class MembershipCreateView(ObjectPermissionMixin, RedirectViewMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs['project'] = self.project
-        kwargs['is_site_manager'] = is_site_manager(self.request.user)
+        kwargs['is_site_manager'] = self.request.user.role.is_site_manager
         return kwargs
 
     def get_success_url(self):
@@ -69,7 +68,7 @@ class MembershipDeleteView(ObjectPermissionMixin, RedirectViewMixin, DeleteView)
     def form_valid(self, form):
         self.obj = self.get_object()
 
-        if (self.request.user in self.obj.project.owners) or is_site_manager(self.request.user):
+        if (self.request.user in self.obj.project.owners) or self.request.user.is_site_manager:
             # user is owner or site manager
             if is_last_owner(self.obj.project, self.obj.user):
                 logger.info('User "%s" not allowed to remove last user "%s"',

--- a/rdmo/projects/views/membership.py
+++ b/rdmo/projects/views/membership.py
@@ -68,7 +68,7 @@ class MembershipDeleteView(ObjectPermissionMixin, RedirectViewMixin, DeleteView)
     def form_valid(self, form):
         self.obj = self.get_object()
 
-        if (self.request.user in self.obj.project.owners) or self.request.user.is_site_manager:
+        if (self.request.user in self.obj.project.owners) or self.request.user.role.is_site_manager:
             # user is owner or site manager
             if is_last_owner(self.obj.project, self.obj.user):
                 logger.info('User "%s" not allowed to remove last user "%s"',

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -125,13 +125,15 @@ class ProjectViewSet(ModelViewSet):
         'last_changed'
     )
 
-    filter_for_user = False  # flag for get_queryset to return only projects like for a regular user
-
     def get_queryset(self):
         if hasattr(self, '_cached_queryset'):
             return self._cached_queryset
 
-        queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct().prefetch_related(
+        # for the user action (below), we need to set filter_for_user to s to filter the
+        # projects for the current user regardless of their permissions, e.g. for admins
+        filter_for_user = (self.action == 'user')
+
+        queryset = Project.objects.filter_user(self.request.user, filter_for_user).distinct().prefetch_related(
             'snapshots',
             'views',
             Prefetch('memberships', queryset=Membership.objects.prefetch_related(
@@ -154,7 +156,6 @@ class ProjectViewSet(ModelViewSet):
 
     @action(detail=False, methods=['GET'], permission_classes=(HasModelPermission | HasProjectsPermission, ))
     def user(self, request, *args, **kwargs):
-        self.filter_for_user = True
         return self.list(request, *args, **kwargs)
 
     @action(detail=True, methods=['POST'],

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -39,6 +39,7 @@ from .filters import (
 )
 from .models import Continuation, Integration, Invite, Issue, Membership, Project, Snapshot, Value, Visibility
 from .permissions import (
+    HasProjectLeavePermission,
     HasProjectPagePermission,
     HasProjectPermission,
     HasProjectProgressModelPermission,
@@ -483,6 +484,15 @@ class ProjectMembershipViewSet(ProjectNestedViewSetMixin, ModelViewSet):
             'request': request, 'view': self
         })
         return Response(serializer.data)
+
+    @action(detail=False, methods=['delete'], permission_classes=(HasProjectLeavePermission, ))
+    def leave(self, request, parent_lookup_project=None):
+        membership = Membership.objects.filter(project=self.project).get(user=request.user)
+        if membership.is_last_owner:
+            raise ValidationError(_('The last owner is not allowed to leave the project.'))
+        else:
+            membership.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class ProjectIntegrationViewSet(ProjectNestedViewSetMixin, ModelViewSet):

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import OuterRef, Prefetch, Q, Subquery
+from django.db.models import F, OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import Coalesce, Greatest
 from django.http import Http404, HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
@@ -65,6 +65,8 @@ from .serializers.v1 import (
     ProjectInviteSerializer,
     ProjectInviteUpdateSerializer,
     ProjectIssueSerializer,
+    ProjectMembershipHierarchySerializer,
+    ProjectMembershipListSerializer,
     ProjectMembershipSerializer,
     ProjectMembershipUpdateSerializer,
     ProjectSerializer,
@@ -443,10 +445,37 @@ class ProjectMembershipViewSet(ProjectNestedViewSetMixin, ModelViewSet):
         return Membership.objects.filter(project=self.project)
 
     def get_serializer_class(self):
-        if self.action == 'update':
+        if self.action == 'list':
+            return ProjectMembershipListSerializer
+        elif self.action == 'update':
             return ProjectMembershipUpdateSerializer
         else:
             return ProjectMembershipSerializer
+
+    @action(detail=False, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ))
+    def hierarchy(self, request, parent_lookup_project=None):
+        # get the ancestors of this project
+        ancestors = self.project.get_ancestors()
+
+        # add a subquery to find the highest occurrence of a user in the project hierarchy
+        highest_project = Membership.objects.filter(
+            project__in=ancestors, user_id=OuterRef('user_id')
+        ).order_by('-project__level')
+
+        # query memberships for all ancestors, but only the highest level
+        memberships = Membership.objects.filter(project__in=ancestors) \
+                                        .annotate(highest=Subquery(highest_project.values('project__level')[:1])) \
+                                        .filter(highest=F('project__level')) \
+                                        .select_related('project', 'user')
+
+        if settings.SOCIALACCOUNT:
+            # prefetch the users social account, if that relation exists
+            memberships = memberships.prefetch_related('user__socialaccount_set')
+
+        serializer = ProjectMembershipHierarchySerializer(memberships, many=True, context={
+            'request': request, 'view': self
+        })
+        return Response(serializer.data)
 
 
 class ProjectIntegrationViewSet(ProjectNestedViewSetMixin, ModelViewSet):

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -127,10 +127,15 @@ class ProjectViewSet(ModelViewSet):
     filter_for_user = False  # flag for get_queryset to return only projects like for a regular user
 
     def get_queryset(self):
+        if hasattr(self, '_cached_queryset'):
+            return self._cached_queryset
+
         queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct().prefetch_related(
             'snapshots',
             'views',
-            Prefetch('memberships', queryset=Membership.objects.select_related('user'), to_attr='memberships_list')
+            Prefetch('memberships', queryset=Membership.objects.prefetch_related(
+                'user__socialaccount_set'
+            ).select_related('user'), to_attr='memberships_list')
         ).select_related('catalog', 'visibility')
 
         # prepare subquery for last_changed
@@ -142,7 +147,9 @@ class ProjectViewSet(ModelViewSet):
         # when Greatest returns a value, then Coalesce will return this value
         queryset = queryset.annotate(last_changed=Coalesce(Greatest(last_changed_subquery, 'updated'), 'updated'))
 
-        return queryset
+        # cache queryset and return
+        self._cached_queryset = queryset
+        return self._cached_queryset
 
     @action(detail=False, methods=['GET'], permission_classes=(HasModelPermission | HasProjectsPermission, ))
     def user(self, request, *args, **kwargs):


### PR DESCRIPTION
This PR aims to add a `permissions` object to the projects API (and probably more endpoints).