### PR TITLE
Update artifact actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Download wheel
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: Packages
         path: dist
@@ -126,7 +126,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Download wheel
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: Packages
         path: dist
@@ -154,7 +154,7 @@ jobs:
       env:
         DJANGO_DEBUG: True
         GITHUB_DB_BACKEND: ${{ matrix.db-backend }}
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v6
       with:
         name: screenshots
         path: screenshots/**/*.png
@@ -202,7 +202,7 @@ jobs:
           python-version: "3.14"
           cache: pip
       - name: Download wheel
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
actions/download-artifact@v6, actions/upload-artifact@v5. Actions will be forced to run with Node.js 24 by default starting
June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of 
these actions are available that support Node.js 24. To opt into Node.js 24 now, set the
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js
24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```