### PR TITLE
feat: add support for python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.9', '3.13', '3.14-dev']
         db-backend: [mysql, postgres]
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
   "version",


### PR DESCRIPTION
## Description

- [ ] replace `python-version: ['3.9', '3.13', '3.14-dev']` with `python-version: ['3.9', '3.14']`

## Motivation and Context

Python 3.14 is scheduled for 2025-10-07.

Ref: https://peps.python.org/pep-0745/

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

## Screenshots (if appropriate)

<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
