### PR TITLE
Handle empty sections in AnswerTree

### DIFF
--- a/rdmo/projects/answers.py
+++ b/rdmo/projects/answers.py
@@ -79,7 +79,8 @@ class AnswerTree:
 
             # find the first element
             if element_type in self.verbose:
-                element_node['first'] = element_node['elements'][0]['id']
+                if element_node['elements']:
+                    element_node['first'] = element_node['elements'][0]['id']
 
             # aggregate count and total from the child elements
             element_node['count'] = sum(child_node['count'] for child_node in element_node['elements'])


### PR DESCRIPTION
<!--- These comments are hidden when you submit the pull request, --->
<!--- so you do not need to remove them. --->

<!--- Before opening a pull request, go over all the following points: --->
<!--- * I have read the contributor guide (CONTRIBUTING.md) --->
<!--- * My code follows the code style of this project --->
<!--- * I added tests to cover my changes --->
<!--- * If needed, I updated the documentation --->
<!--- * If needed, I added translations if they are needed --->
<!--- * If needed, I added migration files and checked for potential conflicts --->

<!--- This project only accepts pull requests related to open issues. --->
<!--- If suggesting a new feature or change, please discuss it in an issue first. --->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. --->

<!--- Please provide a general summary of your changes in the title of the pull request --->

## Description
<!--- Describe your changes in detail --->

<!--- Please link to a related issue here --->
Related issue: [#1563](https://github.com/rdmorganiser/rdmo/issues/1563)

## Motivation and Context
Solving issue. 

## How has this been tested?
Reproduced the bug with a catalog containing an empty section. Found the error message - after it is not there. 

## Screenshots (if appropriate)
Before: 

<img width="759" height="275" alt="image" src="https://github.com/user-attachments/assets/fdc4d5b5-1e60-438e-a88b-ffc325257203" />


After 
<img width="963" height="454" alt="image" src="https://github.com/user-attachments/assets/133b832c-ea21-4cb5-8972-955359bc9de9" />


<!--- This pull request template is adapted from: --->
<!--- https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- https://github.com/dec0dOS/amazing-github-template (MIT License). --->
