### PR TITLE
Project fields

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -466,6 +466,9 @@ PROJECT_VALUES_VALIDATION_PHONE_REGEX = re.compile(r'''
     [\d\s]*$          # Main number with spaces
 ''', re.VERBOSE)
 
+
+PROJECT_FIELDS = {}
+
 DEFAULT_URI_PREFIX = 'http://example.com/terms'
 
 REPLACE_MISSING_TRANSLATION = False

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -142,6 +142,12 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     visibility = serializers.CharField(source='visibility.get_help_display', read_only=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for field in settings.PROJECT_FIELDS:
+            self.fields[field] = serializers.CharField(read_only=True)
+
     class Meta:
         model = Project
         fields = (
@@ -166,7 +172,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'progress_total',
             'progress_count',
             'visibility',
-            'permissions',
+            'permissions'
         )
         read_only_fields = (
             'snapshots',

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -154,12 +154,28 @@ class ProjectViewSet(ModelViewSet):
         last_changed_subquery = Subquery(
             Value.objects.filter(project=OuterRef('pk')).order_by('-updated').values('updated')[:1]
         )
+
+        extra_subqueries = {}
+        if settings.PROJECT_FIELDS:
+            questions = {
+                question.uri: question
+                for question in Question.objects.filter(uri__in=settings.PROJECT_FIELDS.values())
+            }
+            extra_subqueries.update({
+                field: Subquery(
+                    Value.objects.filter(project=OuterRef('pk'), snapshot=None, attribute=questions[uri].attribute)
+                                 .values('text')[:1]
+                )
+                for field, uri in settings.PROJECT_FIELDS.items()
+            })
+
         # the 'updated' field from a Project always returns a valid DateTime value
         # when Greatest returns null, then Coalesce will return the value for 'updated' as a fall-back
         # when Greatest returns a value, then Coalesce will return this value
         queryset = queryset.annotate(
             current_role=membership_subquery,
-            last_changed=Coalesce(Greatest(last_changed_subquery, 'updated'), 'updated')
+            last_changed=Coalesce(Greatest(last_changed_subquery, 'updated'), 'updated'),
+            **extra_subqueries
         )
 
         # cache queryset and return


### PR DESCRIPTION
This is an experimental PR to see how we can include questions/attributes/values in the main projects table. It works pretty good. The setup expects:

```
PROJECT_FIELDS = {
    'text': 'http://example.com/terms/questions/catalog/individual/text/text',
    'textarea': 'http://example.com/terms/questions/catalog/individual/textarea/textarea'
}
```

where the URIs are **Questions** and the keys label the annotations to the queryset and are also the keys in the project(s) JSON.