### PR TITLE
chore: apply pep 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ keywords = [
   "research data",
   "research data management",
 ]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "AUTHORS"]
 authors = [
   {name = "RDMO Arbeitsgemeinschaft", email = "rdmo-team@listserv.dfn.de"},
 ]
@@ -23,7 +24,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django :: 4.2",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Description

This PR 

1. replaces the deprecated TOML table with a SPDX expression.

```
/tmp/baipp-uv_cache_dir/builds-v0/.tmpa3fQ6I/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
```

2. removes the deprecated license classifier

```
/tmp/baipp-uv_cache_dir/builds-v0/.tmpa3fQ6I/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
```

3. adds all "licensy" files to `license-files`, including authors and notice. Is that alright?

See deprecation warnings in build output: https://github.com/rdmorganiser/rdmo/actions/runs/18658978891/job/53194830236

Refs:
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
- https://peps.python.org/pep-0639/

## Motivation and Context

In the future, the deprecation warnings will lead to build errors, which will make building the package impossible.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

## Screenshots (if appropriate)

<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
