### PR TITLE
Add views action to ProjectViewSet

### DIFF
--- a/rdmo/core/tests/test_openapi.py
+++ b/rdmo/core/tests/test_openapi.py
@@ -10,7 +10,7 @@ users = (
     'anonymous'
 )
 
-n_path = 136
+n_path = 137
 
 @pytest.mark.parametrize('username', users)
 def test_openapi_schema(db, client, login, settings, username):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -9,9 +9,11 @@ from rest_framework import serializers
 
 from rdmo.accounts.serializers.v1 import UserLookupSerializer
 from rdmo.accounts.utils import get_full_name
+from rdmo.core.serializers import TranslationSerializerMixin
 from rdmo.domain.models import Attribute
 from rdmo.questions.models import Catalog
 from rdmo.services.validators import ProviderValidator
+from rdmo.views.models import View
 
 from ...models import (
     Integration,
@@ -564,6 +566,17 @@ class ProjectValueSerializer(serializers.ModelSerializer):
         )
 
 
+class ProjectViewsSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = View
+        fields = (
+            'id',
+            'title',
+            'help'
+        )
+
+
 class ProjectAttachmentSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -577,13 +590,34 @@ class ProjectAttachmentSerializer(serializers.ModelSerializer):
         )
 
 
-class ProjectViewSerializer(serializers.Serializer):
+class ProjectAnswersSerializer(serializers.Serializer):
 
-    project = serializers.PrimaryKeyRelatedField(read_only=True)
-    snapshot = serializers.PrimaryKeyRelatedField(read_only=True)
-    view = serializers.PrimaryKeyRelatedField(read_only=True)
     html = serializers.CharField(read_only=True)
     attachments = ProjectAttachmentSerializer(many=True, read_only=True)
+
+
+class ProjectViewSerializer(serializers.ModelSerializer):
+
+    html = serializers.SerializerMethodField()
+    attachments = serializers.SerializerMethodField()
+
+    class Meta:
+        model = View
+        fields = (
+            'id',
+            'title',
+            'help',
+            'html',
+            'attachments'
+        )
+
+    def get_html(self, obj):
+        return self.context.get('html', '')
+
+    def get_attachments(self, obj):
+        attachments = self.context.get('attachments', [])
+        serializer = ProjectAttachmentSerializer(attachments, many=True, read_only=True)
+        return serializer.data
 
 
 class MembershipSerializer(serializers.ModelSerializer):

--- a/rdmo/projects/tests/test_viewset_project_views.py
+++ b/rdmo/projects/tests/test_viewset_project_views.py
@@ -37,10 +37,33 @@ export_formats = ['html']
 
 urlnames = {
     'views': 'v1-projects:project-views',
-    'views-snapshot': 'v1-projects:project-views-snapshot',
-    'views-export': 'v1-projects:project-views-export',
-    'views-export-snapshot': 'v1-projects:project-views-export-snapshot',
+    'view': 'v1-projects:project-view',
+    'view-snapshot': 'v1-projects:project-view-snapshot',
+    'view-export': 'v1-projects:project-view-export',
+    'view-export-snapshot': 'v1-projects:project-view-export-snapshot',
 }
+
+
+@pytest.mark.parametrize('username,password', users)
+@pytest.mark.parametrize('project_id', projects)
+def test_views(db, client, username, password, project_id):
+    client.login(username=username, password=password)
+    project = Project.objects.get(pk=project_id)
+    project_views = list(project.views.values_list('id', flat=True))
+
+    url = reverse(urlnames['views'], args=[project_id])
+    response = client.get(url)
+
+    if project_id in view_project_permission_map.get(username, []):
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+        assert [item['id'] for item in response.json()] == project_views
+    else:
+        if password:
+            assert response.status_code == 404
+        else:
+            assert response.status_code == 401
+
 
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('project_id', projects)
@@ -50,7 +73,7 @@ def test_view(db, client, username, password, project_id, view_id):
     project = Project.objects.get(pk=project_id)
     project_views = list(project.views.values_list('id', flat=True))
 
-    url = reverse(urlnames['views'], args=[project_id, view_id])
+    url = reverse(urlnames['view'], args=[project_id, view_id])
     response = client.get(url)
 
     if project_id in view_project_permission_map.get(username, []) and view_id in project_views:
@@ -71,7 +94,7 @@ def test_view_snapshot(db, client, username, password, snapshot_id, view_id):
     snapshot = Snapshot.objects.get(pk=snapshot_id)
     project_views = list(snapshot.project.views.values_list('id', flat=True))
 
-    url = reverse(urlnames['views-snapshot'], args=[snapshot.project.id, snapshot_id, view_id])
+    url = reverse(urlnames['view-snapshot'], args=[snapshot.project.id, snapshot_id, view_id])
     response = client.get(url)
 
     if snapshot.project.id in view_project_permission_map.get(username, []) and view_id in project_views:
