### PR TITLE
Add value signals

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -293,7 +293,7 @@ export function storeValue(value) {
       dispatch(addToPending(pendingId))
       dispatch(storeValueInit(valueId))
 
-      return ValueApi.storeValue(projectId, { ...value, widget_type })
+      return ValueApi.storeValue(projectId, { ...value, widget_type, page: page.id, question: question && question.id })
         .then((value) => {
 
           dispatch(fetchNavigation(page))
@@ -480,12 +480,13 @@ export function deleteValue(value) {
       if (isNil(value.id)) {
         return dispatch(deleteValueSuccess(valueId))
       } else {
-        return ValueApi.deleteValue(projectId, value)
+        const page = getState().interview.page
+        const sets = getState().interview.sets
+        const question = page.questions.find((question) => question.attribute === value.attribute)
+        const refresh = question.optionsets.some((optionset) => optionset.has_refresh)
+
+        return ValueApi.deleteValue(projectId, value, { page: page.id, question: question && question.id })
           .then(() => {
-            const page = getState().interview.page
-            const sets = getState().interview.sets
-            const question = page.questions.find((question) => question.attribute === value.attribute)
-            const refresh = question.optionsets.some((optionset) => optionset.has_refresh)
 
             dispatch(fetchNavigation(page))
             dispatch(updateProgress())

--- a/rdmo/projects/signals.py
+++ b/rdmo/projects/signals.py
@@ -1,0 +1,5 @@
+from django.dispatch import Signal
+
+value_created = Signal()
+value_updated = Signal()
+value_deleted = Signal()

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -75,6 +75,7 @@ from .serializers.v1 import (
 )
 from .serializers.v1.overview import CatalogSerializer, ProjectOverviewSerializer
 from .serializers.v1.page import PageSerializer
+from .signals import value_created, value_deleted, value_updated
 from .utils import (
     check_conditions,
     check_options,
@@ -531,6 +532,24 @@ class ProjectValueViewSet(ProjectNestedViewSetMixin, ModelViewSet):
         'option',
         'option__uri',
     )
+
+    def perform_create(self, serializer):
+        page = self.request.data.pop('page', None)
+        question = self.request.data.pop('question', None)
+        super().perform_create(serializer)
+        value_created.send(sender=Value, instance=serializer.instance, page=page, question=question)
+
+    def perform_update(self, serializer):
+        page = self.request.data.pop('page', None)
+        question = self.request.data.pop('question', None)
+        super().perform_update(serializer)
+        value_updated.send(sender=Value, instance=serializer.instance, page=page, question=question)
+
+    def perform_destroy(self, instance):
+        page = self.request.data.pop('page', None)
+        question = self.request.data.pop('question', None)
+        super().perform_destroy(instance)
+        value_deleted.send(sender=Value, instance=instance, page=page, question=question)
 
     def get_queryset(self):
         return self.project.values.filter(snapshot=None).select_related('attribute', 'option')


### PR DESCRIPTION
This PR adds the value signals we previously considered to allow plugins to only "react" on changes to values if they are triggered through the `ProjectValueViewSet` and not by creating snapshots or copying values.

This is necessary to solve: https://github.com/rdmorganiser/rdmo-plugins-ror/issues/2 and https://github.com/rdmorganiser/rdmo-plugins-orcid/issues/2.

