### PR TITLE
Use setuptools_scm to dynamically create the version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ node_modules
 build
 dist
 *.egg-info
-_version.py
 
 .imdone/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ exclude = ["*assets*", "*tests*"]
 "*" = ["*"]
 
 [tool.setuptools_scm]
-version_file = "rdmo/_version.py"
 version_scheme = "release-branch-semver"
 
 [tool.ruff]

--- a/rdmo/__init__.py
+++ b/rdmo/__init__.py
@@ -1,4 +1,7 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
 try:
-    from ._version import __version__, __version_tuple__, version, version_tuple
-except ImportError:
-    __version__ = __version_tuple__ = version = version_tuple = None
+    VERSION = __version__ = _version(__package__)
+except PackageNotFoundError:
+    VERSION = __version__ = "0.0.0+unknown"


### PR DESCRIPTION
With `2.4.0`, I would like to an automatically generated version, created from the git tag or the latest ref. I use this setup in several other repos for some time now. Any objections @MyPyDavid @afuetterer ? (lets see if this breaks the CI)