### PR TITLE
Refactor queryset optimizations

### DIFF
--- a/rdmo/conditions/serializers/export.py
+++ b/rdmo/conditions/serializers/export.py
@@ -7,7 +7,7 @@ from ..models import Condition
 
 class ConditionExportSerializer(serializers.ModelSerializer):
 
-    source = AttributeExportSerializer()
+    source = serializers.SerializerMethodField()
     target_option = serializers.SerializerMethodField()
 
     class Meta:
@@ -22,6 +22,11 @@ class ConditionExportSerializer(serializers.ModelSerializer):
             'target_text',
             'target_option'
         )
+
+    def get_source(self, obj):
+        source = self.context.get('attribute_map', {}).get(obj.source_id)
+        if source:
+            return AttributeExportSerializer(source).data
 
     def get_target_option(self, obj):
         if obj.target_option is not None:

--- a/rdmo/conditions/serializers/export.py
+++ b/rdmo/conditions/serializers/export.py
@@ -26,7 +26,7 @@ class ConditionExportSerializer(serializers.ModelSerializer):
     def get_source(self, obj):
         source = self.context.get('attribute_map', {}).get(obj.source_id)
         if source:
-            return AttributeExportSerializer(source).data
+            return AttributeExportSerializer(source, context=self.context).data
 
     def get_target_option(self, obj):
         if obj.target_option is not None:

--- a/rdmo/conditions/tests/test_api_performance_condition.py
+++ b/rdmo/conditions/tests/test_api_performance_condition.py
@@ -4,30 +4,19 @@ from django.urls import reverse
 
 from .test_viewset_condition import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 9},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 11, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 9, 'url_kwargs': {'pk': 1}},
