### PR TITLE
Fix datepicker date conversion in interview

### DIFF
--- a/rdmo/core/assets/js/utils/date.js
+++ b/rdmo/core/assets/js/utils/date.js
@@ -1,0 +1,6 @@
+export const getDateFromDatetime = (datetime) => {
+    const year = datetime.getFullYear()
+    const month = String(datetime.getMonth() + 1).padStart(2, '0')
+    const day = String(datetime.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+}

--- a/rdmo/projects/assets/js/interview/components/main/widget/DateInput.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/DateInput.js
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { enGB, de, it, es, fr } from 'date-fns/locale'
 
 import lang from 'rdmo/core/assets/js/utils/lang'
+import { getDateFromDatetime } from 'rdmo/core/assets/js/utils/date'
 
 import { getQuestionTextId, getQuestionHelpId } from '../../../utils/question'
 import { isDefaultValue } from '../../../utils/value'
@@ -42,7 +43,7 @@ const DateInput = ({ question, value, disabled, updateValue, buttons }) => {
   }
 
   const handleChange = (date) => {
-    const text = date.toISOString().slice(0,10)
+    const text = getDateFromDatetime(date)
     updateValue(value, { text, unit: question.unit, value_type: question.value_type })
   }
 


### PR DESCRIPTION
`date.toISOString().slice(0,10)` switches to the day before due to timezone issues.