@@ -93,7 +116,7 @@ def test_view_export(db, client, username, password, project_id, view_id, export
     project = Project.objects.get(pk=project_id)
     project_views = list(project.views.values_list('id', flat=True))
 
-    url = reverse(urlnames['views-export'], args=[project_id, view_id, export_format])
+    url = reverse(urlnames['view-export'], args=[project_id, view_id, export_format])
     response = client.get(url)
 
     if project_id in view_project_permission_map.get(username, []) and view_id in project_views:
@@ -114,7 +137,7 @@ def test_view_snapshot_export(db, client, username, password, snapshot_id, view_
     snapshot = Snapshot.objects.get(pk=snapshot_id)
     project_views = list(snapshot.project.views.values_list('id', flat=True))
 
-    url = reverse(urlnames['views-export-snapshot'], args=[snapshot.project.id, snapshot_id, view_id, export_format])
+    url = reverse(urlnames['view-export-snapshot'], args=[snapshot.project.id, snapshot_id, view_id, export_format])
     response = client.get(url)
 
     if snapshot.project.id in view_project_permission_map.get(username, []) and view_id in project_views:

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -64,6 +64,7 @@ from .serializers.v1 import (
     InviteSerializer,
     IssueSerializer,
     MembershipSerializer,
+    ProjectAnswersSerializer,
     ProjectCopySerializer,
     ProjectHierarchySerializer,
     ProjectIntegrationSerializer,
@@ -80,6 +81,7 @@ from .serializers.v1 import (
     ProjectSnapshotSerializer,
     ProjectValueSerializer,
     ProjectViewSerializer,
+    ProjectViewsSerializer,
     ProjectVisibilitySerializer,
     SnapshotSerializer,
     UserInviteSerializer,
@@ -435,9 +437,7 @@ class ProjectViewSet(ModelViewSet):
         except Snapshot.DoesNotExist:
             snapshot = None
 
-        serializer = ProjectViewSerializer({
-            'project': project,
-            'snapshot': snapshot,
+        serializer = ProjectAnswersSerializer({
             'html': render_to_string('projects/project_answers.html', {
                 'project': project,
                 'snapshot': snapshot,
@@ -490,8 +490,15 @@ class ProjectViewSet(ModelViewSet):
         return self.answers_export(request, pk, export_format, snapshot_id)
 
     @action(detail=True, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ),
+            url_path=r'views')
+    def views(self, request, pk):
+        project = self.get_object()
+        serializer = ProjectViewsSerializer(project.views, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ),
             url_path=r'views/(?P<view_id>\d+)')
-    def views(self, request, pk, view_id, snapshot_id=None):
+    def view(self, request, pk, view_id, snapshot_id=None):
         project = self.get_object()
         project.catalog.prefetch_elements()
 
@@ -505,26 +512,21 @@ class ProjectViewSet(ModelViewSet):
         except Snapshot.DoesNotExist:
             snapshot = None
 
-        serializer = ProjectViewSerializer({
-            'project': project,
-            'snapshot': snapshot,
-            'view': view,
+        serializer = ProjectViewSerializer(view, context={
             'html': view.render(project, snapshot),
             'attachments': project.values.filter(snapshot=snapshot).filter(value_type=VALUE_TYPE_FILE).order_by('file')
         })
         return Response(serializer.data)
 
-
     @action(detail=True, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ),
             url_path=r'snapshots/(?P<snapshot_id>\d+)/views/(?P<view_id>\d+)')
-    def views_snapshot(self, request, pk, view_id, snapshot_id):
+    def view_snapshot(self, request, pk, view_id, snapshot_id):
         # extra method since DRF does not officially support optional named parameters inside url_path
-        return self.views(request, pk, view_id, snapshot_id)
-
+        return self.view(request, pk, view_id, snapshot_id)
 
     @action(detail=True, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ),
             url_path=r'views/(?P<view_id>\d+)/export/(?P<export_format>[a-z]+)')
-    def views_export(self, request, pk, view_id, export_format, snapshot_id=None):
+    def view_export(self, request, pk, view_id, export_format, snapshot_id=None):
         project = self.get_object()
         project.catalog.prefetch_elements()
 
@@ -547,9 +549,9 @@ class ProjectViewSet(ModelViewSet):
 
     @action(detail=True, methods=['get'], permission_classes=(HasModelPermission | HasProjectPermission, ),
             url_path=r'snapshots/(?P<snapshot_id>\d+)/views/(?P<view_id>\d+)/export/(?P<export_format>[a-z]+)')
-    def views_export_snapshot(self, request, pk, view_id, export_format, snapshot_id):
+    def view_export_snapshot(self, request, pk, view_id, export_format, snapshot_id):
         # extra method since DRF does not officially support optional named parameters inside url_path
-        return self.views_export(request, pk, view_id, export_format, snapshot_id)
+        return self.view_export(request, pk, view_id, export_format, snapshot_id)
 
     @action(detail=False, url_path='upload-accept', permission_classes=(IsAuthenticated, ))
     def upload_accept(self, request):


### PR DESCRIPTION
This PR adds a `/api/v1/projects/projects/1/views/` action to the `ProjectViewSet` and slightly refactors the other view related actions we just merged. I removed `project` and `snapshot` since they are already in the url and they are also not present in the other responses. (@CalamityC is that ok?).

The new response looks like this:

```
[
    {
        "id": 1,
        "title": "Ansicht A",
        "help": "..."
    },
    ...
]
```

The `view` action looks like this now:

```

{
    "id": 1,
    "title": "Ansicht A",
    "help": "...",
    "html": "...",
    "attachments": [
        {
            "id": 238,
            "created": "2020-11-12T14:16:06.602000+01:00",
            "updated": "2020-11-17T15:47:31.645000+01:00",
            "file_name": "rdmo-logo.svg",
            "file_url": "/api/v1/projects/values/238/file/"
        },
        ...
    ]
}
```

The `answers` endpoint looks similar but has only `html` and `attachments`.