### PR TITLE
Fix verbose name buttons

### DIFF
--- a/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/PageHead.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { capitalize, isEmpty, isNil } from 'lodash'
+import { isEmpty, isNil, upperFirst } from 'lodash'
 
 import useModal from 'rdmo/core/assets/js/hooks/useModal'
 
@@ -122,7 +122,7 @@ const PageHead = ({ templates, page, sets, values, disabled, currentSet,
                 !disabled && (
                   <li>
                     <a href="" title={labels.add} className="add-set" onClick={handleOpenCreateModal}>
-                      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(page.verbose_name)}
+                      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {upperFirst(page.verbose_name)}
                     </a>
                   </li>
                 )
@@ -153,7 +153,7 @@ const PageHead = ({ templates, page, sets, values, disabled, currentSet,
         ) : (
           !disabled && (
             <button role="button" className="btn btn-success" title={labels.add} onClick={createModal.open}>
-              <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(page.verbose_name)}
+              <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {upperFirst(page.verbose_name)}
             </button>
           )
         )

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { capitalize, maxBy } from 'lodash'
+import { maxBy, upperFirst } from 'lodash'
 
 const AddValue = ({ question, values, currentSet, disabled, createValue }) => {
   const handleClick = () => {
@@ -19,7 +19,7 @@ const AddValue = ({ question, values, currentSet, disabled, createValue }) => {
   return !disabled && question.is_collection && (
     <button type="button" className="btn btn-success btn-xs add-value-button" onClick={handleClick}
             title={gettext('Add answer')} aria-label={gettext('Add answer')}>
-      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(question.verbose_name)}
+      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {upperFirst(question.verbose_name)}
     </button>
   )
 }

--- a/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSetAddSet.js
+++ b/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSetAddSet.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { capitalize, maxBy } from 'lodash'
+import { maxBy, upperFirst } from 'lodash'
 
 const QuestionSetAddSet = ({ questionset, sets, setPrefix, disabled, createSet }) => {
   const handleClick = () => {
@@ -18,7 +18,7 @@ const QuestionSetAddSet = ({ questionset, sets, setPrefix, disabled, createSet }
     <button type="button" className="btn btn-success btn-add-set"
             title={'Add block'} aria-label={'Add block'}
             onClick={handleClick}>
-      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {capitalize(questionset.verbose_name)}
+      <i className="fa fa-plus fa-btn" aria-hidden="true"></i> {upperFirst(questionset.verbose_name)}
     </button>
   )
 }


### PR DESCRIPTION
This PR fixes the issue discussed in the last meeting:

```
capitalize('dies ist ein Test') -> 'Dies ist ein test'
upperFirst('dies ist ein Test') -> 'Dies ist ein Test'
```