### PR TITLE
build(deps): bump pytest and related test depedencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,11 +193,12 @@ rest_framework = ["rest_framework"]
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
 
-[tool.pytest.ini_options]
+[tool.pytest]
+strict = true
 DJANGO_SETTINGS_MODULE = "config.settings"
 testpaths = ["rdmo/*/tests"]
 pythonpath = [".", "testing"]
-addopts = '-p no:randomly -m "not e2e"'
+addopts = ["-ra", "-p no:randomly", "-m", "not e2e"]
 markers = [
   "e2e: marks tests as end-to-end tests using playwright (deselect with '-m \"not e2e\"')",
 ]


### PR DESCRIPTION
## Description

This PR bumps Pytest to >= 9.0 and all its related libraries.
Also now you can use `[tool.pytest]` in the pyproject.toml configuration.
Ref: https://github.com/pytest-dev/pytest/releases/tag/9.0.0

I added `-ra` to the pytest opts, which will print a summary “r”eport of “a”ll results.
Also I added the `strict` setting, which enables strict mode.
https://docs.pytest.org/en/stable/reference/reference.html#confval-strict

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->
Locally in my fork.