-    'detail_export': {
-        'max_queries': 9, 'url_kwargs': {'pk': 1, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 9, {}),
+    ('index', 3, {}),
+    ('export', 11, {'export_format': 'xml'}),
+    ('detail', 9, {'pk': 1}),
+    ('detail_export', 9, {'pk': 1, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
-def test_actions_max_query_counts(
-    db, admin_client, django_assert_max_num_queries,
-    action, max_queries, url_kwargs,
-):
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
+def test_actions_max_query_counts(db, admin_client, django_assert_max_num_queries, action, max_queries, url_kwargs):
     url = reverse(urlnames[action], kwargs=url_kwargs)
 
     with django_assert_max_num_queries(max_queries):

--- a/rdmo/conditions/viewsets.py
+++ b/rdmo/conditions/viewsets.py
@@ -18,11 +18,6 @@ from .serializers.export import ConditionExportSerializer
 from .serializers.v1 import ConditionIndexSerializer, ConditionSerializer
 
 
-def get_attributes_by_id():
-    attributes = list(Attribute.objects.all())
-    return {attribute.pk: attribute for attribute in attributes}
-
-
 class ConditionViewSet(ModelViewSet):
     permission_classes = (HasModelPermission | HasObjectPermission, )
     serializer_class = ConditionSerializer
@@ -46,15 +41,7 @@ class ConditionViewSet(ModelViewSet):
         elif self.action in ['export', 'detail_export']:
             return queryset.select_related(
                 'source',
-                'source__parent',
                 'target_option'
-            ).prefetch_related(
-                'optionsets',
-                'pages',
-                'questionsets',
-                'questions',
-                'tasks',
-                'editors'
             )
         else:
             return queryset.select_related(
@@ -79,10 +66,12 @@ class ConditionViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            conditions = list(queryset)
-            context = self.get_export_renderer_context(request, attributes_by_id=True)
-            serializer = ConditionExportSerializer(conditions, many=True, context=context)
-            xml = ConditionRenderer().render(serializer.data, context=context)
+            serializer = ConditionExportSerializer(
+                queryset,
+                many=True,
+                context=self.get_export_serializer_context(queryset),
+            )
+            xml = ConditionRenderer().render(serializer.data, context=self.get_export_renderer_context(request))
             return XMLResponse(xml, name='conditions')
         else:
             return render_to_format(self.request, export_format, 'conditions', 'conditions/export/conditions.html', {
@@ -91,28 +80,35 @@ class ConditionViewSet(ModelViewSet):
 
     @action(detail=True, url_path='export(?:/(?P<export_format>[a-z]+))?')
     def detail_export(self, request, pk=None, export_format='xml'):
-        condition = self.get_object()
+        instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = ConditionExportSerializer(condition, context=context)
-            xml = ConditionRenderer().render([serializer.data], context=context)
-            return XMLResponse(xml, name=condition.uri_path)
+            serializer = ConditionExportSerializer(
+                instance,
+                context=self.get_export_serializer_context([instance]),
+            )
+            xml = ConditionRenderer().render([serializer.data], context=self.get_export_renderer_context(request))
+            return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(
-                self.request, export_format, condition.uri_path, 'conditions/export/conditions.html', {
-                    'conditions': [condition]
+                self.request, export_format, instance.uri_path, 'conditions/export/conditions.html', {
+                    'conditions': [instance]
                 }
             )
 
-    def get_export_renderer_context(self, request, attributes_by_id=False):
+    def get_export_serializer_context(self, conditions):
+        return {
+            'attribute_map': Attribute.objects.get_queryset_ancestors(
+                Attribute.objects.filter(id__in=[condition.source_id for condition in conditions]),
+                include_self=True
+            ).in_bulk()
+        }
+
+    def get_export_renderer_context(self, request):
         full = is_truthy(request.GET.get('full'))
-        context = {
+        return {
             'attributes': full or is_truthy(request.GET.get('attributes')),
             'options': full or is_truthy(request.GET.get('options')),
         }
-        if attributes_by_id:
-            context['attributes_by_id'] = get_attributes_by_id()
-        return context
 
 
 class RelationViewSet(ChoicesViewSet):

--- a/rdmo/domain/renderers/mixins.py
+++ b/rdmo/domain/renderers/mixins.py
@@ -9,13 +9,14 @@ class AttributeRendererMixin:
             self.render_text_element(xml, 'key', {}, attribute['key'])
             self.render_text_element(xml, 'path', {}, attribute['path'])
             self.render_text_element(xml, 'dc:comment', {}, attribute['comment'])
-            self.render_text_element(xml, 'parent', {'dc:uri': attribute['parent']}, None)
+            self.render_text_element(xml, 'parent', {
+                'dc:uri': attribute['parent']['uri'] if attribute['parent'] is not None else None
+            }, None)
             xml.endElement('attribute')
 
         if include_children:
             for child in attribute.get('children', []):
                 self.render_attribute(xml, child)
 
-        parent_data = attribute.get('parent_data')
-        if parent_data:
-            self.render_attribute(xml, parent_data, include_children=False)
+        if attribute['parent']:
+            self.render_attribute(xml, attribute['parent'], include_children=False)

--- a/rdmo/domain/serializers/export.py
+++ b/rdmo/domain/serializers/export.py
@@ -21,4 +21,4 @@ class AttributeExportSerializer(serializers.ModelSerializer):
     def get_parent(self, obj):
         parent = self.context.get('attribute_map', {}).get(obj.parent_id)
         if parent:
-            return AttributeExportSerializer(parent).data
+            return AttributeExportSerializer(parent, context=self.context).data

--- a/rdmo/domain/serializers/export.py
+++ b/rdmo/domain/serializers/export.py
@@ -6,7 +6,6 @@ from ..models import Attribute
 class AttributeExportSerializer(serializers.ModelSerializer):
 
     parent = serializers.SerializerMethodField()
-    parent_data = serializers.SerializerMethodField()
 
     class Meta:
         model = Attribute
@@ -17,37 +16,9 @@ class AttributeExportSerializer(serializers.ModelSerializer):
             'path',
             'comment',
             'parent',
-            'parent_data',
         )
 
     def get_parent(self, obj):
-        parent = self.get_parent_object_from_context(obj)
-        return parent.uri if parent is not None else None
-
-    def get_parent_data(self, obj):
-        parent = self.get_parent_object_from_context(obj)
-
-        if parent is None:
-            return None
-
-        cache = self.context.setdefault('parent_data_cache', {})
-
-        if parent.pk not in cache:
-            cache[parent.pk] = AttributeExportSerializer(
-                parent,
-                context=self.context,
-            ).data
-
-        return cache[parent.pk]
-
-    def get_parent_object_from_context(self, obj):
-        if obj.parent_id is None:
-            return None
-
-        attributes_by_id = self.context.get('attributes_by_id', {})
-
-        if obj.parent_id in attributes_by_id:
-            return attributes_by_id[obj.parent_id]
-
-        # fallback for edge cases, but this can query
-        return obj.parent
+        parent = self.context.get('attribute_map', {}).get(obj.parent_id)
+        if parent:
+            return AttributeExportSerializer(parent).data

--- a/rdmo/domain/tests/test_api_performance_attribute.py
+++ b/rdmo/domain/tests/test_api_performance_attribute.py
@@ -4,22 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_attribute import urlnames
 
-max_query_map = {
-    'list': {'max_queries': 10},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 12, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 11, 'url_kwargs': {'pk': 1}},
-    'detail_export': {'max_queries': 12, 'url_kwargs': {'pk': 1, 'export_format': 'xml'}},
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 10, {}),
+    ('index', 3, {}),
+    ('export', 12, {'export_format': 'xml'}),
+    ('detail', 11, {'pk': 1}),
+    ('detail_export', 12, {'pk': 1, 'export_format': 'xml'}),
+]
+
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_domain_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/domain/viewsets.py
+++ b/rdmo/domain/viewsets.py
@@ -37,7 +37,7 @@ class AttributeViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = Attribute.objects.all().order_by('path')
-        if self.action in ('index','nested', 'export', 'detail_export'):
+        if self.action in ('index', 'nested', 'export', 'detail_export'):
             return queryset
         else:
             return queryset.annotate(
@@ -51,6 +51,7 @@ class AttributeViewSet(ModelViewSet):
                 'questions',
                 'tasks_as_start',
                 'tasks_as_end',
+                'editors',
             )
 
     def get_serializer_class(self):
@@ -73,9 +74,9 @@ class AttributeViewSet(ModelViewSet):
         if export_format == 'xml':
             attributes = list(queryset)
             serializer = AttributeExportSerializer(
-                attributes, many=True, context={
-                    'attributes_by_id': { attribute.pk: attribute for attribute in attributes}
-                },
+                queryset,
+                many=True,
+                context=self.get_export_serializer_context(attributes),
             )
             xml = AttributeRenderer().render(serializer.data)
             return XMLResponse(xml, name='attributes')
@@ -94,9 +95,9 @@ class AttributeViewSet(ModelViewSet):
         attributes = instance.get_descendants(include_self=True)
         if export_format == 'xml':
             serializer = AttributeExportSerializer(
-                attributes, many=True, context={
-                    'attributes_by_id': {attribute.pk: attribute for attribute in attributes}
-                },
+                attributes,
+                many=True,
+                context=self.get_export_serializer_context(attributes),
             )
             xml = AttributeRenderer().render(serializer.data)
             return XMLResponse(xml, name=instance.key)
@@ -110,3 +111,10 @@ class AttributeViewSet(ModelViewSet):
                     'attributes': attributes
                 }
             )
+
+    def get_export_serializer_context(self, attributes):
+        return {
+            'attribute_map': {
+                attribute.pk: attribute for attribute in attributes
+            }
+        }

--- a/rdmo/options/tests/test_api_performance_option.py
+++ b/rdmo/options/tests/test_api_performance_option.py
@@ -4,22 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_options import urlnames
 
-max_query_map_option = {
-    'list': {'max_queries': 10},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 12, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 10, 'url_kwargs': {'pk': 1}},
-    'detail_export': {'max_queries': 12, 'url_kwargs': {'pk': 1, 'export_format': 'xml'}},
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 10, {}),
+    ('index', 3, {}),
+    ('export', 12, {'export_format': 'xml'}),
+    ('detail', 10, {'pk': 1}),
+    ('detail_export', 12, {'pk': 1, 'export_format': 'xml'}),
+]
+
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map_option.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_option_endpoints_query_counts(
     admin_client,
     django_assert_max_num_queries,

--- a/rdmo/options/tests/test_api_performance_optionset.py
+++ b/rdmo/options/tests/test_api_performance_optionset.py
@@ -4,22 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_optionsets import urlnames
 
-max_query_map_optionset = {
-    'list': {'max_queries': 8},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 11, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 8, 'url_kwargs': {'pk': 1}},
-    'detail_export': {'max_queries': 10, 'url_kwargs': {'pk': 1, 'export_format': 'xml'}},
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 8, {}),
+    ('index', 3, {}),
+    ('export', 11, {'export_format': 'xml'}),
+    ('detail', 8, {'pk': 1}),
+    ('detail_export', 10, {'pk': 1, 'export_format': 'xml'}),
+]
+
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map_optionset.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_optionset_endpoints_query_counts(
     admin_client,
     django_assert_max_num_queries,

--- a/rdmo/options/viewsets.py
+++ b/rdmo/options/viewsets.py
@@ -13,6 +13,7 @@ from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 from rdmo.core.views import ChoicesViewSet
+from rdmo.domain.models import Attribute
 
 from .models import Option, OptionSet
 from .renderers import OptionRenderer, OptionSetRenderer
@@ -43,12 +44,17 @@ class OptionSetViewSet(ModelViewSet):
         queryset = OptionSet.objects.all()
         if self.action in ['index']:
             return queryset
+        elif self.action in ['export', 'detail_export']:
+            return queryset.prefetch_related(
+                'optionset_options__option',
+                'conditions',
+            )
         else:
             return queryset.prefetch_related(
                 'optionset_options__option',
                 'conditions',
                 'questions',
-                'editors'
+                'editors',
             )
 
     @action(detail=False)
@@ -66,7 +72,11 @@ class OptionSetViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            serializer = OptionSetExportSerializer(queryset, many=True)
+            serializer = OptionSetExportSerializer(
+                queryset,
+                many=True,
+                context=self.get_export_serializer_context(queryset),
+            )
             xml = OptionSetRenderer().render(serializer.data, context=self.get_export_renderer_context(request))
             return XMLResponse(xml, name='optionsets')
         else:
@@ -78,7 +88,10 @@ class OptionSetViewSet(ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            serializer = OptionSetExportSerializer(instance)
+            serializer = OptionSetExportSerializer(
+                instance,
+                context=self.get_export_serializer_context([instance]),
+            )
             xml = OptionSetRenderer().render([serializer.data], context=self.get_export_renderer_context(request))
             return XMLResponse(xml, name=instance.uri_path)
         else:
@@ -87,6 +100,18 @@ class OptionSetViewSet(ModelViewSet):
                     'optionsets': [instance]
                 }
             )
