### PR TITLE
Remove slack and add matrix and mastodon to README and pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ RDMO is a tool to support the systematic planning, organisation and implementati
   <dd>https://rdmo.readthedocs.io</dd>
   <dt>Mailing list</dt>
   <dd>https://www.listserv.dfn.de/sympa/subscribe/rdmo</dd>
-  <dt>Slack</dt>
-  <dd>https://rdmo.slack.com</dd>
+  <dt>Matrix</dt>
+  <dd>https://matrix.to/#/#rdmo:matrix.org</dd>
   <dt>Demo</dt>
   <dd>https://rdmo.aip.de</dd>
 </dl>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,13 @@ pytest = [
 ]
 
 [project.urls]
-changelog = "https://github.com/rdmorganiser/rdmo/blob/main/CHANGELOG.md"
-documentation = "https://rdmo.readthedocs.io"
-homepage = "https://rdmorganiser.github.io"
-issues = "https://github.com/rdmorganiser/rdmo/issues"
-repository = "https://github.com/rdmorganiser/rdmo.git"
-slack = "https://rdmo.slack.com"
+Homepage = "https://rdmorganiser.github.io"
+Repository = "https://github.com/rdmorganiser/rdmo"
+Issues = "https://github.com/rdmorganiser/rdmo/issues"
+Changelog = "https://github.com/rdmorganiser/rdmo/blob/main/CHANGELOG.md"
+Documentation = "https://rdmo.readthedocs.io"
+Mastodon = "https://openbiblio.social/@rdmo"
+Matrix = "https://matrix.to/#/#rdmo:matrix.org"
 
 [project.scripts]
 rdmo-admin = "rdmo.__main__:main"


### PR DESCRIPTION
This PR replaces slack with mastodon and reorganizes things a bit.

Resolves: #1571 .