### PR TITLE
Add a custom SiteAdmin and add id to list display

### DIFF
--- a/rdmo/core/admin.py
+++ b/rdmo/core/admin.py
@@ -1,4 +1,7 @@
 from django import forms
+from django.contrib import admin
+from django.contrib.sites.admin import SiteAdmin
+from django.contrib.sites.models import Site
 
 
 class ElementAdminForm(forms.ModelForm):
@@ -6,3 +9,13 @@ class ElementAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['uri_path'].required = True
+
+
+if admin.site.is_registered(Site):
+    admin.site.unregister(Site)
+
+
+@admin.register(Site)
+class CustomSiteAdmin(SiteAdmin):
+    list_display = ('id', 'domain', 'name')
+    search_fields = ('domain', 'name')

--- a/rdmo/core/admin.py
+++ b/rdmo/core/admin.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib import admin
-from django.contrib.sites.admin import SiteAdmin
+from django.contrib.sites.admin import SiteAdmin as DjangoSiteAdmin
 from django.contrib.sites.models import Site
 
 
@@ -10,12 +10,14 @@ class ElementAdminForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields['uri_path'].required = True
 
-
+# the original Django SiteAdmin needs to be unregistered first
 if admin.site.is_registered(Site):
     admin.site.unregister(Site)
 
 
 @admin.register(Site)
-class CustomSiteAdmin(SiteAdmin):
+class SiteAdmin(DjangoSiteAdmin):
     list_display = ('id', 'domain', 'name')
-    search_fields = ('domain', 'name')
+    list_display_links = ('domain',)
+    search_fields = ('id', 'domain', 'name')
+    ordering = ('id',)

--- a/rdmo/core/tests/test_admin.py
+++ b/rdmo/core/tests/test_admin.py
@@ -1,0 +1,18 @@
+import pytest
+
+from django.urls import reverse
+
+sites = (
+    (1, 'example.com'),
+    (2, 'foo.com'),
+    (3, 'bar.com'),
+)
+
+
+@pytest.mark.parametrize('site_id, domain', sites)
+def test_admin_sites_site(admin_client, site_id, domain):
+    url = reverse('admin:sites_site_changelist') + f'?q={domain}'
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    assert reverse('admin:sites_site_change', args=[site_id]).encode() in response.content


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --->

<!--- Please link to a related issue here --->
Related issue: `None`
Adds a `CustomSiteAdmin `

## Motivation and Context
We have many Sites in the instance and it gets hard to see which `SITE_ID` they have..

## Discussion

* can this go in rdmo.core or should go to the rdmo-app?
* add more features like a project count so the display table?
