### PR TITLE
Message storage

### DIFF
--- a/rdmo/core/settings.py
+++ b/rdmo/core/settings.py
@@ -75,6 +75,8 @@ TEMPLATES = [
     },
 ]
 
+MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
+
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )


### PR DESCRIPTION
This PR sets `MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"` in order to get rid of the messages cookie (instead of https://github.com/rdmorganiser/rdmo/pull/1510 🙄).

Resolves #1189 .