### PR TITLE
Use short_title in compute_navigation

### DIFF
--- a/rdmo/core/models.py
+++ b/rdmo/core/models.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from django.db import models
 from django.utils.timezone import now
-from django.utils.translation import get_language
+from django.utils.translation import get_language, get_supported_language_variant
 from django.utils.translation import gettext_lazy as _
 
 from rdmo.core.utils import get_languages
@@ -31,7 +31,7 @@ class Model(models.Model):
 class TranslationMixin:
 
     def trans(self, field):
-        current_language = get_language()
+        current_language = get_supported_language_variant(get_language())
 
         languages = get_languages()
         for lang_code, _lang_string, lang_field in languages:

--- a/rdmo/core/tests/test_tags.py
+++ b/rdmo/core/tests/test_tags.py
@@ -10,7 +10,9 @@ def test_i18n_switcher(rf):
     # create a fake template with a name
     template = "{% load core_tags %}{% i18n_switcher %}"
 
+    # set a language
     with translation.override(settings.LANGUAGES[0][0]):
+
         # render the link
         request = rf.get(reverse('home'))
         context = RequestContext(request, {})

--- a/rdmo/core/tests/test_tags.py
+++ b/rdmo/core/tests/test_tags.py
@@ -10,15 +10,13 @@ def test_i18n_switcher(rf):
     # create a fake template with a name
     template = "{% load core_tags %}{% i18n_switcher %}"
 
-    # set a language
-    translation.activate(settings.LANGUAGES[0][0])
-
-    # render the link
-    request = rf.get(reverse('home'))
-    context = RequestContext(request, {})
-    rendered_template = Template(template).render(context)
-    for language in settings.LANGUAGES:
-        if language == settings.LANGUAGES[0]:
-            assert '<a href="/i18n/{}/"><u>{}</u></a>'.format(*language) in rendered_template
-        else:
-            assert'<a href="/i18n/{}/">{}</a>'.format(*language) in rendered_template
+    with translation.override(settings.LANGUAGES[0][0]):
+        # render the link
+        request = rf.get(reverse('home'))
+        context = RequestContext(request, {})
+        rendered_template = Template(template).render(context)
+        for language in settings.LANGUAGES:
+            if language == settings.LANGUAGES[0]:
+                assert '<a href="/i18n/{}/"><u>{}</u></a>'.format(*language) in rendered_template
+            else:
+                assert '<a href="/i18n/{}/">{}</a>'.format(*language) in rendered_template

--- a/rdmo/core/tests/test_tags.py
+++ b/rdmo/core/tests/test_tags.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.template import RequestContext, Template
 from django.urls import reverse
-from django.utils import translation
 
 
 def test_i18n_switcher(rf):
@@ -10,15 +9,12 @@ def test_i18n_switcher(rf):
     # create a fake template with a name
     template = "{% load core_tags %}{% i18n_switcher %}"
 
-    # set a language
-    with translation.override(settings.LANGUAGES[0][0]):
-
-        # render the link
-        request = rf.get(reverse('home'))
-        context = RequestContext(request, {})
-        rendered_template = Template(template).render(context)
-        for language in settings.LANGUAGES:
-            if language == settings.LANGUAGES[0]:
-                assert '<a href="/i18n/{}/"><u>{}</u></a>'.format(*language) in rendered_template
-            else:
-                assert '<a href="/i18n/{}/">{}</a>'.format(*language) in rendered_template
+    # render the link
+    request = rf.get(reverse('home'))
+    context = RequestContext(request, {})
+    rendered_template = Template(template).render(context)
+    for language in settings.LANGUAGES:
+        if language == settings.LANGUAGES[0]:
+            assert '<a href="/i18n/{}/"><u>{}</u></a>'.format(*language) in rendered_template
+        else:
+            assert '<a href="/i18n/{}/">{}</a>'.format(*language) in rendered_template

--- a/rdmo/core/tests/test_utils.py
+++ b/rdmo/core/tests/test_utils.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from django.utils.translation import activate
+from django.utils import translation
 
 from rdmo.core.utils import (
     human2bytes,
@@ -85,8 +85,8 @@ def test_human2bytes(human: str | None, bytes: float):
 
 @pytest.mark.parametrize("locale, date_string, expected_date", valid_date_strings)
 def test_parse_date_from_string_valid_formats(settings, locale, date_string, expected_date):
-    activate(locale)
-    assert parse_date_from_string(date_string) == expected_date
+    with translation.override(locale):
+        assert parse_date_from_string(date_string) == expected_date
 
 
 @pytest.mark.parametrize("invalid_date, error_msg", invalid_date_strings)

--- a/rdmo/projects/answers.py
+++ b/rdmo/projects/answers.py
@@ -44,12 +44,12 @@ class AnswerTree:
 
             if element_type in ['catalog', 'page', 'questionset']:
                 element_node.update({
-                    'title': markdown2html(element.title),
+                    'title': markdown2html(element.short_title) or markdown2html(element.title),
                     'help': markdown2html(element.help)
                 })
             elif element_type == 'section':
                 element_node.update({
-                    'title': markdown2html(element.title)
+                    'title': markdown2html(element.short_title) or markdown2html(element.title)
                 })
             elif element_type == 'question':
                 element_node.update({

--- a/rdmo/projects/tests/test_navigation.py
+++ b/rdmo/projects/tests/test_navigation.py
@@ -86,3 +86,32 @@ def test_compute_navigation(db, section_uri):
                 assert page['total'] == total, page['uri']
                 assert page['show'] == show, page['uri']
                 assert 'title' in  page  # test for verbose, help is filtered out
+
+def test_compute_navigation_uses_short_title_as_title(db):
+    project = Project.objects.get(id=1)
+    project.catalog.prefetch_elements()
+
+    # ARRANGE: pick a section and its first page
+    section = project.catalog.elements[0]
+    page = section.elements[0]
+
+    # ARRANGE: clear the normal titles and set short titles
+    section.title_lang1 = ""
+    section.short_title_lang1 = 'SectionShorty'
+    section.save()
+    page.title_lang1 = ""
+    page.short_title_lang1 = 'PageShorty'
+    page.save()
+
+    # ACT: compute navigation for this section
+    section = project.catalog.sections.get(id=section.id)
+    navigation = compute_navigation(project, section)
+
+    # ASSERT: find the section title and compare to its short_title
+    section_nav = next((s for s in navigation if s['id'] == section.id), None)
+    assert section_nav.get('title') == 'SectionShorty'
+
+    # ASSERT: find the page title and compare to its short_title
+    pages = section_nav.get('pages', [])
+    page_nav = next((p for p in pages if p['id'] == page.id), None)
+    assert page_nav.get('title') == 'PageShorty'

--- a/rdmo/projects/tests/test_navigation.py
+++ b/rdmo/projects/tests/test_navigation.py
@@ -87,6 +87,7 @@ def test_compute_navigation(db, section_uri):
                 assert page['show'] == show, page['uri']
                 assert 'title' in  page  # test for verbose, help is filtered out
 
+
 def test_compute_navigation_uses_short_title_as_title(db):
     project = Project.objects.get(id=1)
     project.catalog.prefetch_elements()


### PR DESCRIPTION
Shot titles where accidentally removed in RDMO 2.4.0. This restores there use in the sidebar of the interview. Draft for now since I don't know if we want to have an extra release for this.