### PR TITLE
ci: add a check for the target branch on PRs (only `.../release ` can target `main`)

### DIFF
--- a/.github/workflows/check-pr-target-branch.yml
+++ b/.github/workflows/check-pr-target-branch.yml
@@ -1,0 +1,31 @@
+name: Check PR target branch
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  check-pr-target-branch:
+    name: Check PR target branch
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Validate source and target branch
+        shell: bash
+        env:
+          SOURCE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          echo "Source branch: ${SOURCE_BRANCH}"
+          echo "Target branch: ${TARGET_BRANCH}"
+
+          main_target_branch_regex='^[0-9]+\.[0-9]+\.[0-9]+/(release)$'
+
+          if [[ "${TARGET_BRANCH}" == "main" && ! "${SOURCE_BRANCH}" =~ ${main_target_branch_regex} ]]; then
+            echo "::warning title=Wrong PR target branch::Branch '${SOURCE_BRANCH}' targets 'main'. Only '<x.y.z>/release' branches are expected to target 'main'. Feature and fix branches should target their matching release branch instead, for example '2.5.2/release'."
+            exit 1
+          fi
+
+          echo "PR target branch looks OK."


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title of the pull request --->

## Description
<!--- Describe your changes in detail --->

When I tried to target this PR to `main` it failed and showed:

```shell
Run echo "Source branch: ${SOURCE_BRANCH}"
Source branch: 2.5.2/ci/add-check-pr-target-branch
Target branch: main
Warning: Branch '2.5.2/ci/add-check-pr-target-branch' targets 'main'. Only '<x.y.z>/release' branches are expected to target 'main'. Feature and fix branches should target their matching release branch instead, for example '2.5.2/release'.
Error: Process completed with exit code 1.
```


## Motivation and Context
Maybe it can help in preventing accidentally wrong merges, without cluttering the CI too much..

This would prevent targeting a non-release branch to `main` accidentally.

