### PR TITLE
Add questions to ProjectIssueSerializer and IssueSerializer

### DIFF
--- a/rdmo/projects/models/issue.py
+++ b/rdmo/projects/models/issue.py
@@ -97,6 +97,22 @@ class Issue(models.Model):
 
         return dates
 
+    @property
+    def questions(self):
+        # collect all source_ids from all conditions of the task of this issue
+        source_ids = {
+            condition.source_id
+            for condition in self.task.conditions.all()
+        }
+
+        # prefetch the catalog and filter all questions for the source_ids and all pages for those questions
+        self.project.catalog.prefetch_elements()
+        questions = list(filter(lambda q: q.source_id in source_ids, self.project.catalog.questions))
+        for question in questions:
+            question.page_list = list(filter(lambda p: question in p.elements, self.project.catalog.pages))
+
+        return questions
+
 
 class IssueResource(models.Model):
 

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -12,7 +12,7 @@ from rdmo.accounts.utils import get_full_name
 from rdmo.conditions.serializers.v1 import ConditionSerializer
 from rdmo.core.serializers import TranslationSerializerMixin
 from rdmo.domain.models import Attribute
-from rdmo.questions.models import Catalog
+from rdmo.questions.models import Catalog, Page, Question
 from rdmo.services.validators import ProviderValidator
 from rdmo.tasks.models import Task
 from rdmo.views.models import View
@@ -549,10 +549,35 @@ class ProjectIssueResourceSerializer(serializers.ModelSerializer):
         )
 
 
+class ProjectIssuePageSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Page
+        fields = (
+            'id',
+            'title',
+            'help'
+        )
+
+class ProjectIssueQuestionSerializer(serializers.ModelSerializer):
+
+    pages = ProjectIssuePageSerializer(source='page_list', read_only=True, many=True)
+
+    class Meta:
+        model = Question
+        fields = (
+            'id',
+            'text',
+            'help',
+            'pages'
+        )
+
+
 class ProjectIssueSerializer(serializers.ModelSerializer):
 
     task = ProjectIssueTaskSerializer(read_only=True)
     resources = ProjectIssueResourceSerializer(read_only=True, many=True)
+    questions = ProjectIssueQuestionSerializer(read_only=True, many=True)
     resolve = serializers.BooleanField(read_only=True)
     dates = serializers.ReadOnlyField()
 
@@ -564,7 +589,8 @@ class ProjectIssueSerializer(serializers.ModelSerializer):
             'status',
             'resolve',
             'resources',
-            'dates'
+            'dates',
+            'questions',
         )
 
 
@@ -760,11 +786,37 @@ class IssueResourceSerializer(serializers.ModelSerializer):
         )
 
 
+class IssuePageSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Page
+        fields = (
+            'id',
+            'title',
+            'help'
+        )
+
+
+class IssueQuestionSerializer(serializers.ModelSerializer):
+
+    pages = ProjectIssuePageSerializer(source='page_list', read_only=True, many=True)
+
+    class Meta:
+        model = Question
+        fields = (
+            'id',
+            'text',
+            'help',
+            'pages'
+        )
+
+
 class IssueSerializer(serializers.ModelSerializer):
 
     project = serializers.PrimaryKeyRelatedField(read_only=True)
     task = IssueTaskSerializer(read_only=True)
     resources = IssueResourceSerializer(read_only=True, many=True)
+    questions = IssueQuestionSerializer(read_only=True, many=True)
     resolve = serializers.BooleanField(read_only=True)
     dates = serializers.ReadOnlyField()
 
@@ -777,7 +829,8 @@ class IssueSerializer(serializers.ModelSerializer):
             'status',
             'resolve',
             'resources',
-            'dates'
+            'dates',
+            'questions'
         )
 
 


### PR DESCRIPTION
The exiting part is in `rdmo/projects/models/issue.py`. It used the Python `filter` since with `catalog.prefetch_elements()` we already have the catalog in memory.