+
+    def get_export_serializer_context(self, optionsets):
+        return {
+            'attribute_map': Attribute.objects.get_queryset_ancestors(
+                Attribute.objects.filter(id__in={
+                    condition.source_id
+                    for optionset in optionsets
+                    for condition in optionset.conditions.all()
+                }),
+                include_self=True
+            ).in_bulk()
+        }
 
     def get_export_renderer_context(self, request):
         full = is_truthy(request.GET.get('full'))

--- a/rdmo/projects/tests/test_api_performance_project.py
+++ b/rdmo/projects/tests/test_api_performance_project.py
@@ -1,0 +1,28 @@
+import pytest
+
+from django.urls import reverse
+
+max_queries = [
+    # urlname, max_queries, url_args
+    ('project_answers', 41, [1]),
+    ('project_answers_export', 34, [1, 'html']),
+]
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize('urlname,max_queries,url_args', max_queries)
+def test_project_answer_endpoints_query_counts(
+    db,
+    client,
+    django_assert_max_num_queries,
+    urlname,
+    max_queries,
+    url_args,
+):
+    client.login(username='owner', password='owner')
+    url = reverse(urlname, args=url_args)
+
+    with django_assert_max_num_queries(max_queries):
+        response = client.get(url)
+
+    assert response.status_code == 200

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -25,6 +25,7 @@ from rdmo.core.permissions import HasModelPermission
 from rdmo.core.utils import human2bytes, is_truthy, return_file_response
 from rdmo.options.models import OptionSet
 from rdmo.questions.models import Catalog, Page, Question, QuestionSet
+from rdmo.questions.prefetch import project_page_prefetch_lookups
 from rdmo.tasks.models import Task
 from rdmo.views.models import View
 
@@ -696,12 +697,9 @@ class ProjectPageViewSet(ProjectNestedViewSetMixin, RetrieveModelMixin, GenericV
 
     def get_queryset(self):
         self.project.catalog.prefetch_elements()
-        page = Page.objects.filter_by_catalog(self.project.catalog).prefetch_related(
-            *Page.prefetch_lookups,
-            'page_questions__question__optionsets__optionset_options__option',
-            'page_questionsets__questionset__questionset_questions__question__optionsets__optionset_options__option',
+        return Page.objects.filter_by_catalog(self.project.catalog).prefetch_related(
+            *project_page_prefetch_lookups()
         )
-        return page
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/rdmo/questions/managers.py
+++ b/rdmo/questions/managers.py
@@ -9,6 +9,14 @@ from rdmo.core.managers import (
     GroupsQuerySetMixin,
 )
 
+from .prefetch import (
+    catalog_prefetch_lookups,
+    page_prefetch_lookups,
+    question_prefetch_lookups,
+    questionset_prefetch_lookups,
+    section_prefetch_lookups,
+)
+
 
 class CatalogQuerySet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, AvailabilityQuerySetMixin, models.QuerySet):
 
@@ -16,7 +24,7 @@ class CatalogQuerySet(CurrentSiteQuerySetMixin, GroupsQuerySetMixin, Availabilit
         return self.filter(models.Q(catalogs=None) | models.Q(catalogs=catalog))
 
     def prefetch_elements(self):
-        return self.prefetch_related(*self.model.prefetch_lookups)
+        return self.prefetch_related(*catalog_prefetch_lookups())
 
     def filter_for_user(self, user):
         return (
@@ -45,7 +53,7 @@ class CatalogManager(CurrentSiteManagerMixin, GroupsManagerMixin, AvailabilityMa
 class SectionQuerySet(models.QuerySet):
 
     def prefetch_elements(self):
-        return self.prefetch_related(*self.model.prefetch_lookups)
+        return self.prefetch_related(*section_prefetch_lookups())
 
 
 class SectionManager(models.Manager):
@@ -60,7 +68,7 @@ class SectionManager(models.Manager):
 class PageQuerySet(models.QuerySet):
 
     def prefetch_elements(self):
-        return self.prefetch_related(*self.model.prefetch_lookups)
+        return self.prefetch_related(*page_prefetch_lookups())
 
     def filter_by_catalog(self, catalog):
         ids = [descendant.id for descendant in catalog.descendants if isinstance(descendant, self.model)]
@@ -82,7 +90,7 @@ class PageManager(models.Manager):
 class QuestionSetQuerySet(models.QuerySet):
 
     def prefetch_elements(self):
-        return self.prefetch_related(*self.model.prefetch_lookups)
+        return self.prefetch_related(*questionset_prefetch_lookups())
 
     def filter_by_catalog(self, catalog):
         ids = [descendant.id for descendant in catalog.descendants if isinstance(descendant, self.model)]
@@ -101,7 +109,7 @@ class QuestionSetManager(models.Manager):
 class QuestionQuerySet(models.QuerySet):
 
     def prefetch_elements(self):
-        return self.prefetch_related(*self.model.prefetch_lookups)
+        return self.prefetch_related(*question_prefetch_lookups())
 
     def filter_by_catalog(self, catalog):
         ids = [descendant.id for descendant in catalog.descendants if isinstance(descendant, self.model)]

--- a/rdmo/questions/models/catalog.py
+++ b/rdmo/questions/models/catalog.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -11,6 +10,7 @@ from rdmo.core.models import Model, TranslationMixin
 from rdmo.core.utils import join_url
 
 from ..managers import CatalogManager
+from ..prefetch import catalog_prefetch_lookups
 
 
 class Catalog(Model, TranslationMixin):
@@ -198,7 +198,7 @@ class Catalog(Model, TranslationMixin):
         return list(filter(lambda q: q.is_optional, self.questions))
 
     def prefetch_elements(self):
-        models.prefetch_related_objects([self], *self.prefetch_lookups)
+        models.prefetch_related_objects([self], *catalog_prefetch_lookups())
 
     def to_dict(self):
         elements = [element.to_dict() for element in self.elements]
@@ -255,85 +255,3 @@ class Catalog(Model, TranslationMixin):
         if not uri_path:
             raise RuntimeError('uri_path is missing')
         return join_url(uri_prefix or settings.DEFAULT_URI_PREFIX, '/questions/', uri_path)
-
-
-def condition_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
-    )
-
-
-def question_prefetch(path):
-    from .question import Question
-
-    return Prefetch(
-        path,
-        queryset=Question.objects.select_related(
-            'attribute',
-            'default_option',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            'optionsets',
-        )
-    )
-
-
-def child_questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-        )
-    )
-
-
-def questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-            child_questionset_prefetch('questionset_questionsets__questionset'),
-        )
-    )
-
-
-def page_prefetch(path):
-    from .page import Page
-
-    return Prefetch(
-        path,
-        queryset=Page.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('page_questions__question'),
-            questionset_prefetch('page_questionsets__questionset'),
-        )
-    )
-
-
-def section_prefetch(path):
-    from .section import Section
-
-    return Prefetch(
-        path,
-        queryset=Section.objects.prefetch_related(
-            page_prefetch('section_pages__page'),
-        )
-    )
-
-
-Catalog.prefetch_lookups = (
-    section_prefetch('catalog_sections__section'),
-)

