### PR TITLE
Add value signals

### DIFF
--- a/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
+++ b/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
@@ -67,7 +67,7 @@ export default function interviewReducer(state = initialState, action) {
         (value) => value.id == action.value.id ? {...value, ...action.attrs} : value
       )}
     case STORE_VALUE_SUCCESS:
-      if (state.values.map((value) => (value.id || value.tmp_id)).includes(action.valueId)) {
+      if (state.values.some((value) => (value.id || value.tmp_id) == action.valueId)) {
         return {
           ...state,
           values: state.values.map((value) => (

--- a/rdmo/projects/signals.py
+++ b/rdmo/projects/signals.py
@@ -1,0 +1,5 @@
+from django.dispatch import Signal
+
+value_created = Signal()
+value_updated = Signal()
+value_deleted = Signal()

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -75,6 +75,7 @@ from .serializers.v1 import (
 )
 from .serializers.v1.overview import CatalogSerializer, ProjectOverviewSerializer
 from .serializers.v1.page import PageSerializer
+from .signals import value_created, value_deleted, value_updated
 from .utils import (
     check_conditions,
     check_options,
@@ -531,6 +532,18 @@ class ProjectValueViewSet(ProjectNestedViewSetMixin, ModelViewSet):
         'option',
         'option__uri',
     )
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        value_created.send(sender=Value, instance=serializer.instance)
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        value_updated.send(sender=Value, instance=serializer.instance)
+
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        value_deleted.send(sender=Value, instance=instance)
 
     def get_queryset(self):
         return self.project.values.filter(snapshot=None).select_related('attribute', 'option')


### PR DESCRIPTION
This PR adds the value signals we previously considered to allow plugins to only "react" on changes to values if they are triggered through the `ProjectValueViewSet` and not by creating snapshots or copying values.

This is necessary to solve: https://github.com/rdmorganiser/rdmo-plugins-ror/issues/2 and https://github.com/rdmorganiser/rdmo-plugins-orcid/issues/2.
