### PR TITLE
2.5.2/fix question gap

### DIFF
--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -154,6 +154,13 @@ $variant-background-color: #f5f5f5 !default;
     }
 }
 
+@media (min-width: 992px) {
+  .interview-question:nth-child(4n + 3) {
+    clear: both;
+    float: right;
+  }
+}
+
 .interview-questionset {
     .interview-questionset-label {
         margin-bottom: 10px;

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -155,7 +155,7 @@ $variant-background-color: #f5f5f5 !default;
 }
 
 @media (min-width: 992px) {
-  .interview-question:nth-child(4n + 3) {
+  .interview-question.col-md-6:nth-child(4n + 3) {
     clear: both;
     float: right;
   }


### PR DESCRIPTION
On two columned (col-md-6) questions there could be a gap in the display that is caused by bootstrap float:

<img width="1732" height="1194" alt="Bildschirmfoto 2026-07-15 um 14 47 42" src="https://github.com/user-attachments/assets/652ea5b4-d18f-4da7-9d62-4df29c54db69" />