--- a/rdmo/questions/models/page.py
+++ b/rdmo/questions/models/page.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -11,6 +10,7 @@ from rdmo.core.utils import join_url
 from rdmo.domain.models import Attribute
 
 from ..managers import PageManager
+from ..prefetch import page_prefetch_lookups
 
 
 class Page(Model, TranslationMixin):
@@ -223,7 +223,7 @@ class Page(Model, TranslationMixin):
         return descendants
 
     def prefetch_elements(self):
-        models.prefetch_related_objects([self], *self.prefetch_lookups)
+        models.prefetch_related_objects([self], *page_prefetch_lookups())
 
     def to_dict(self):
         return {
@@ -242,61 +242,3 @@ class Page(Model, TranslationMixin):
         if not uri_path:
             raise RuntimeError('uri_path is missing')
         return join_url(uri_prefix or settings.DEFAULT_URI_PREFIX, '/questions/', uri_path)
-
-
-def condition_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
-    )
-
-
-def question_prefetch(path):
-    from .question import Question
-
-    return Prefetch(
-        path,
-        queryset=Question.objects.select_related(
-            'attribute',
-            'default_option',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            'optionsets',
-        )
-    )
-
-
-def child_questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-        )
-    )
-
-
-def questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-            child_questionset_prefetch('questionset_questionsets__questionset'),
-        )
-    )
-
-
-Page.prefetch_lookups = (
-    condition_prefetch('conditions'),
-    question_prefetch('page_questions__question'),
-    questionset_prefetch('page_questionsets__questionset'),
-)

--- a/rdmo/questions/models/question.py
+++ b/rdmo/questions/models/question.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -14,6 +13,7 @@ from rdmo.options.models import Option
 
 from ..constants import WIDGET_TYPE_CHOICES
 from ..managers import QuestionManager
+from ..prefetch import question_prefetch_lookups
 
 
 class Question(Model, TranslationMixin):
@@ -264,7 +264,7 @@ class Question(Model, TranslationMixin):
         return []
 
     def prefetch_elements(self):
-        models.prefetch_related_objects([self], *self.prefetch_lookups)
+        models.prefetch_related_objects([self], *question_prefetch_lookups())
 
     def to_dict(self, *ancestors):
         return {
@@ -288,17 +288,3 @@ class Question(Model, TranslationMixin):
         if not uri_path:
             raise RuntimeError('uri_path is missing')
         return join_url(uri_prefix or settings.DEFAULT_URI_PREFIX, '/questions/', uri_path)
-
-
-def condition_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
-    )
-
-
-Question.prefetch_lookups = (
-    condition_prefetch('conditions'),
-    'optionsets',
-    'default_option',
-)

--- a/rdmo/questions/models/questionset.py
+++ b/rdmo/questions/models/questionset.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -11,6 +10,7 @@ from rdmo.core.utils import join_url
 from rdmo.domain.models import Attribute
 
 from ..managers import QuestionSetManager
+from ..prefetch import questionset_prefetch_lookups
 
 
 class QuestionSet(Model, TranslationMixin):
@@ -199,7 +199,7 @@ class QuestionSet(Model, TranslationMixin):
         return descendants
 
     def prefetch_elements(self):
-        models.prefetch_related_objects([self], *self.prefetch_lookups)
+        models.prefetch_related_objects([self], *questionset_prefetch_lookups())
 
     def to_dict(self, *ancestors):
         return {
@@ -217,45 +217,3 @@ class QuestionSet(Model, TranslationMixin):
         if not uri_path:
             raise RuntimeError('uri_path is missing')
         return join_url(uri_prefix or settings.DEFAULT_URI_PREFIX, '/questions/', uri_path)
-
-
-def condition_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
-    )
-
-
-def question_prefetch(path):
-    from .question import Question
-
-    return Prefetch(
-        path,
-        queryset=Question.objects.select_related(
-            'attribute',
-            'default_option',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            'optionsets',
-        )
-    )
-
-
-def child_questionset_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-            'questionset_questionsets',
-        )
-    )
-
-
-QuestionSet.prefetch_lookups = (
-    condition_prefetch('conditions'),
-    question_prefetch('questionset_questions__question'),
-    child_questionset_prefetch('questionset_questionsets__questionset'),
-)

--- a/rdmo/questions/models/section.py
+++ b/rdmo/questions/models/section.py
@@ -1,15 +1,14 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from rdmo.conditions.models import Condition
 from rdmo.core.models import Model, TranslationMixin
 from rdmo.core.utils import join_url
 
 from ..managers import SectionManager
