### PR TITLE
OpenApi improvements

### DIFF
--- a/rdmo/core/tests/test_openapi.py
+++ b/rdmo/core/tests/test_openapi.py
@@ -1,5 +1,9 @@
 import pytest
 
+from django.contrib.auth.models import User
+
+from rest_framework.authtoken.models import Token
+
 import yaml
 
 pytestmark = pytest.mark.django_db
@@ -12,7 +16,7 @@ users = (
 
 
 @pytest.mark.parametrize('username', users)
-def test_openapi_schema(db, client, login, settings, username):
+def test_openapi_schema(db, client, login, username):
     login(username)
 
     response = client.get('/api/v1/schema/')
@@ -24,7 +28,26 @@ def test_openapi_schema(db, client, login, settings, username):
         assert len(schema['paths']) > 120
         assert len(schema['paths']) < 140
     else:
-        assert response.status_code == 302
+        assert response.status_code == 403
+
+
+def test_openapi_schema_token(db, client):
+    user = User.objects.get(username='user')
+    token, _ = Token.objects.get_or_create(user=user)
+
+    response = client.get('/api/v1/schema/', headers={
+        'Authorization': f'Token {token}'
+    })
+
+    assert response.status_code == 200
+
+
+def test_openapi_schema_token_forbidden(db, client, login):
+    response = client.get('/api/v1/schema/', headers={
+        'Authorization': 'Token wrong'
+    })
+
+    assert response.status_code == 403
 
 
 @pytest.mark.parametrize('username', users)

--- a/rdmo/core/urls/v1/__init__.py
+++ b/rdmo/core/urls/v1/__init__.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.urls import include, path
 
 urlpatterns = [
@@ -14,3 +15,8 @@ urlpatterns = [
 
     path('core/', include('rdmo.core.urls.v1.core')),
 ]
+
+if apps.is_installed('drf_spectacular'):
+    urlpatterns += [
+        path('', include('rdmo.core.urls.v1.openapi')),
+    ]

--- a/rdmo/core/urls/v1/openapi.py
+++ b/rdmo/core/urls/v1/openapi.py
@@ -2,13 +2,22 @@ from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.views.generic.base import RedirectView
 
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 app_name = 'v1-openapi'
 
+
+class AuthenticatedSpectacularAPIView(SpectacularAPIView):
+    authentication_classes = [SessionAuthentication, TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+
 urlpatterns = [
-    path('schema/', login_required(SpectacularAPIView.as_view()), name='schema'),
+    path('schema/', AuthenticatedSpectacularAPIView.as_view(), name='schema'),
     path('swagger/', login_required(SpectacularSwaggerView.as_view(url_name='v1-openapi:schema')), name='swagger'),
     path('redoc/', login_required(SpectacularRedocView.as_view(url_name='v1-openapi:schema')), name='redoc'),
-    path('', RedirectView.as_view(pattern_name='api', permanent=False))
+    path('', RedirectView.as_view(pattern_name='api', permanent=False)),
 ]


### PR DESCRIPTION
New version of https://github.com/rdmorganiser/rdmo/pull/1581:

* Add openapi urls to core urls (conditionally)
* Use DRF token or session authentication for the schema

This should not be part of 2.4.5 since it forces the users to update their `urls.py`. The old `2.5.0/openapi-urls` was weirdly broken, so I created this new, release agnostic branch.