### PR TITLE
Contributing guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document provides an overview over the architecture of RDMO and provides in
 
 ## Core dependencies
 
-RDMO is a [Django](https://www.djangoproject.com/) application with an integrated [React](https://react.dev/) backend.
+RDMO is a [Django](https://www.djangoproject.com/) application with an integrated [React](https://react.dev/) frontend.
 
 On the backend, it makes heavy use of:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,159 @@
+# Architecture
+
+This document provides an overview over the architecture of RDMO and provides information about the different modules.
+
+## Core dependencies
+
+RDMO is a [Django](https://www.djangoproject.com/) application with an integrated [React](https://react.dev/) backend.
+
+On the backend, it makes heavy use of:
+
+* [Django Rest Framework](https://www.django-rest-framework.org/) (DRF) for the REST API,
+* [rules](https://github.com/dfunckt/django-rules) for object based permissions.
+
+The frontend code relies on:
+
+* [webpack](https://webpack.js.org) for bundling,
+* [Redux](https://redux.js.org/) for state management,
+* [Redux Thunk](https://github.com/reduxjs/redux-thunk) for asynchronous Redux actions,
+* [Bootstrap](https://getbootstrap.com/) as CSS framework,
+* [lodash](https://lodash.com/) for various utilities.
+
+Testing is done with:
+
+* [pytest](https://docs.pytest.org) for the backend,
+* [Playwright](https://playwright.dev) for the frontend.
+
+## File layout
+
+The main `rdmo` package consists of the following modules:
+
+```
+rdmo/
+├── core/              ← Core functionality
+├── accounts/          ← Authentication & user profiles
+├── domain/            ← Domain model
+├── questions/         ← Structure of the questionnaire
+├── conditions/        ← Conditional display of questions or answers
+├── options/           ← Controlled vocabularies for answers
+├── tasks/             ← Follow up actions based on answers
+├── views/             ← Templating for output and export
+├── projects/          ← User projects, snapshots and answers
+├── management/        ← Management editing backend
+└── services/          ← OAuth / external integrations
+```
+
+Each module (an *app* in Django terms) tries to follow the conventional layout and naming conventions:
+
+* `admin.py` → Django admin interface configuration
+* `apps.py` → Django app configuration
+* `assets/` → Source files for the frontend (JavaScript, CSS, ...)
+* `constants.py` → Definition of constant values
+* `exports.py` → Export plugin functionality
+* `filters.py` → Filters for DRF viewsets
+* `forms.py` → Django forms
+* `handlers/` or `handlers.py` → Handlers for Django signals
+* `imports.py` → Helper functionality for the XML import
+* `managers.py` → Managers for Django models
+* `migrations/` → Django database migrations
+* `mixins.py` → Mixins for different classes
+* `models/` or `models.py` → Django database models
+* `permissions.py` → DRF permission classes
+* `providers.py` → Optionset provider plugins
+* `renderers/` or `renderers.py` → Render functionality for the XML export
+* `rules.py` → Object based permissions
+* `serializers/` or `serializers.py` → DRF serializers
+* `signals.py` → Signals for Django signals
+* `static/` → Build front end assets, ignored by Git
+* `templates/` → Django templates
+* `templatetags/` → Django template tags and filters
+* `tests/` → Tests
+* `urls/` or `urls.py` → Django URL mapping
+* `utils.py` → Utility functions
+* `validators.py` → Additional validators for DRF
+* `views/` or `views.py` → Django views
+* `viewsets.py` → DRF viewsets for the REST API
+
+In addition, the `rdmo` repository contains the following notable files or directories:
+
+* `pyproject.toml` → Python package configuration
+* `rdmo/locale` → Translation files
+* `rdmo/share` → Supplemental files
+* `testing` → Test configuration & fixtures
+* `conftest.py` → pytest setup
+* `webpack.config.js` → Frontend build configuration
+* `package.json` and `package-lock.json` → Frontend dependencies
+
+The `assets` directories in the modules use the following structure:
+
+* `assets/js/` → JavaScript front-end code, separated by React app
+    * `actions/` → Actions for the Redux store
+    * `api/` → API classes with methods mapping the endpoints of the REST API
+    * `components/` → React components
+    * `factories/` → Factory functions for front end objects
+    * `hooks/` → React hooks
+    * `reducers/` → Reducers for the Redux store
+    * `store/` → Configuration and initialization of the Redux store
+    * `utils/` → Utility functions
+* `assets/scss/` → Sass files, separated by React app
+* `assets/fonts/`, `assets/img/` → Additional, static assets
+
+## Internal dependencies
+
+```plain
+┌────────────┐         ┌────────────┐
+│ core       │◀───┬────┤ accounts   │
+└────────────┘    │    └────────────┘
+                  │    ┌────────────┐         ┌────────────┐
+                  ├────┤ domain     │◀───┬────┤ projects   │
+                  │    └────────────┘    │    └────────────┘
+                  │    ┌────────────┐    │    ┌────────────┐
+                  ├────┤ conditions │◀───┼────┤ management │
+                  │    └────────────┘    │    └────────────┘
+                  │    ┌────────────┐    │
+                  ├────┤ options    │◀───┤
+                  │    └────────────┘    │
+                  │    ┌────────────┐    │
+                  ├────┤ questions  │◀───┤
+                  │    └────────────┘    │
+                  │    ┌────────────┐    │
+                  ├────┤ tasks      │◀───┤
+                  │    └────────────┘    │
+                  │    ┌────────────┐    │
+                  └────┤ views      │◀───┘
+                       └────────────┘
+```
+
+The modules depend on each other in the following way:
+
+* `core` does not depend on the other modules.
+* `accounts` does only depend on `core`.
+* `conditions`, `domain`, `options`, `questions`, `tasks`, `views` depend only on `core` (with the exception that the `options.Optionset` model and the `conditions.Condition` depend on each other).
+* `project` and `management` depend on `conditions`, `domain`, `options`, `questions`, `tasks`, `views` and `core`.
+
+Besides those dependencies:
+
+* `utils.py` and `managers.py` must not depend on anything inside the module.
+* `models.py` must only depend on `utils.py` and `managers.py`.
+
+If utility functions, which depend on the models are needed, they are put in special files, e.g. `process.py`. Utility functions for tests are placed in `tests/helpers.py`.
+
+Only after careful consideration, functions can use local imports (in the function body) to circumvent the described dependency rules.
+
+## Backend considerations
+
+RDMO tries to follow the conventional style of Django projects. It should work with all database backends and with all common web server setups. The aim is to limit the dependencies and the effort to maintain an instance to a minimum. For the same reason, RDMO does not depend on a caching solution or an infrastructure for asynchronous tasks.
+
+While some parts of RDMO use the common Django MVC-pattern using models, (class-based) views and templates, other parts use the Django Rest Service pattern using viewsets, serializers and renderers. The latter is used by the interactive frontend (see below), but also as scriptable API.
+
+## Frontend considerations
+
+As already mentioned, major parts of RDMO are implemented as separate interactive *single page applications*. In particular:
+
+* the projects table located at `/projects/`,
+* the project dashboard located at `/projects/<id>/`,
+* the management interface located at `/management/`.
+
+The Django template of these pages contain just an empty element, and the functionality is implemented with JavaScript, React and Redux, and makes heavy use of the REST API.
+
+In order to keep the deployment effort low, no node dependencies need to be handled by the maintainers of the instances. Instead, the frontend is build when creating the release and is then shipped as part of the `rdmo` Python package. Frontend source files reside in `rdmo/<module>/assets/` and the build is stored in `rdmo/<module>/static/`, from where Django handles them as regular static files.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,43 +100,25 @@ The `assets` directories in the modules use the following structure:
 
 ## Internal dependencies
 
-```plain
-┌────────────┐         ┌────────────┐
-│ core       │◀───┬────┤ accounts   │
-└────────────┘    │    └────────────┘
-                  │    ┌────────────┐         ┌────────────┐
-                  ├────┤ domain     │◀───┬────┤ projects   │
-                  │    └────────────┘    │    └────────────┘
-                  │    ┌────────────┐    │    ┌────────────┐
-                  ├────┤ conditions │◀───┼────┤ management │
-                  │    └────────────┘    │    └────────────┘
-                  │    ┌────────────┐    │
-                  ├────┤ options    │◀───┤
-                  │    └────────────┘    │
-                  │    ┌────────────┐    │
-                  ├────┤ questions  │◀───┤
-                  │    └────────────┘    │
-                  │    ┌────────────┐    │
-                  ├────┤ tasks      │◀───┤
-                  │    └────────────┘    │
-                  │    ┌────────────┐    │
-                  └────┤ views      │◀───┘
-                       └────────────┘
-```
-
-The modules depend on each other in the following way:
+The modules directly depend on each other (e.g. by importing classes or functions) in the following way:
 
 * `core` does not depend on the other modules.
-* `accounts` does only depend on `core`.
-* `conditions`, `domain`, `options`, `questions`, `tasks`, `views` depend only on `core` (with the exception that the `options.Optionset` model and the `conditions.Condition` depend on each other).
-* `project` and `management` depend on `conditions`, `domain`, `options`, `questions`, `tasks`, `views` and `core`.
+* `accounts` and `domain` depend only on `core`.
+* `conditions` depends on `core`, `domain`, and `options`.
+* `options` depends on `core` and `conditions`.
+* `questions` depends on `core`, `conditions`, `domain`, and `options`.
+* `tasks` depends on `core`, `conditions`, `domain`, and `questions`.
+* `views` depends on `core` and `questions`.
+* `project` and `management` depend on `core`, `conditions`, `domain`, `options`, `questions`, `tasks`, and `views`.
 
 Besides those dependencies:
 
 * `utils.py` and `managers.py` must not depend on anything inside the module.
 * `models.py` must only depend on `utils.py` and `managers.py`.
 
-If utility functions, which depend on the models are needed, they are put in special files, e.g. `process.py`. Utility functions for tests are placed in `tests/helpers.py`.
+If utility functions are needed, which depend on the models they are put in special files, e.g. `process.py`. Utility functions for tests are placed in `tests/helpers.py`.
+
+Besides those relationships, which should not be extended, implicit dependencies exists, e.g. when functions take objects from other modules as arguments.
 
 Only after careful consideration, functions can use local imports (in the function body) to circumvent the described dependency rules.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,30 +1,33 @@
-Code of Conduct
-===============
+# Code of Conduct
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as contributors and maintainers pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-Examples of behavior that contributes to creating a positive environment include:
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+Examples of behavior that contributes to a positive environment for our community include:
 
-Examples of unacceptable behavior by participants include:
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Publishing others' private information, such as a physical or email address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at rdmo-team@listserv.dfn.de. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+This Code of Conduct applies within all spaces maintained by the **RDMO. Research Data Management Organiser e.V.** ("RDMO e.V."), including the GitHub organization at <https://github.com/rdmorganiser>, the RDMO mailing list, the RDMO Matrix space, and any other communication channels operated on behalf of the community. It also applies when an individual is representing the community in public spaces.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the RDMO e.V. at <contact@rdmo.org>. All complaints will be reviewed and investigated, and will receive a response that is deemed appropriate to the circumstances. The RDMO e.V. is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at http://contributor-covenant.org/version/1/4.
+Maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the board (*Vorstand*) of the RDMO e.V.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), drawing from versions [1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) and [2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,94 +1,104 @@
 # Contributing to RDMO
 
-You are welcome to contribute to RDMO by improving and changing it! However, we want to provide a stable software for the community and therefore ask you to follow the following workflow.
+RDMO is the work of a community of people committed to improving research data management and the tools that support it. Over the last decade, contributors from different fields and institutions have come together to build something that genuinely serves researchers.
 
-Here is a list of important resources for new contributors:
+We are always happy to welcome new contributors! Whether you are reporting a bug, improving the documentation, or working on a new feature, every contribution, no matter how small, is a meaningful part of that effort. We are glad you are here.
 
-- [Source Code](https://github.com/rdmorganiser/rdmo)
-- [Documentation](https://rdmo.readthedocs.io)
-- [Issue Tracker](https://github.com/rdmorganiser/rdmo/issues)
-- [Code of Conduct](https://github.com/rdmorganiser/rdmo/blob/main/CODE_OF_CONDUCT.md)
+To make sure contributions can be reviewed and integrated smoothly, we ask that you take a few minutes to read through this guide. It covers how the RDMO community is organized, how we work as a distributed open source project, our development process, and the coding styles and tools we use.
 
-## How to report a bug
+While this document describes the work on the main [RDMO repository](https://github.com/rdmorganiser/rdmo), these principles also apply to the other tools and plugins maintained by the RDMO community. Please note the separate documents regarding the [architecture](https://github.com/rdmorganiser/rdmo/blob/main/ARCHITECTURE.md) and [coding style](https://github.com/rdmorganiser/rdmo/blob/main/STYLE.md) of RDMO.
 
-If you found a bug or want a feature to be added, look at the existing [issues](https://github.com/rdmorganiser/rdmo/issues) first. If you find a corresponding issue, please comment on it. If no issue matches, create one (select "Bug report").
+## Code of conduct
 
-When filing an issue, make sure to answer these questions:
+To keep our community open, respectful, and welcoming for everyone, we ask all contributors and maintainers to follow our [Code of Conduct](https://github.com/rdmorganiser/rdmo/blob/main/CODE_OF_CONDUCT.md).
 
-- Which operating system and Python version are you using?
-- Which version of this project are you using?
+## Governance
+
+Since 2024, the **RDMO. Research Data Management Organiser e.V.** acts as governance for the development and maintenance of RDMO, is point of contact for developers and users, organizes release management and manages external communications. All of this is carried out in collaboration with the entire RDMO community.
+
+A **Release Manager** has been appointed to oversee the technical development of the software, whilst following the instructions of the Board and reporting annually to the General Meeting. This includes the coordination of releases as well as coordinating development activities, ensuring consistent code quality and maintaining the necessary tools for bug tracking, documentation, and source code management.
+
+The community maintains the **Software Group**, which supports all software development around RDMO, and the **Content Groups**, which works on questionnaires, views and other RDMO content. Both groups meet regularly. If you aim to contribute to RDMO, it is best to join one of those meetings. Please join our mailing list to stay updated on these meetings and all other activities around RDMO: rdmo@listserv.dfn.de.
+
+You can contact us via email at contact@rdmo.org or join our Matrix space at [rdmo:matrix.org](https://matrix.to/#/#rdmo:matrix.org).
+
+## Development process
+
+RDMO uses GitHub as development platform. The main [RDMO repository](https://github.com/rdmorganiser/rdmo), as well as all other software and content, which is maintained by the community, is stored in the [RDMO GitHub organisation](https://github.com/rdmorganiser). If you consider yourself part of the community, we kindly encourage you to join this organisation as a public member, so others can see you are part of the community.
+
+### Issues
+
+If you found a bug in RDMO or want a feature to be added, look at the existing [issues](https://github.com/rdmorganiser/rdmo/issues) first. If you find a corresponding issue, please comment on it. If no issue matches, create one (select *Bug report* or *Feature request*). When reporting a bug, make sure to answer these questions:
+
+- Which version of RDMO are you using?
+- Which RDMO instance are you working with?
+- Which operating system, browser and Python version are you using?
 - What did you do?
-- What did you expect to see?
-- What did you see instead?
+- What did you expect to happen?
+- What happened instead?
 
-The best way to get your bug fixed is to provide a test case, and/or steps to reproduce the issue.
-
-## How to request a feature
-
-If you want a feature to be added, look at the existing [issues](https://github.com/rdmorganiser/rdmo/issues) first. If you find a corresponding issue, please comment on it. If no issue matches, create one (select "Feature request").
+The best way to get your bug fixed is to provide precise steps to reproduce the issue.
 
 If you decide to work on the issue yourself, please wait until you received some feedback from us. Maybe we are already working on it (and forgot to comment on the issue), or we have other plans for the affected code.
 
-## How to set up your development environment
+As a general rule, **all software bugs should be reported as GitHub issues**. An exception are security-critical bugs, which may also be reported confidentially to the release management, to be made public only once they have been fixed.
 
-You need [Python 3.10+](https://www.python.org/downloads).
+In any case, to avoid unintentional duplication of effort, **always create an issue before you start working on the code**.
 
-Install the package with development requirements:
+### Pull requests
 
-```console
-$ pip install -e ".[dev]"
-$ pip show rdmo
-Name: rdmo
-Version: 2.0.0
-[...]
-```
+All changes to RDMO must be submitted as [pull request](https://github.com/rdmorganiser/rdmo/pulls) (PR) on GitHub. As stated above, an issue should be reported beforehand. Each pull request undergoes a review process involving the release manager and/or other experienced developers before it can be merged. Reviewers are expected to assess the changes for correctness, code quality, compatibility, and alignment with the conventions described in this document.
 
-See also: [Development docs](https://rdmo.readthedocs.io/en/latest/development/setup.html).
+Pull requests may only be merged once all required reviews have been approved and any raised concerns have been addressed. The release manager holds final responsibility for approving and coordinating the merge of contributions into the main code base. Before merge, PR need to be rebased to the target branch by the creator of the PR.
 
-## How to test the project
+The review by the release manager and the other developers **does not replace thorough testing of functionality and performance** by the contributor. Please make the process as easy as possible for the reviewers.
 
-Run the full test suite with pytest:
+### Milestones
 
-```console
-$ pytest
-```
+In order to improve the transparency of the development process, all issues and pull requests are assigned to a [milestone](https://github.com/rdmorganiser/rdmo/milestones), which correspond to the new RDMO version in development.
 
-See also: [Testing docs](https://rdmo.readthedocs.io/en/latest/development/testing.html).
+### Releases
 
-## How to submit changes
+Once all issues relating to the milestone have been resolved and the release has been reviewed in depth, the release manager will merge the release branch into the `main` branch and create a new release on [GitHub](https://github.com/rdmorganiser/rdmo/releases) and [PyPI](https://pypi.org/project/rdmo/). Following the release, the community will be notified via email and social media.
 
-It is recommended to open an issue before starting work on anything. This will allow a chance to talk it over with the owners and validate your approach.
+RDMO uses [semantic versioning](https://semver.org). While the major version is only increased for major changes in the data model or the user interface, the minor version is incremented for changes that potentially need instance maintainers to update their local setup or theme. The patch version is increased for non-breaking bug fixes and minor changes to functionality.
 
-Please fork our repository and create a new branch named according to what you want to do (e.g. `fix_login_form` or `fancy_feature`).
+For major and minor releases we prepare a release candidate to be tested by the community. The period between the release candidate and the actual release should be at least 4 weeks.
 
-Open a [pull request](https://github.com/rdmorganiser/rdmo/pulls) to submit changes to this project. Afterwards, check if your branch is still up to date. If not perform a rebase. The project team will review your pull request.
+### Commits and Branches
 
-Your pull request needs to meet the following guidelines for acceptance:
+Ideally, commits should made often, ideally after every small, logical unit of work. Keep the later use in e.g. `git blame` in mind. Commit messages should be clear and concise and should use the imperative mood, be capitalized, not end in a period, and not exceed 72 characters. If a longer messages is needed, separate subject and body by an empty line (see also [How to Write a Git Commit Message](https://cbea.ms/git-commit/)).
 
-- The pytest suite must pass without errors and warnings.
-- Include unit tests.
-- If your changes add functionality, update the documentation accordingly.
+The `main` branch of RDMO should always be in sync with the latest release. It is protected on GitHub and must not be updated without consulting the release manager. Usually it is only updated immediately before the release. Release branches are named `<version>/release` and collect all contributions leading to the release. When working on the code, please name your branches according to the following pattern: `<version>/<type>/<description>`, e.g. `2.4.1/fix/date-picker` or `2.5.0/feature/nh3`. Please use hyphens (`-`) instead of underscores (`_`).
 
-Feel free to submit early, though—we can always iterate on this.
+## Coding style
 
-To run linting and code formatting checks before committing your change, you can install pre-commit as a Git hook by running the following command:
+In general, we prioritize readable, maintainable code over clever or overly concise solutions. A key part of this is adhering to the [Locality of Behaviour](https://htmx.org/essays/locality-of-behaviour/) principle: the behaviour of a unit of code should be as obvious as possible by looking only at that unit of code. The logic of a single feature should not be split across distant files or layers when it can reasonably live together. Separate functions should only be created if a certain functionality is used on several occasions, if the separation follows a common pattern or if the function is tested independently.
 
-```console
-$ pre-commit install
-```
+When submitting pull requests, please keep it small and focused. A good PR addresses a single feature, bug fix, or concern. Avoid bundling unrelated changes, such as refactors, formatting cleanups, or dependency updates, alongside functional changes, as this makes review slower and harder to reason about. If you notice something that needs fixing while working on a PR, open a separate issue or PR for it rather than folding it in. Smaller, well-scoped PRs are easier to review and faster to merge.
 
-To run the linting and code formatting checks (e.g. ruff) on the entire code base, use the command:
+In RDMO, we try to follow common conventions from the Python, Django and React communities. By now, RDMO has developed its own coding style, which we ask you to respect. For Python code, we use [ruff](https://github.com/astral-sh/ruff) for automatic linting and follow its suggestions. Unlike many Python projects, we do not enforce [black](https://github.com/psf/black) or [ruff format](https://github.com/astral-sh/ruff). Contributors are trusted to follow the style guidelines without automated formatting.
 
-```console
-$ pre-commit run --all-files --color=always
-```
+For a full breakdown of naming conventions, style, patterns, API and UX considerations see the separate [Code Style Reference](https://github.com/rdmorganiser/rdmo/blob/main/STYLE.md).
 
-These checks will run as a CI job as well.
+## AI contributions
 
-## Code style
+AI-assisted coding is permitted in this project, though contributors bear full responsibility for any AI-generated code they submit. All contributions, regardless of how they were written, must meet the same standards of quality, correctness, and style. Contributors are expected to review, test, and understand every line of code they submit. **Submitting AI output without verification is not acceptable.** When AI tooling plays a significant role in a contribution, please explain the used models and tooling in the PR description. This helps maintainers give useful feedback and keeps our review process transparent.
 
-Please use the [coding standards from the Django project](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/) and try to follow our conventions as close as possible.
+## Development environment
 
----
+While not mandatory, we suggest to use the development setup as described in the [RDMO documentation](https://rdmo.readthedocs.io/en/latest/development/index.html).
 
-*This contributor guide is adapted from [cookiecutter-hypermodern-python 2022.6.3 (MIT License)](https://github.com/cjolowicz/cookiecutter-hypermodern-python/blob/2022.6.3/%7B%7Bcookiecutter.project_name%7D%7D/CONTRIBUTING.md).*
+## Testing
+
+Automatic tests are very important to us and we require tests for each new feature implemented. Usually we implement and run integration tests, which perform single requests against a URL or endpoint. Most crucial are tests, which perform requests as different users with different permissions. If you intend to add tests for your contributed code, we recommend looking at the existing tests to get a better understanding of our testing approach.
+
+How to run the tests is described in the [Testing docs of the RDMO documentation](https://rdmo.readthedocs.io/en/latest/development/index.html)
+
+## Continuous integration
+
+The [RDMO repository](https://github.com/rdmorganiser/rdmo) on GitHub uses GitHub actions to run a series of test and build jobs on each push to a branch with an active pull request. Passing these checks is mandatory for all contributions.
+
+## Pre-commit hooks
+
+In order to improve code quality and consistency before every commit, we use [pre-commit](https://pre-commit.com). To install the hook in your copy of the repository, install pre-commit (`pip install pre-commit`) and run `pre-commit install`. From that point on, the configured hooks will run automatically on any staged files when you run commit. If a hook fails or modifies a file, the commit will be aborted and you can review the changes, re-stage the files, and commit again. You can also run all hooks manually against the entire code base at any time with `pre-commit run --all`, which is recommended before opening a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ For major and minor releases we prepare a release candidate to be tested by the 
 
 ### Commits and Branches
 
-Ideally, commits should made often, ideally after every small, logical unit of work. Keep the later use in e.g. `git blame` in mind. Commit messages should be clear and concise and should use the imperative mood, be capitalized, not end in a period, and not exceed 72 characters. If a longer messages is needed, separate subject and body by an empty line (see also [How to Write a Git Commit Message](https://cbea.ms/git-commit/)).
+Ideally, commits should be made often, ideally after every small, logical unit of work. Keep the later use in e.g. `git blame` in mind. Commit messages should be clear and concise and should use the imperative mood (e.g. `Add ...` instead of `Adding ...` or `Adds ...`), be capitalized, not end in a period, and not exceed 72 characters. If the commit relates to a specific issue, please include it in the message (e.g. `Fix ... (#123)`).
 
 The `main` branch of RDMO should always be in sync with the latest release. It is protected on GitHub and must not be updated without consulting the release manager. Usually it is only updated immediately before the release. Release branches are named `<version>/release` and collect all contributions leading to the release. When working on the code, please name your branches according to the following pattern: `<version>/<type>/<description>`, e.g. `2.4.1/fix/date-picker` or `2.5.0/feature/nh3`. Please use hyphens (`-`) instead of underscores (`_`).
 
@@ -77,7 +77,7 @@ In general, we prioritize readable, maintainable code over clever or overly conc
 
 When submitting pull requests, please keep it small and focused. A good PR addresses a single feature, bug fix, or concern. Avoid bundling unrelated changes, such as refactors, formatting cleanups, or dependency updates, alongside functional changes, as this makes review slower and harder to reason about. If you notice something that needs fixing while working on a PR, open a separate issue or PR for it rather than folding it in. Smaller, well-scoped PRs are easier to review and faster to merge.
 
-In RDMO, we try to follow common conventions from the Python, Django and React communities. By now, RDMO has developed its own coding style, which we ask you to respect. For Python code, we use [ruff](https://github.com/astral-sh/ruff) for automatic linting and follow its suggestions. Unlike many Python projects, we do not enforce [black](https://github.com/psf/black) or [ruff format](https://github.com/astral-sh/ruff). Contributors are trusted to follow the style guidelines without automated formatting.
+In RDMO, we try to follow common conventions from the Python, Django and React communities. By now, RDMO has developed its own coding style, which we ask you to respect. For Python code, we use [ruff](https://github.com/astral-sh/ruff) for automatic linting and formatting. For JavaScript we use [ESLint](https://eslint.org/).
 
 For a full breakdown of naming conventions, style, patterns, API and UX considerations see the separate [Code Style Reference](https://github.com/rdmorganiser/rdmo/blob/main/STYLE.md).
 
@@ -93,7 +93,7 @@ While not mandatory, we suggest to use the development setup as described in the
 
 Automatic tests are very important to us and we require tests for each new feature implemented. Usually we implement and run integration tests, which perform single requests against a URL or endpoint. Most crucial are tests, which perform requests as different users with different permissions. If you intend to add tests for your contributed code, we recommend looking at the existing tests to get a better understanding of our testing approach.
 
-How to run the tests is described in the [Testing docs of the RDMO documentation](https://rdmo.readthedocs.io/en/latest/development/index.html)
+How to run the tests is described in the [Testing docs of the RDMO documentation](https://rdmo.readthedocs.io/en/latest/development/testing.html)
 
 ## Continuous integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to RDMO
 
+> This document took effect in accordance with § 11 of the Articles of Association (Vereinssatzung) by resolution of the General Meeting of the association **RDMO. Research Data Management Organiser e. V.** on May 18, 2026. Changes to this document require the approval of the General Meeting.
+
 RDMO is the work of a community of people committed to improving research data management and the tools that support it. Over the last decade, contributors from different fields and institutions have come together to build something that genuinely serves researchers.
 
 We are always happy to welcome new contributors! Whether you are reporting a bug, improving the documentation, or working on a new feature, every contribution, no matter how small, is a meaningful part of that effort. We are glad you are here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We are always happy to welcome new contributors! Whether you are reporting a bug
 
 To make sure contributions can be reviewed and integrated smoothly, we ask that you take a few minutes to read through this guide. It covers how the RDMO community is organized, how we work as a distributed open source project, our development process, and the coding styles and tools we use.
 
-While this document describes the work on the main [RDMO repository](https://github.com/rdmorganiser/rdmo), these principles also apply to the other tools and plugins maintained by the RDMO community. Please note the separate documents regarding the [architecture](https://github.com/rdmorganiser/rdmo/blob/main/ARCHITECTURE.md) and [coding style](https://github.com/rdmorganiser/rdmo/blob/main/STYLE.md) of RDMO.
+While this document describes the work on the main [RDMO repository](https://github.com/rdmorganiser/rdmo), these principles also apply to the other tools and plugins maintained by the RDMO community. Please note the separate documents regarding the [architecture](https://github.com/rdmorganiser/rdmo/blob/main/ARCHITECTURE.md), the [security policy](https://github.com/rdmorganiser/rdmo/blob/main/SECURITY.md) and [coding style](https://github.com/rdmorganiser/rdmo/blob/main/STYLE.md) of RDMO.
 
 ## Code of conduct
 
@@ -41,7 +41,7 @@ The best way to get your bug fixed is to provide precise steps to reproduce the 
 
 If you decide to work on the issue yourself, please wait until you received some feedback from us. Maybe we are already working on it (and forgot to comment on the issue), or we have other plans for the affected code.
 
-As a general rule, **all software bugs should be reported as GitHub issues**. An exception are security-critical bugs, which may also be reported confidentially to the release management, to be made public only once they have been fixed.
+As a general rule, **all software bugs should be reported as GitHub issues**. Exceptions are security-critical bugs, which may also be reported confidentially to the release management, to be made public only once they have been fixed (see the [security policy](https://github.com/rdmorganiser/rdmo/blob/main/SECURITY.md) for details)).
 
 In any case, to avoid unintentional duplication of effort, **always create an issue before you start working on the code**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Scope
+
+This policy defines how the RDMO. Research Data Management Organiser e.V. (hereafter "RDMO e.V."), which maintains the GitHub organization at <https://github.com/rdmorganiser>, fulfills its obligations as an open‑source software steward under the EU Cyber Resilience Act (CRA) for the open‑source projects that we systematically support on GitHub. This applies to:
+
+* the main [`rdmo`](https://github.com/rdmorganiser/rdmo) repository
+* the [`rdmo-app`](https://github.com/rdmorganiser/rdmo-app) repository
+* the [`rdmo-catalog`](https://github.com/rdmorganiser/rdmo-catalog) repository
+
+For issues in plugins, themes, or local instances, please report to the respective maintainers. The RDMO team is happy to help coordinate where possible.
+
+## Roles and responsibilities
+
+The **RDMO e.V.** acts as governance for the development and maintenance of RDMO. The association is legally represented by its board (Vorstand).
+
+The **Release Manager** is appointed by the association and oversees the technical development of the software. This includes vulnerability intake, coordination, and disclosure.
+
+**security@rdmo.org** acts as the official contact point for all security related inquiries.
+
+## Supported versions
+
+RDMO is distributed as a Python package on [PyPI](https://pypi.org/project/rdmo/) with accompanying [releases on GitHub](https://github.com/rdmorganiser/rdmo/releases). Security fixes are released on the latest minor version line. Earlier releases do not receive backports as a matter of policy. The supported remediation for older deployments is to upgrade. Security fixes are usually announced as part of a [new release on GitHub](https://github.com/rdmorganiser/rdmo/releases) accompanied by a message on the [RDMO mailing list](https://www.listserv.dfn.de/sympa/subscribe/rdmo).
+
+The [`rdmo-app`](https://github.com/rdmorganiser/rdmo-app) repository follows a rolling-release model and is updated by pulling the latest `main` branch or manually implementing the changes into the local fork. The [`rdmo-catalog`](https://github.com/rdmorganiser/rdmo-catalog) repository uses [releases on GitHub](https://github.com/rdmorganiser/rdmo-catalog/releases).
+
+Operators of RDMO instances are strongly encouraged to subscribe to release notifications on GitHub, as well as subscribe to the [RDMO mailing list](https://www.listserv.dfn.de/sympa/subscribe/rdmo), and to keep their deployments up to date.
+
+## Reporting a vulnerability
+
+**Short version: please report security issues by emailing security@rdmo.org.**
+
+Regular bugs and feature requests should be reported as public [issues](https://github.com/rdmorganiser/rdmo/issues) on GitHub. Due to the sensitive nature of security issues, please **do not** report vulnerabilities in this way. Instead, please report confidentially by emailing security@rdmo.org. The Release Manager will then work with you to resolve any issues where required, prior to any public disclosure.
+
+If you report a vulnerability, please include:
+
+* A brief description of the issue and where it occurs.
+* A minimal, working proof of concept (code snippet or reproduction steps).
+* The versions of RDMO, Django and Python you tested against.
+* Optionally, a minimal patch with the mitigation for the issue.
+
+The Release Manager will acknowledge reports within 5 working days and provide an initial assessment within 10 working days.
+
+Because RDMO is maintained by a small team, please allow reasonable time for triage and remediation before any public disclosure. Our process is modeled on the [Django project's security policy](https://docs.djangoproject.com/en/dev/internals/security/).
+
+## Development practices
+
+All maintainers are required to maintain secure workflows and development environments. This includes the following practices:
+
+* The default `main` branch of a repository is protected and all changes require pull requests.
+* Pull requests must be reviewed by another maintainer and have at least one approving review before merging.
+* Pull requests must not be merged if the continuous integration workflows fail.
+* Maintainers with write access must enable two-factor authentication on GitHub.
+
+## Cooperation with authorities
+
+In accordance with the EU Cyber Resilience Act, the RDMO e.V., represented by its board (Vorstand), is the legal entity responsible for cooperation with market-surveillance authorities. The operational contact point is security@rdmo.org.

--- a/STYLE.md
+++ b/STYLE.md
@@ -102,4 +102,4 @@ Custom CSS code should be kept to a minimum. For CSS classes hyphens `-` should 
 
 In the interactive front end, regular links (using the `a` tag) should only be used to navigate to a frontend location or a backend URL, which actually exists and which users might want to copy or bookmark. In all other cases, a `button` is preferred. The CSS class `link` can be used to make it look like a link. Usually `button` has `type="button"`, unless used as submit button in a form.
 
-Form input fields should apply or save automatically. This save operation needs a visual indicator to communicate success to the user. An exception are fields in models, which are saved when the submit button of the modal is clicked.
+Form input fields should apply or save automatically. This save operation needs a visual indicator to communicate success to the user. An exception are fields in modals, which are saved when the submit button of the modal is clicked.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,102 @@
+# Coding Style
+
+This document outlines the naming conventions and code patterns used in RDMO, as well as guidelines for the user interface. There may be cases where deviating from these conventions is necessary. In such cases, the reasoning should either be documented in a comment or be clear from the surrounding context of the code.
+
+## Naming conventions
+
+Consistent and descriptive naming is one of the key factors for readable and maintainable code. Giving good names to variables, functions, and classes not only makes the code easier to understand and debug, it also helps when reviewing code and onboarding new team members.
+
+In general, we want to follow established naming conventions used in [Django](https://www.djangoproject.com), [Django Rest Framework](https://www.django-rest-framework.org) (DRF), [React](https://react.dev) and [Bootstrap](https://getbootstrap.com). In addition, please follow the guidelines below when naming new variables, functions or methods:
+
+* The prefixes `set` and `get` should be used for functions which perform little to none operations. In Python classes, we prefer `@property` instead of `get_egg(self)`. For more complex functions we use `compute` as prefix. An exception are well established Django/DRF patterns like `get_queryset`.
+* If functions access the network (e.g. in the front end) or the database, `fetch` and `store` are good prefixes.
+* The words `list`, `retrieve`, `create`, `update`, `delete` correspond to *actions* in DRF. The boolean `detail` describes whether the API works with one object or a list.
+* The Django permission system uses `view`, `add`, `change`, `delete` to describe the operations it checks. The same words are used in the admin interface.
+* The data model of RDMO introduces its own vocabulary, which can lead to confusion. Terms like `catalog`, `section`, `page`, `view`, `attribute`, or `value` should only be used when the context is clear.
+* For function props, we use names like `onClick` and `onSubmit`. When handling events in the body of a component, we use functions like `handleClick` or `handleSubmit`.
+* Custom hooks should be prefixed with `use`.
+* In the front end, `location` describes the current URL visible to the user, usually in the form of a JavaScript state object containing the different parameters.
+
+Please note [ARCHITECTURE.md](https://github.com/rdmorganiser/rdmo/blob/main/ARCHITECTURE.md) for the file naming conventions used in RDMO.
+
+## Language-Specific Patterns
+
+### Python and Django
+
+For Python code, we use [ruff](https://github.com/astral-sh/ruff) as linter (as configured in `pyproject.toml`) and follow its suggestions. Unlike many Python projects, we do not enforce [black](https://github.com/psf/black) or [ruff format](https://github.com/astral-sh/ruff). Contributors are trusted to follow the style guidelines without automated formatting.
+
+The maximum line length is 120 characters. When breaking longer statements, we avoid `\`. We use **single quotes for strings**. Double-quotes are used in favor of escaping quotes in strings or when using dicts in f-strings. For constant iterables we use tuples `()` instead of lists `[]`.
+
+Examples:
+
+```python
+# use parenthesis and indent nicely
+last_changed_subquery = Subquery(
+    Value.objects.filter(project=OuterRef('pk'))
+                 .order_by('-updated')
+                 .values('updated')[:1]
+)
+
+# multi line strings have the space at the end
+Error(
+    "When ACCOUNT_TERMS_OF_USE is enabled, "
+    "The TermsAndConditionsRedirectMiddleware is missing from the middlewares.",
+    ...
+)
+
+# we prefer line breaks after { or [
+get_kwargs = {
+    'attribute': data.get('attribute'),
+    'set_prefix': data.get('set_prefix'),
+    'set_index': data.get('set_index')
+}
+```
+
+RDMO uses [Django settings](https://docs.djangoproject.com/en/6.0/ref/settings/) extensively. All settings have a default value set in `rdmo/core/settings.py`. For readability, settings must not check if they exists (e.g. using `try/except` or `hasattr`).
+
+Complex database requests can have a big impact on the performance of the application. Queries using multiple models / tables need to make use of [select_related](https://docs.djangoproject.com/en/stable/ref/models/querysets/#select-related) and [prefetch_related](https://docs.djangoproject.com/en/stable/ref/models/querysets/#prefetch-related). [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io) can be used to access database performance.
+
+### JavaScript and React
+
+In the JavaScript code, we use [ESlint](https://eslint.org). Like for the Python code, we use a maximum line length of 120 characters and single quotes for strings. Semicolons are omitted. Indentation uses 2 spaces, with switch case bodies indented one level inside the switch and the branches of ternary expressions indented when they wrap. Multiline ternaries must place each arm on its own line whenever the expression spans multiple lines.
+
+In JSX, multiline expressions must be wrapped in parentheses with the opening parenthesis on a new line. Inside JSX curly braces, newlines are required when the expression is multiline, while single-line expressions must be spaced consistently within the same block. JSX attribute quotes use double quotes (e.g., `className="foo"`), as opposed to the single quotes used elsewhere in JS.
+
+Examples:
+
+```javascript
+// conditional rendering
+{
+  attribute.id && (
+    <div className="panel-body panel-border">
+      {info}
+    </div>
+  )
+}
+
+// multiline tertiary operators
+{
+  page.id ? (
+    <>
+      <strong>{gettext('Page')}{': '}</strong>
+      <code className="code-questions">{page.uri}</code>
+    </>
+  ) : (
+    <strong>{gettext('Create page')}</strong>
+  )
+}
+```
+
+We only use functional components and only one component should be in a single file.
+
+## UI/UI considerations
+
+All front end logic needs to be implemented with a consistent user experience in mind. Generic components reside in `rdmo/core/assets/js/components` and should be used where ever possible.
+
+The styling should align with Bootstrap and it should be possible to adjust the visual style in a local theme using CSS variables alone and **without re-building the front end**.
+
+Custom CSS code should be kept to a minimum. For CSS classes hyphens `-` should be used instead of underscores (`_`).
+
+In the interactive front end, `a` should be used when there is a front end route or a backend URL which users might want to copy or bookmark. In all other cases, a `button` is preferred. The CSS class `link` can be used to make it look like a link. Usually `button` has `type="button"`, unless used as submit button in a form.
+
+Form input fields should should apply or save automatically. This save operation needs a visual indicator to communicate success to the user. An exception are fields in models modals are only saved on the submit button of the modal.

--- a/STYLE.md
+++ b/STYLE.md
@@ -6,10 +6,11 @@ This document outlines the naming conventions and code patterns used in RDMO, as
 
 Consistent and descriptive naming is one of the key factors for readable and maintainable code. Giving good names to variables, functions, and classes not only makes the code easier to understand and debug, it also helps when reviewing code and onboarding new team members.
 
-In general, we want to follow established naming conventions used in [Django](https://www.djangoproject.com), [Django Rest Framework](https://www.django-rest-framework.org) (DRF), [React](https://react.dev) and [Bootstrap](https://getbootstrap.com). In addition, please follow the guidelines below when naming new variables, functions or methods:
+In general, we want to follow established naming conventions used in Django, Django Rest Framework (DRF), React, Redux and Bootstrap. In addition, please follow the guidelines below when naming new variables, functions or methods:
 
-* The prefixes `set` and `get` should be used for functions which perform little to none operations. In Python classes, we prefer `@property` instead of `get_egg(self)`. For more complex functions we use `compute` as prefix. An exception are well established Django/DRF patterns like `get_queryset`.
+* The prefixes `set` and `get` should be used for functions which perform little to none operations.
 * If functions access the network (e.g. in the front end) or the database, `fetch` and `store` are good prefixes.
+* For more complex functions we use `compute` as prefix. An exception are well established Django/DRF patterns like `get_queryset`.
 * The words `list`, `retrieve`, `create`, `update`, `delete` correspond to *actions* in DRF. The boolean `detail` describes whether the API works with one object or a list.
 * The Django permission system uses `view`, `add`, `change`, `delete` to describe the operations it checks. The same words are used in the admin interface.
 * The data model of RDMO introduces its own vocabulary, which can lead to confusion. Terms like `catalog`, `section`, `page`, `view`, `attribute`, or `value` should only be used when the context is clear.
@@ -23,9 +24,7 @@ Please note [ARCHITECTURE.md](https://github.com/rdmorganiser/rdmo/blob/main/ARC
 
 ### Python and Django
 
-For Python code, we use [ruff](https://github.com/astral-sh/ruff) as linter (as configured in `pyproject.toml`) and follow its suggestions. Unlike many Python projects, we do not enforce [black](https://github.com/psf/black) or [ruff format](https://github.com/astral-sh/ruff). Contributors are trusted to follow the style guidelines without automated formatting.
-
-The maximum line length is 120 characters. When breaking longer statements, we avoid `\`. We use **single quotes for strings**. Double-quotes are used in favor of escaping quotes in strings or when using dicts in f-strings. For constant iterables we use tuples `()` instead of lists `[]`.
+For Python code, we use [ruff](https://github.com/astral-sh/ruff) as linter and formatter (as configured in `pyproject.toml`). Instead of the [black](https://github.com/psf/black)/[ruff format](https://docs.astral.sh/ruff/formatter/) defaults, we use a maximum line length of 120 characters and single quotes for strings. [Magic trailing commas](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma) can be used to enforce line breaks and to format lists and dicts in a consistent way.
 
 Examples:
 
@@ -33,24 +32,28 @@ Examples:
 # use parenthesis and indent nicely
 last_changed_subquery = Subquery(
     Value.objects.filter(project=OuterRef('pk'))
-                 .order_by('-updated')
-                 .values('updated')[:1]
+    .order_by('-updated')
+    .values('updated')[:1]
 )
 
 # multi line strings have the space at the end
 Error(
     "When ACCOUNT_TERMS_OF_USE is enabled, "
     "The TermsAndConditionsRedirectMiddleware is missing from the middlewares.",
-    ...
+    ...,
 )
 
-# we prefer line breaks after { or [
+# magic trailing commas prevent inlining of short dicts or lists
 get_kwargs = {
     'attribute': data.get('attribute'),
     'set_prefix': data.get('set_prefix'),
-    'set_index': data.get('set_index')
+    'set_index': data.get('set_index'),  # <- magic trailing comma
 }
 ```
+
+For constant iterables we use tuples `()` instead of lists `[]`.
+
+In Python classes, we prefer `@property` instead of getter method (e.g. like `get_var(self)`).
 
 RDMO uses [Django settings](https://docs.djangoproject.com/en/6.0/ref/settings/) extensively. All settings have a default value set in `rdmo/core/settings.py`. For readability, settings must not check if they exists (e.g. using `try/except` or `hasattr`).
 
@@ -74,7 +77,7 @@ Examples:
   )
 }
 
-// multiline tertiary operators
+// multiline ternary operators
 {
   page.id ? (
     <>
@@ -89,7 +92,7 @@ Examples:
 
 We only use functional components and only one component should be in a single file.
 
-## UI/UI considerations
+## User interface considerations
 
 All front end logic needs to be implemented with a consistent user experience in mind. Generic components reside in `rdmo/core/assets/js/components` and should be used where ever possible.
 
@@ -97,6 +100,6 @@ The styling should align with Bootstrap and it should be possible to adjust the 
 
 Custom CSS code should be kept to a minimum. For CSS classes hyphens `-` should be used instead of underscores (`_`).
 
-In the interactive front end, `a` should be used when there is a front end route or a backend URL which users might want to copy or bookmark. In all other cases, a `button` is preferred. The CSS class `link` can be used to make it look like a link. Usually `button` has `type="button"`, unless used as submit button in a form.
+In the interactive front end, regular links (using the `a` tag) should only be used to navigate to a frontend location or a backend URL, which actually exists and which users might want to copy or bookmark. In all other cases, a `button` is preferred. The CSS class `link` can be used to make it look like a link. Usually `button` has `type="button"`, unless used as submit button in a form.
 
-Form input fields should should apply or save automatically. This save operation needs a visual indicator to communicate success to the user. An exception are fields in models modals are only saved on the submit button of the modal.
+Form input fields should apply or save automatically. This save operation needs a visual indicator to communicate success to the user. An exception are fields in models, which are saved when the submit button of the modal is clicked.


### PR DESCRIPTION
This PR adds/updates 5 documents to the repo:

* `CONTRIBUTING.md` contains the guidelines for contributors how we work.
* `ARCHITECTURE.md` aims to explain the structure of the repository, file naming conventions and external and internal dependencies.
* `STYLE.md` collects naming conventions, code patterns and ux/ui considerations.
* (edit 2026-05-05) `CODE_OF_CONDUCT.md` our code of conduct.
* (edit 2026-05-05) `SECURITY.md`.

I will present the documents at the community meeting and we will have a review process with the community. While afterwards `CONTRIBUTING.md` is meant to be more or less stable, I expect the other two documents to be updated more frequently.

Direct links for convenience:

* https://github.com/rdmorganiser/rdmo/blob/contributing-guide/CONTRIBUTING.md
* https://github.com/rdmorganiser/rdmo/blob/contributing-guide/ARCHITECTURE.md
* https://github.com/rdmorganiser/rdmo/blob/contributing-guide/STYLE.md
* https://github.com/rdmorganiser/rdmo/blob/contributing-guide/CODE_OF_CONDUCT.md
* https://github.com/rdmorganiser/rdmo/blob/contributing-guide/SECURITY.md
 