+from ..prefetch import section_prefetch_lookups
 
 
 class Section(Model, TranslationMixin):
@@ -139,7 +138,7 @@ class Section(Model, TranslationMixin):
         return descendants
 
     def prefetch_elements(self):
-        models.prefetch_related_objects([self], *self.prefetch_lookups)
+        models.prefetch_related_objects([self], *section_prefetch_lookups())
 
     def to_dict(self):
         elements = [element.to_dict() for element in self.elements]
@@ -157,74 +156,3 @@ class Section(Model, TranslationMixin):
         if not uri_path:
             raise RuntimeError('uri_path is missing')
         return join_url(uri_prefix or settings.DEFAULT_URI_PREFIX, '/questions/', uri_path)
-
-
-def condition_prefetch(path):
-    return Prefetch(
-        path,
-        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
-    )
-
-
-def question_prefetch(path):
-    from .question import Question
-
-    return Prefetch(
-        path,
-        queryset=Question.objects.select_related(
-            'attribute',
-            'default_option',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            'optionsets',
-        )
-    )
-
-
-def child_questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-        )
-    )
-
-
-def questionset_prefetch(path):
-    from .questionset import QuestionSet
-
-    return Prefetch(
-        path,
-        queryset=QuestionSet.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('questionset_questions__question'),
-            child_questionset_prefetch('questionset_questionsets__questionset'),
-        )
-    )
-
-
-def page_prefetch(path):
-    from .page import Page
-
-    return Prefetch(
-        path,
-        queryset=Page.objects.select_related(
-            'attribute',
-        ).prefetch_related(
-            condition_prefetch('conditions'),
-            question_prefetch('page_questions__question'),
-            questionset_prefetch('page_questionsets__questionset'),
-        )
-    )
-
-
-Section.prefetch_lookups = (
-    page_prefetch('section_pages__page'),
-)

--- a/rdmo/questions/prefetch.py
+++ b/rdmo/questions/prefetch.py
@@ -1,0 +1,136 @@
+from django.db.models import Prefetch
+
+from rdmo.conditions.models import Condition
+
+
+def condition_prefetch(path):
+    return Prefetch(
+        path,
+        queryset=Condition.objects.select_related('source', 'source__parent', 'target_option')
+    )
+
+
+def question_options_prefetch_lookups():
+    return (
+        'optionsets',
+        'optionsets__optionset_options__option',
+    )
+
+
+def question_prefetch(path, include_options=False):
+    from .models import Question
+
+    optionset_lookups = question_options_prefetch_lookups() if include_options else ('optionsets',)
+
+    return Prefetch(
+        path,
+        queryset=Question.objects.select_related(
+            'attribute',
+            'default_option',
+        ).prefetch_related(
+            condition_prefetch('conditions'),
+            *optionset_lookups,
+        )
+    )
+
+
+def questionset_questionset_prefetch(path):
+    from .models import QuestionSet
+
+    return Prefetch(
+        path,
+        queryset=QuestionSet.objects.select_related(
+            'attribute',
+        ).prefetch_related(
+            condition_prefetch('conditions'),
+            question_prefetch('questionset_questions__question'),
+        )
+    )
+
+
+def questionset_prefetch(path, include_question_options=False):
+    from .models import QuestionSet
+
+    return Prefetch(
+        path,
+        queryset=QuestionSet.objects.select_related(
+            'attribute',
+        ).prefetch_related(
+            condition_prefetch('conditions'),
+            question_prefetch(
+                'questionset_questions__question',
+                include_options=include_question_options
+            ),
+            questionset_questionset_prefetch('questionset_questionsets__questionset'),
+        )
+    )
+
+
+def page_prefetch(path):
+    from .models import Page
+
+    return Prefetch(
+        path,
+        queryset=Page.objects.select_related(
+            'attribute',
+        ).prefetch_related(
+            condition_prefetch('conditions'),
+            question_prefetch('page_questions__question'),
+            questionset_prefetch('page_questionsets__questionset'),
+        )
+    )
+
+
+def section_prefetch(path):
+    from .models import Section
+
+    return Prefetch(
+        path,
+        queryset=Section.objects.prefetch_related(
+            page_prefetch('section_pages__page'),
+        )
+    )
+
+
+def catalog_prefetch_lookups():
+    return (
+        section_prefetch('catalog_sections__section'),
+    )
+
+
+def section_prefetch_lookups():
+    return (
+        page_prefetch('section_pages__page'),
+    )
+
+
+def page_prefetch_lookups():
+    return (
+        condition_prefetch('conditions'),
+        question_prefetch('page_questions__question'),
+        questionset_prefetch('page_questionsets__questionset'),
+    )
+
+
+def project_page_prefetch_lookups():
+    return (
+        condition_prefetch('conditions'),
+        question_prefetch('page_questions__question', include_options=True),
+        questionset_prefetch('page_questionsets__questionset', include_question_options=True),
+    )
+
+
+def questionset_prefetch_lookups():
+    return (
+        condition_prefetch('conditions'),
+        question_prefetch('questionset_questions__question'),
+        questionset_questionset_prefetch('questionset_questionsets__questionset'),
+    )
+
+
+def question_prefetch_lookups():
+    return (
+        condition_prefetch('conditions'),
+        'optionsets',
+        'default_option',
+    )

