### PR TITLE
Add tests for navigation for a catalog without sections or pages

### DIFF
--- a/rdmo/projects/tests/test_viewset_project.py
+++ b/rdmo/projects/tests/test_viewset_project.py
@@ -582,6 +582,39 @@ def test_navigation_section(db, client, username, password, project_id):
             assert response.status_code == 401
 
 
+def test_navigation_without_sections(db, client):
+    from rdmo.questions.models.section import Section
+    project_id = 1
+    username = 'owner'
+    Section.objects.all().delete()
+
+    client.login(username=username, password=username)
+
+    url = reverse(urlnames['navigation'], args=[project_id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_navigation_without_pages(db, client):
+    from rdmo.questions.models.page import Page
+    project_id = 1
+    username = 'owner'
+    Page.objects.all().delete()
+
+    client.login(username=username, password=username)
+
+    url = reverse(urlnames['navigation'], args=[project_id])
+    response = client.get(url)
+    response_data = response.json()
+
+    assert response.status_code == 200
+    for data in response_data:
+        assert data['count'] == 0
+        assert data['first'] is None
+
+
 @pytest.mark.parametrize('username,password', users)
 @pytest.mark.parametrize('project_id', projects)
 @pytest.mark.parametrize('condition_id', conditions)


### PR DESCRIPTION
This PR contains test for the issue fixed in https://github.com/rdmorganiser/rdmo/pull/1583.