### PR TITLE
Add view information to project wrapper

### DIFF
--- a/rdmo/views/models.py
+++ b/rdmo/views/models.py
@@ -165,6 +165,11 @@ class View(models.Model, TranslationMixin):
             'conditions': project_wrapper.conditions,
             'format': export_format,
             'rdmo_version': __version__,
+            'view': {
+                'id': self.id,
+                'title': self.title,
+                'help': self.help
+            },
             'site': {
                 'name': site.name,
                 'domain': site.domain


### PR DESCRIPTION
This PR adds information about the view to the project wrapper and by this to the available information that can be used in RDMO views.