### PR TITLE
chore: remove obsolete filter for warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,12 +208,6 @@ filterwarnings = [
   # fail on RemovedInDjango50Warning exception
   "error::django.utils.deprecation.RemovedInDjango50Warning",
 
-  # ignore warnings raised from within coreapi 2.3.3
-  "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-
-  # ignore warning from rest_framework about coreapi
-  "ignore:CoreAPI compatibility is deprecated and will be removed in DRF 3.17:rest_framework.RemovedInDRF317Warning",
-
   # ignore warnings raised by widget_tweaks.py
   "ignore:'maxsplit' is passed as positional argument",
 


### PR DESCRIPTION
<!--- These comments are hidden when you submit the pull request, --->
<!--- so you do not need to remove them. --->

<!--- Before opening a pull request, go over all the following points: --->
<!--- * I have read the contributor guide (CONTRIBUTING.md) --->
<!--- * My code follows the code style of this project --->
<!--- * I added tests to cover my changes --->
<!--- * If needed, I updated the documentation --->
<!--- * If needed, I added translations if they are needed --->
<!--- * If needed, I added migration files and checked for potential conflicts --->

<!--- This project only accepts pull requests related to open issues. --->
<!--- If suggesting a new feature or change, please discuss it in an issue first. --->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. --->

<!--- Please provide a general summary of your changes in the title of the pull request --->

## Description
<!--- Describe your changes in detail --->
This PR cleans up some of the warnings filters. These were supposed to be removed, when switching to drf-spectular, but were forgotten. Should be alright to remove, right? coreapi is not used anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

## Screenshots (if appropriate)

<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
