### PR TITLE
Add Cookies to window

### DIFF
--- a/rdmo/core/assets/js/base.js
+++ b/rdmo/core/assets/js/base.js
@@ -1,3 +1,4 @@
 import 'bootstrap-sass'
 
 window.$ = require('jquery')
+window.Cookies = require('js-cookie')


### PR DESCRIPTION
This PR adds `Cookie` from `js-cookie` to the JS window object, which is helpfull when writing `fetch` outside of the React apps.