### PR TITLE
ci: fix zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
       patterns:
       - django*
       - drf*
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -44,6 +46,8 @@ updates:
     github-actions:
       patterns:
       - '*'
+  cooldown:
+    default-days: 7
 - package-ecosystem: npm
   directory: /
   schedule:
@@ -82,3 +86,5 @@ updates:
       dependency-type: production
     dev-dependencies:
       dependency-type: development
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ env:
   PYTHONDONTWRITEBYTECODE: 1
   FORCE_COLOR: 1 # colored output by pytest etc.
 
+permissions: {}
+
 jobs:
 
   build-wheel:
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     # update the version
     - name: Get short commit SHA
       run: |
@@ -48,10 +52,14 @@ jobs:
       run: echo "current_version=$(grep -Po '(?<=__version__ = ")[\d\w.]+(?=")' rdmo/__init__.py)" >> $GITHUB_OUTPUT
     - name: Generate new version (current version + SHA)
       id: new-version
-      run: echo "new_version=${{ steps.current-version.outputs.current_version }}+$SHA" >> $GITHUB_OUTPUT
+      run: echo "new_version=${CURRENT_VERSION}+$SHA" >> $GITHUB_OUTPUT
+      env:
+        CURRENT_VERSION: ${{ steps.current-version.outputs.current_version }}
     - name: Update version in rdmo/__init__.py
       run: |
-        sed -i "s/__version__ = .*/__version__ = \"${{ steps.new-version.outputs.new_version }}\"/" rdmo/__init__.py
+        sed -i "s/__version__ = .*/__version__ = \"${NEW_VERSION}\"/" rdmo/__init__.py
+      env:
+        NEW_VERSION: ${{ steps.new-version.outputs.new_version }}
     # build the webpack bundle
     - uses: actions/setup-node@v6
       with:
@@ -71,6 +79,8 @@ jobs:
         db-backend: [mysql, postgres]
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -129,6 +139,8 @@ jobs:
         db-backend: [postgres]
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -189,6 +201,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -202,6 +216,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -260,6 +276,6 @@ jobs:
       - dependencies
     runs-on: ubuntu-24.04
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,11 @@ repos:
             testing/.*.json|
             testing/.*.xml
         )$
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.16.3
+    hooks:
+    - id: zizmor
+      args: [--fix, --offline]
 ci:
   autoupdate_schedule: monthly
   autofix_prs: false


### PR DESCRIPTION
## Description

This PR hardens the security of the CI workflow, using the tool [zizmor](https://docs.zizmor.sh/), that has helped a lot of python projects in their CI workflows.

Like ruff and other tools it has defined so called "audit rules", that can be reviewed by running the tool on your CI workflow file.

You can test it using `uvx zizmor .` or ` `uvx zizmor --fix .` in rdmo's root dir.

This PR changes a few details and addresses the following audit rules:

- [unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses): pin third party gha to their hash
- [template-injection](https://docs.zizmor.sh/audits/#template-injection): this is interesting and kind of scary
- [excessive-permissions](https://docs.zizmor.sh/audits/#excessive-permissions): our ci workflow runs with the least amount of permissions possible, can be enabled on job basis
- [artipacked](https://docs.zizmor.sh/audits/#artipacked): our ci workflow does not need to do any cd related stuff, e.g. push to master branch
- [dependabot-cooldown](https://docs.zizmor.sh/audits/#dependabot-cooldown): we can wait a couple of days before being notified of new releases, that could be potentially broken

I think all these fixes are reasonable. I also added zizmor's pre-commit hook for future help. But this could of course be discussed. They also have a gha.

What do you think?

## Motivation and Context
Supply-chain attacks.

## How has this been tested?
Tested the hook locally.