### PR TITLE
Fix STORE_VALUE_ERROR in interview reducer

### DIFF
--- a/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
+++ b/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
@@ -134,10 +134,11 @@ export default function interviewReducer(state = initialState, action) {
     case RESOLVE_CONDITIONS_ERROR:
       return { ...state, errors: [...state.errors, { actionType: action.type, ...action.error }] }
     case STORE_VALUE_ERROR:
-      if (action.valueIndex > -1) {
-         return {
-          ...state, values: state.values.map((value, valueIndex) => (
-            valueIndex == action.valueIndex ? {...value, error: action.error, pending: false} : value
+      if (state.values.some((value) => (value.id || value.tmp_id) == action.valueId)) {
+        return {
+          ...state,
+          values: state.values.map((value) => (
+            (value.id || value.tmp_id) == action.valueId ?  {...value, error: action.error, pending: false} : value
           ))
         }
       } else {

--- a/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
+++ b/rdmo/projects/assets/js/interview/reducers/interviewReducer.js
@@ -138,7 +138,7 @@ export default function interviewReducer(state = initialState, action) {
         return {
           ...state,
           values: state.values.map((value) => (
-            (value.id || value.tmp_id) == action.valueId ?  {...value, error: action.error, pending: false} : value
+            (value.id || value.tmp_id) == action.valueId ? {...value, error: action.error, pending: false} : value
           ))
         }
       } else {


### PR DESCRIPTION
I overlooked the `STORE_VALUE_ERROR` case when introducing `tmp_id` in db5ac2c.

Resolves https://github.com/rdmorganiser/rdmo/issues/1635.