--- a/rdmo/questions/tests/test_api_performance_catalog.py
+++ b/rdmo/questions/tests/test_api_performance_catalog.py
@@ -4,26 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_catalog import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 8},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 30, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 8, 'url_kwargs': {'pk': 1}},
-    'detail_export': {
-        'max_queries': 29, 'url_kwargs': {'pk': 1, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries url_kwargs
+    ('list', 8, {}),
+    ('index', 3, {}),
+    ('export', 30, {'export_format': 'xml'}),
+    ('detail', 8, {'pk': 1}),
+    ('detail_export', 29, {'pk': 1, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_catalog_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/questions/tests/test_api_performance_page.py
+++ b/rdmo/questions/tests/test_api_performance_page.py
@@ -4,26 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_page import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 10},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 25, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 10, 'url_kwargs': {'pk': 1}},
-    'detail_export': {
-        'max_queries': 13, 'url_kwargs': {'pk': 1, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 10, {}),
+    ('index', 3, {}),
+    ('export', 25, {'export_format': 'xml'}),
+    ('detail', 10, {'pk': 1}),
+    ('detail_export', 13, {'pk': 1, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_page_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/questions/tests/test_api_performance_question.py
+++ b/rdmo/questions/tests/test_api_performance_question.py
@@ -4,26 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_question import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 10},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 12, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 10, 'url_kwargs': {'pk': 1}},
-    'detail_export': {
-        'max_queries': 12, 'url_kwargs': {'pk': 1, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 10, {}),
+    ('index', 3, {}),
+    ('export', 12, {'export_format': 'xml'}),
+    ('detail', 10, {'pk': 1}),
+    ('detail_export', 12, {'pk': 1, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_question_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/questions/tests/test_api_performance_questionset.py
+++ b/rdmo/questions/tests/test_api_performance_questionset.py
@@ -4,26 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_questionset import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 11},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 17, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 10, 'url_kwargs': {'pk': 89}},
-    'detail_export': {
-        'max_queries': 13, 'url_kwargs': {'pk': 89, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 11, {}),
+    ('index', 3, {}),
+    ('export', 17, {'export_format': 'xml'}),
+    ('detail', 10, {'pk': 89}),
+    ('detail_export', 13, {'pk': 89, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_questionset_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/questions/tests/test_api_performance_section.py
+++ b/rdmo/questions/tests/test_api_performance_section.py
@@ -4,26 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_section import urlnames
 
-max_query_map = {
-    # action: max_queries url_kwargs
-    'list': {'max_queries': 8},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 27, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 8, 'url_kwargs': {'pk': 1}},
-    'detail_export': {
-        'max_queries': 12, 'url_kwargs': {'pk': 1, 'export_format': 'xml'},
-    },
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 8, {}),
+    ('index', 3, {}),
+    ('export', 27, {'export_format': 'xml'}),
+    ('detail', 8, {'pk': 1}),
+    ('detail_export', 12, {'pk': 1, 'export_format': 'xml'}),
+]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_section_endpoints_query_counts(
     db, admin_client, django_assert_max_num_queries,
     action, max_queries, url_kwargs,

--- a/rdmo/questions/utils.py
+++ b/rdmo/questions/utils.py
@@ -1,0 +1,47 @@
+from rdmo.conditions.models import Condition
+from rdmo.domain.models import Attribute
+from rdmo.questions.models import Page, Question, QuestionSet
+
+
+def get_export_serializer_context(elements, renderer_context):
+    if not any(
+        renderer_context.get(key)
+        for key in ('attributes', 'conditions', 'optionsets')
+    ):
+        return {'attribute_map': {}}
+
+    attribute_ids = set()
+    question_ids = set()
+
+    for element in elements:
+        for descendant in get_element_descendants(element):
+            if isinstance(descendant, (Page, QuestionSet, Question)) and descendant.attribute_id:
+                attribute_ids.add(descendant.attribute_id)
+
+            if isinstance(descendant, Question):
+                question_ids.add(descendant.id)
+
+            if isinstance(descendant, (Page, QuestionSet, Question)):
+                attribute_ids.update(
+                    condition.source_id
+                    for condition in descendant.conditions.all()
+                )
+
+    if renderer_context.get('optionsets') and question_ids:
+        attribute_ids.update(
+            Condition.objects.filter(
+                optionsets__questions__id__in=question_ids
+            ).values_list('source_id', flat=True)
+        )
+
+    return {
+        'attribute_map': Attribute.objects.get_queryset_ancestors(
+            Attribute.objects.filter(id__in=attribute_ids),
+            include_self=True
+        ).in_bulk()
+    }
+
+
+def get_element_descendants(element):
+    yield element
+    yield from getattr(element, 'descendants', [])

--- a/rdmo/questions/viewsets.py
+++ b/rdmo/questions/viewsets.py
@@ -41,6 +41,7 @@ from .serializers.v1 import (
     SectionNestedSerializer,
     SectionSerializer,
 )
+from .utils import get_export_serializer_context
 
 
 class CatalogViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
@@ -83,9 +84,13 @@ class CatalogViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = CatalogExportSerializer(queryset, many=True, context=context)
-            xml = CatalogRenderer().render(serializer.data, context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context(queryset, renderer_context),
+            }
+            serializer = CatalogExportSerializer(queryset, many=True, context=serializer_context)
+            xml = CatalogRenderer().render(serializer.data, context=renderer_context)
             return XMLResponse(xml, name='catalogs')
         else:
             return render_to_format(
@@ -98,9 +103,13 @@ class CatalogViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = CatalogExportSerializer(instance, context=context)
-            xml = CatalogRenderer().render([serializer.data], context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context([instance], renderer_context),
+            }
+            serializer = CatalogExportSerializer(instance, context=serializer_context)
+            xml = CatalogRenderer().render([serializer.data], context=renderer_context)
             return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(
@@ -160,9 +169,13 @@ class SectionViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = SectionExportSerializer(queryset, many=True, context=context)
-            xml = SectionRenderer().render(serializer.data, context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context(queryset, renderer_context),
+            }
+            serializer = SectionExportSerializer(queryset, many=True, context=serializer_context)
+            xml = SectionRenderer().render(serializer.data, context=renderer_context)
             return XMLResponse(xml, name='sections')
         else:
             return render_to_format(
@@ -175,9 +188,13 @@ class SectionViewSet(ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = SectionExportSerializer(instance, context=context)
-            xml = SectionRenderer().render([serializer.data], context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context([instance], renderer_context),
+            }
+            serializer = SectionExportSerializer(instance, context=serializer_context)
+            xml = SectionRenderer().render([serializer.data], context=renderer_context)
             return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(
@@ -244,9 +261,13 @@ class PageViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = PageExportSerializer(queryset, many=True, context=context)
-            xml = PageRenderer().render(serializer.data, context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context(queryset, renderer_context),
+            }
+            serializer = PageExportSerializer(queryset, many=True, context=serializer_context)
+            xml = PageRenderer().render(serializer.data, context=renderer_context)
             return XMLResponse(xml, name='pages')
         else:
             return render_to_format(
@@ -259,9 +280,13 @@ class PageViewSet(ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = PageExportSerializer(instance, context=context)
-            xml = PageRenderer().render([serializer.data], context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context([instance], renderer_context),
+            }
+            serializer = PageExportSerializer(instance, context=serializer_context)
+            xml = PageRenderer().render([serializer.data], context=renderer_context)
             return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(
@@ -328,9 +353,13 @@ class QuestionSetViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = QuestionSetExportSerializer(queryset, many=True, context=context)
-            xml = QuestionSetRenderer().render(serializer.data, context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context(queryset, renderer_context),
+            }
+            serializer = QuestionSetExportSerializer(queryset, many=True, context=serializer_context)
+            xml = QuestionSetRenderer().render(serializer.data, context=renderer_context)
             return XMLResponse(xml, name='questionsets')
         else:
             return render_to_format(
@@ -343,9 +372,13 @@ class QuestionSetViewSet(ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = QuestionSetExportSerializer(instance, context=context)
-            xml = QuestionSetRenderer().render([serializer.data], context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context([instance], renderer_context),
+            }
+            serializer = QuestionSetExportSerializer(instance, context=serializer_context)
+            xml = QuestionSetRenderer().render([serializer.data], context=renderer_context)
             return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(
@@ -409,9 +442,13 @@ class QuestionViewSet(ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = QuestionExportSerializer(queryset, many=True, context=context)
-            xml = QuestionRenderer().render(serializer.data, context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context(queryset, renderer_context),
+            }
+            serializer = QuestionExportSerializer(queryset, many=True, context=serializer_context)
+            xml = QuestionRenderer().render(serializer.data, context=renderer_context)
             return XMLResponse(xml, name='questions')
         else:
             return render_to_format(
@@ -424,9 +461,13 @@ class QuestionViewSet(ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            context = self.get_export_renderer_context(request)
-            serializer = QuestionExportSerializer(instance, context=context)
-            xml = QuestionRenderer().render([serializer.data], context=context)
+            renderer_context = self.get_export_renderer_context(request)
+            serializer_context = {
+                **renderer_context,
+                **get_export_serializer_context([instance], renderer_context),
+            }
+            serializer = QuestionExportSerializer(instance, context=serializer_context)
+            xml = QuestionRenderer().render([serializer.data], context=renderer_context)
             return XMLResponse(xml, name=instance.uri_path)
         else:
             return render_to_format(

--- a/rdmo/questions/viewsets.py
+++ b/rdmo/questions/viewsets.py
@@ -13,7 +13,6 @@ from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
 from rdmo.core.views import ChoicesViewSet
-from rdmo.domain.models import Attribute
 from rdmo.management.viewsets import ElementToggleCurrentSiteViewSetMixin
 
 from .constants import WIDGET_TYPE_CHOICES
@@ -42,11 +41,6 @@ from .serializers.v1 import (
     SectionNestedSerializer,
     SectionSerializer,
 )
-
-
-def get_attributes_by_id():
-    attributes = list(Attribute.objects.all())
-    return {attribute.pk: attribute for attribute in attributes}
 
 
 class CatalogViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
@@ -126,7 +120,6 @@ class CatalogViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
             'optionsets': full or is_truthy(request.GET.get('optionsets')),
             'options': full or is_truthy(request.GET.get('options')),
             'conditions': full or is_truthy(request.GET.get('conditions')),
-            'attributes_by_id': get_attributes_by_id(),
         }
 
 
@@ -203,7 +196,6 @@ class SectionViewSet(ModelViewSet):
             'optionsets': full or is_truthy(request.GET.get('optionsets')),
             'options': full or is_truthy(request.GET.get('options')),
             'conditions': full or is_truthy(request.GET.get('conditions')),
-            'attributes_by_id': get_attributes_by_id(),
         }
 
 
@@ -287,7 +279,6 @@ class PageViewSet(ModelViewSet):
             'optionsets': full or is_truthy(request.GET.get('optionsets')),
             'options': full or is_truthy(request.GET.get('options')),
             'conditions': full or is_truthy(request.GET.get('conditions')),
-            'attributes_by_id': get_attributes_by_id(),
         }
 
 
@@ -372,7 +363,6 @@ class QuestionSetViewSet(ModelViewSet):
             'optionsets': full or is_truthy(request.GET.get('optionsets')),
             'options': full or is_truthy(request.GET.get('options')),
             'conditions': full or is_truthy(request.GET.get('conditions')),
-            'attributes_by_id': get_attributes_by_id(),
         }
 
 
@@ -452,7 +442,6 @@ class QuestionViewSet(ModelViewSet):
             'optionsets': full or is_truthy(request.GET.get('optionsets')),
             'options': full or is_truthy(request.GET.get('options')),
             'conditions': full or is_truthy(request.GET.get('conditions')),
-            'attributes_by_id': get_attributes_by_id(),
         }
 
 

--- a/rdmo/tasks/renderers/mixins.py
+++ b/rdmo/tasks/renderers/mixins.py
@@ -17,8 +17,12 @@ class TasksRendererMixin:
                 self.render_text_element(xml, 'title', {'lang': lang_code}, task[f'title_{lang_code}'])
                 self.render_text_element(xml, 'text', {'lang': lang_code}, task[f'text_{lang_code}'])
 
-            self.render_text_element(xml, 'start_attribute',  {'dc:uri': task['start_attribute']}, None)
-            self.render_text_element(xml, 'end_attribute',  {'dc:uri': task['end_attribute']}, None)
+            self.render_text_element(xml, 'start_attribute',  {
+                'dc:uri': task['start_attribute']['uri'] if task['start_attribute'] is not None else None
+            }, None)
+            self.render_text_element(xml, 'end_attribute',  {
+                'dc:uri': task['end_attribute']['uri'] if task['end_attribute'] is not None else None
+            }, None)
             self.render_text_element(xml, 'days_before', {}, task['days_before'])
             self.render_text_element(xml, 'days_after', {}, task['days_after'])
 

--- a/rdmo/tasks/serializers/export.py
+++ b/rdmo/tasks/serializers/export.py
@@ -2,14 +2,15 @@ from rest_framework import serializers
 
 from rdmo.conditions.serializers.export import ConditionExportSerializer
 from rdmo.core.serializers import TranslationSerializerMixin
+from rdmo.domain.serializers.export import AttributeExportSerializer
 
 from ..models import Task
 
 
 class TaskExportSerializer(TranslationSerializerMixin, serializers.ModelSerializer):
 
-    start_attribute = serializers.CharField(source='start_attribute.uri', default=None, read_only=True)
-    end_attribute = serializers.CharField(source='end_attribute.uri', default=None, read_only=True)
+    start_attribute = serializers.SerializerMethodField()
+    end_attribute = serializers.SerializerMethodField()
     conditions = ConditionExportSerializer(many=True)
     catalogs = serializers.SerializerMethodField()
 
@@ -32,6 +33,16 @@ class TaskExportSerializer(TranslationSerializerMixin, serializers.ModelSerializ
             'title',
             'text'
         )
+
+    def get_start_attribute(self, obj):
+        start_attribute = self.context.get('attribute_map', {}).get(obj.start_attribute_id)
+        if start_attribute:
+            return AttributeExportSerializer(start_attribute).data
+
+    def get_end_attribute(self, obj):
+        end_attribute = self.context.get('attribute_map', {}).get(obj.end_attribute_id)
+        if end_attribute:
+            return AttributeExportSerializer(end_attribute).data
 
     def get_catalogs(self, obj):
         return [catalog.uri for catalog in obj.catalogs.all()]

--- a/rdmo/tasks/serializers/export.py
+++ b/rdmo/tasks/serializers/export.py
@@ -37,12 +37,12 @@ class TaskExportSerializer(TranslationSerializerMixin, serializers.ModelSerializ
     def get_start_attribute(self, obj):
         start_attribute = self.context.get('attribute_map', {}).get(obj.start_attribute_id)
         if start_attribute:
-            return AttributeExportSerializer(start_attribute).data
+            return AttributeExportSerializer(start_attribute, context=self.context).data
 
     def get_end_attribute(self, obj):
         end_attribute = self.context.get('attribute_map', {}).get(obj.end_attribute_id)
         if end_attribute:
-            return AttributeExportSerializer(end_attribute).data
+            return AttributeExportSerializer(end_attribute, context=self.context).data
 
     def get_catalogs(self, obj):
         return [catalog.uri for catalog in obj.catalogs.all()]

--- a/rdmo/tasks/tests/test_api_performance_task.py
+++ b/rdmo/tasks/tests/test_api_performance_task.py
@@ -4,22 +4,18 @@ from django.urls import reverse
 
 from .test_viewset_task import urlnames
 
-max_query_map = {
-    'list': {'max_queries': 10},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 12, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 10, 'url_kwargs': {'pk': 1}},
-    'detail_export': {'max_queries': 12, 'url_kwargs': {'pk': 1, 'export_format': 'xml'}},
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 10, {}),
+    ('index', 3, {}),
+    ('export', 12, {'export_format': 'xml'}),
+    ('detail', 10, {'pk': 1}),
+    ('detail_export', 12, {'pk': 1, 'export_format': 'xml'}),
+]
+
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_tasks_endpoints_query_counts(
     db,
     admin_client,

--- a/rdmo/tasks/viewsets.py
+++ b/rdmo/tasks/viewsets.py
@@ -10,6 +10,7 @@ from rdmo.core.exports import XMLResponse
 from rdmo.core.filters import SearchFilter
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 from rdmo.core.utils import is_truthy, render_to_format
+from rdmo.domain.models import Attribute
 from rdmo.management.viewsets import ElementToggleCurrentSiteViewSetMixin
 
 from .models import Task
@@ -37,6 +38,11 @@ class TaskViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
         queryset = Task.objects.all().order_by('uri')
         if self.action in ['index']:
             return queryset
+        elif self.action in ['export', 'detail_export']:
+            return queryset.prefetch_related(
+                'catalogs',
+                'conditions',
+            )
         else:
             return queryset.select_related(
                 'start_attribute',
@@ -61,7 +67,11 @@ class TaskViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
     def export(self, request, export_format='xml'):
         queryset = self.filter_queryset(self.get_queryset())
         if export_format == 'xml':
-            serializer = TaskExportSerializer(queryset, many=True)
+            serializer = TaskExportSerializer(
+                queryset,
+                many=True,
+                context=self.get_export_serializer_context(queryset),
+            )
             xml = TaskRenderer().render(serializer.data, context=self.get_export_renderer_context(request))
             return XMLResponse(xml, name='tasks')
         else:
@@ -73,7 +83,10 @@ class TaskViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
     def detail_export(self, request, pk=None, export_format='xml'):
         instance = self.get_object()
         if export_format == 'xml':
-            serializer = TaskExportSerializer(instance)
+            serializer = TaskExportSerializer(
+                instance,
+                context=self.get_export_serializer_context([instance]),
+            )
             xml = TaskRenderer().render([serializer.data], context=self.get_export_renderer_context(request))
             return XMLResponse(xml, name=instance.uri_path)
         else:
@@ -82,6 +95,23 @@ class TaskViewSet(ElementToggleCurrentSiteViewSetMixin, ModelViewSet):
                     'tasks': [instance]
                 }
             )
+
+    def get_export_serializer_context(self, tasks):
+        attribute_ids = set()
+        for task in tasks:
+            if task.start_attribute:
+                attribute_ids.add(task.start_attribute_id)
+            if task.end_attribute:
+                attribute_ids.add(task.end_attribute_id)
+            for condition in task.conditions.all():
+                attribute_ids.add(condition.source_id)
+
+        return {
+            'attribute_map': Attribute.objects.get_queryset_ancestors(
+                Attribute.objects.filter(id__in=attribute_ids),
+                include_self=True
+            ).in_bulk()
+        }
 
     def get_export_renderer_context(self, request):
         full = is_truthy(request.GET.get('full'))

--- a/rdmo/views/tests/test_api_performance_view.py
+++ b/rdmo/views/tests/test_api_performance_view.py
@@ -4,22 +4,17 @@ from django.urls import reverse
 
 from .test_viewset_view import urlnames
 
-max_query_map = {
-    'list': {'max_queries': 8},
-    'index': {'max_queries': 3},
-    'export': {'max_queries': 10, 'url_kwargs': {'export_format': 'xml'}},
-    'detail': {'max_queries': 8, 'url_kwargs': {'pk': 1}},
-    'detail_export': {'max_queries': 10, 'url_kwargs': {'pk': 1, 'export_format': 'xml'}},
-}
+max_queries = [
+    # action, max_queries, url_kwargs
+    ('list', 8, {}),
+    ('index', 3, {}),
+    ('export', 10, {'export_format': 'xml'}),
+    ('detail', 8, {'pk': 1}),
+    ('detail_export', 10, {'pk': 1, 'export_format': 'xml'}),
+]
 
 @pytest.mark.performance
-@pytest.mark.parametrize(
-    'action,max_queries,url_kwargs',
-    [
-        (action, case['max_queries'], case.get('url_kwargs'))
-        for action, case in max_query_map.items()
-    ],
-)
+@pytest.mark.parametrize('action,max_queries,url_kwargs', max_queries)
 def test_views_endpoints_query_counts(
     db,
     admin_client,


### PR DESCRIPTION
This PR tries to solve the problem how to prefetch all attributes needed for a full export by using an `attribute_map` which is created in the viewset like this, e.g. for `Condition`:

```python
{
    'attribute_map': Attribute.objects.get_queryset_ancestors(
        Attribute.objects.filter(id__in=[condition.source_id for condition in conditions]),
        include_self=True
    ).in_bulk()
}
```

the lookup is then done in the serializer like this:

```python
    def get_source(self, obj):
        source = self.context.get('attribute_map', {}).get(obj.source_id)
        if source:
            return AttributeExportSerializer(source).data
```

since e.g. the `ConditionExportSerializer` is used by all serializers exporting conditions, this needs to be implemented in all those serializers. The PR contains this for all but the `questions` modules, which will a bit more complex.