### PR TITLE
Remove messages framework

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -12,7 +12,6 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
     # rdmo modules
@@ -50,7 +49,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'rdmo.accounts.middleware.TermsAndConditionsRedirectMiddleware'
@@ -68,7 +66,6 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
                 'django_settings_export.settings_export',
             ],
         },


### PR DESCRIPTION
This PR removes the messages framework, mainly to fix the issue with the `messages` cookie in https://github.com/rdmorganiser/rdmo/issues/1189, but also because we never used it anyway (right?).

If we decide to keep it, the following would remove the cookie as well:

```python
MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
```
