### PR TITLE
ci: switch to smaller `ubuntu-slim` runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     name: Indicate completion to coveralls
     needs: test
     if: ${{ always() }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - name: Run Coveralls finish
       uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
@@ -253,7 +253,7 @@ jobs:
       - test-e2e
       - dev-setup
       - dependencies
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:


### PR DESCRIPTION
## Description

For these smaller ci jobs the newer ubuntu-slim runner should be sufficient, no need for a full fledged VM.

Refs: 
- https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/
- https://docs.github.com/en/actions/reference/runners/github-hosted-runners

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. --->
<!--- Include details of your testing environment, and the tests you ran to --->
<!--- see how your change affects other areas of the code, etc. --->

