### PR TITLE
chore: clean up obsolete dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 
 [project]
 name = "rdmo"
@@ -72,11 +72,9 @@ ci = [
   "pytest-github-actions-annotate-failures>=0.2.0,<0.4.0",
 ]
 dev = [
-  "build>=1.0,<2.0",
   "pipdeptree>=2.13,<3.0",
   "pre-commit>=3.4,<5.0",
   "setuptools>=73,<81",
-  "wheel>=0.42,<0.46",
   "rdmo[allauth,openapi,pytest]",
 ]
 gunicorn = [


### PR DESCRIPTION
## Description

After merging #1445 has been merged, we no longer call `build` manually in CI. I opt to remove it from dev dependencies then.

Same goes for `wheel`.

Also let's please remove it from `build-system.requires`, as per:

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended, as the backend no longer requires the wheel package, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).

Ref: Second note under https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

## Screenshots (if appropriate)

<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
