### PR TITLE
Refactor ProjectOverviewSerializer

### DIFF
--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -46,7 +46,7 @@ const Page = ({ config, settings, templates, overview, page, sets, values, fetch
     }
   }, [page.id])
 
-  const isManager = overview.permissions?.view_management
+  const isManager = overview.permissions?.can_view_management
   const disabled = (
     !overview.permissions?.can_add_value ||
     !overview.permissions?.can_change_value ||

--- a/rdmo/projects/assets/js/interview/components/sidebar/Overview.js
+++ b/rdmo/projects/assets/js/interview/components/sidebar/Overview.js
@@ -7,7 +7,7 @@ import Html from 'rdmo/core/assets/js/components/Html'
 
 const Overview = ({ config, overview, help, configActions }) => {
 
-  const isManager = overview.permissions?.view_management
+  const isManager = overview.permissions?.can_view_management
   const readOnly = (
     !overview.permissions?.can_add_value ||
     !overview.permissions?.can_change_value ||

--- a/rdmo/projects/serializers/v1/overview.py
+++ b/rdmo/projects/serializers/v1/overview.py
@@ -44,5 +44,5 @@ class ProjectOverviewSerializer(serializers.ModelSerializer):
                 'can_add_value': request.user.has_perm('projects.add_value_object', obj),
                 'can_change_value': request.user.has_perm('projects.change_value_object', obj),
                 'can_delete_value': request.user.has_perm('projects.delete_value_object', obj),
-                'view_management': request.user.has_perm('management.view_management', obj)
+                'can_view_management': request.user.has_perm('management.view_management', obj)
             }


### PR DESCRIPTION
This PR is a small add-on to `fix-management-ui-access` and fixes the problem that legacy reviewers don't see the management panels in the interview. It also refactors the serializer (and the front-end) to use RDMO3 permission format. It's a small change, I hope its ok. (`ProjectOverviewSerializer` will be removed eventually, I guess.)