### PR TITLE
3.0.0 refactor project location

### DIFF
--- a/rdmo/projects/assets/js/project/actions/projectActions.js
+++ b/rdmo/projects/assets/js/project/actions/projectActions.js
@@ -15,7 +15,7 @@ import * as actionTypes from './actionTypes'
 export function setPage(page) {
   return function(dispatch) {
     dispatch(updateConfig('page', page))
-    updateLocation(page)
+    updateLocation({ page })
   }
 }
 

--- a/rdmo/projects/assets/js/project/store/configureStore.js
+++ b/rdmo/projects/assets/js/project/store/configureStore.js
@@ -55,11 +55,12 @@ export default function configureStore() {
   )
 
   const getConfigFromLocation = () => {
-    const { page, itemId, itemAction } = parseLocation()
+    const { page, pageId, action, actionId } = parseLocation()
 
     store.dispatch(configActions.updateConfig('page', page, false))
-    store.dispatch(configActions.updateConfig('itemId', itemId, false))
-    store.dispatch(configActions.updateConfig('itemAction', itemAction, false))
+    store.dispatch(configActions.updateConfig('pageId', pageId, false))
+    store.dispatch(configActions.updateConfig('action', action, false))
+    store.dispatch(configActions.updateConfig('actionId', actionId, false))
   }
 
   // this event is triggered when the page first loads

--- a/rdmo/projects/assets/js/project/utils/location.js
+++ b/rdmo/projects/assets/js/project/utils/location.js
@@ -5,19 +5,17 @@ import { isEmpty } from 'lodash'
 export const parseLocation = () => {
   const pathname = window.location.pathname
 
-  const m1 = pathname.match(/\/projects\/\d+\/(?<page>[a-z-]+)\/(?<itemId>\d+)\/(?<itemAction>[a-z-]+)[/]*$/)
-  if (m1) {
-    return m1.groups
-  }
+  const patterns = [
+    /\/projects\/\d+\/(?<page>[a-z-]+)\/(?<pageId>\d+)\/(?<action>[a-z-]+)\/(?<actionId>\d+)[/]*$/,
+    /\/projects\/\d+\/(?<page>[a-z-]+)\/(?<pageId>\d+)\/(?<action>[a-z-]+)[/]*$/,
+    /\/projects\/\d+\/(?<page>[a-z-]+)\/(?<action>[a-z-]+)\/(?<actionId>\d+)[/]*$/,
+    /\/projects\/\d+\/(?<page>[a-z-]+)\/(?<action>[a-z-]+)[/]*$/,
+    /\/projects\/\d+\/(?<page>[a-z-]+)[/]*$/
+  ]
 
-  const m2 = pathname.match(/\/projects\/\d+\/(?<page>[a-z-]+)\/(?<itemId>\d+)[/]*$/)
-  if (m2) {
-    return m2.groups
-  }
-
-  const m3 = pathname.match(/\/projects\/\d+\/(?<page>[a-z-]+)[/]*$/)
-  if (m3) {
-    return m3.groups
+  for (const pattern of patterns) {
+    const match = pathname.match(pattern)
+    if (match) return match.groups
   }
 
   return {
@@ -25,27 +23,23 @@ export const parseLocation = () => {
   }
 }
 
-export const updateLocation = (page, itemId, itemAction) => {
-  const pathname = buildPath(page, itemId, itemAction)
+export const updateLocation = ({ page, pageId, action, actionId }) => {
+  const pathname = buildPath({ page, pageId, action, actionId })
   if (pathname != window.location.pathname) {
     history.pushState(null, null, pathname)
   }
 }
 
-export const buildPath = (page, itemId, itemAction) => {
-  let path = `${baseUrl}/projects/${projectId}/`
+export const buildPath = ({ page, pageId, action, actionId }) => {
+  const segments = [baseUrl, 'projects', projectId]
 
   if (!isEmpty(page)) {
-    path += page + '/'
+    segments.push(page)
 
-    if (!isEmpty(itemId)) {
-      path += itemId + '/'
-
-      if (!isEmpty(itemAction)) {
-        path += itemAction + '/'
-      }
-    }
+    if (!isEmpty(pageId)) segments.push(pageId)
+    if (!isEmpty(action)) segments.push(action)
+    if (!isEmpty(actionId)) segments.push(actionId)
   }
 
-  return path
+  return segments.join('/') + '/'
 }


### PR DESCRIPTION
This PR updates `rdmo/projects/assets/js/project/utils/location.js` to be more flexible. `parseLocation` and `updateLocation` now use both the same object as input/output:

```
{ page, pageId, action, actionId }
```

This should parse the following urls:

```
/projects/1/
/projects/1/interview/
/projects/1/documents/
/projects/1/documents/views/1
/projects/1/snapshots/1/
/projects/1/snapshots/1/answers
/projects/1/snapshots/1/views/1
```

I suggest we use the `documents` page for current answers/views and snapshots and `snapshots` for the snapshots. The highlighting of the sidebar can then just check `page`.