### PR TITLE
Improve questionset config (dropdown in management UI)

### DIFF
--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -14,13 +14,33 @@ import maxBy from 'lodash/maxBy'
 import Link from 'rdmo/core/assets/js/components/Link'
 import { getId, getLabel, getHelp } from 'rdmo/management/assets/js/utils/forms'
 
-const formatOptionLabel = ({ label }) => (
-  <span>
-    {label.split('/').map((part, index) => (
-      index === 0 ? part : [<wbr key={index} />, '/', part]
-    ))}
-  </span>
-)
+const formatOptionLabel = ({ label }, { context }) => {
+  const parts = label.split('/')
+
+  if (context === 'menu') {
+    // insert <wbr> at /
+    return (
+      <span>
+        {
+          parts.map((part, index) => (
+            index === 0 ? part : [<wbr key={index} />, '/', part]
+          ))
+        }
+      </span>
+    )
+  } else if (parts.length >= 3) {
+    const head = `${parts.slice(0, -3).join('/')}`
+    const tail = `/${parts.slice(-3).join('/')}`
+    return (
+      <span className="truncate-option-label">
+        <span className="truncate-option-label-head">{head}</span>
+        <span className="truncate-option-label-tail">{tail}</span>
+      </span>
+    )
+  } else {
+    return label
+  }
+}
 
 const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, errors, disabled, ariaLabelledBy,
                                   handleChange, handleEdit, handleRemove, handleDrag }) => {

--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -19,6 +19,7 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
                                   handleChange, handleEdit, handleRemove, handleDrag }) => {
   const dragRef = useRef(null)
   const dropRef = useRef(null)
+  const firstDropRef = useRef(null)
 
   const [{}, drag] = useDrag(() => ({
     type: field,
@@ -32,7 +33,17 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
       isOver: monitor.isOver()
     }),
     drop: (item) => {
-      handleDrag(item.index, index)
+      handleDrag(item.index, index + 1)
+    },
+  }))
+
+  const [{ isOver: isOverFirst }, firstDrop] = useDrop(() => ({
+    accept: field,
+    collect: (monitor) => ({
+      isOver: monitor.isOver()
+    }),
+    drop: (item) => {
+      handleDrag(item.index, 0)
     },
   }))
 
@@ -40,6 +51,12 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
     'drop': true,
     'show': isDragging,
     'over': isOver
+  })
+
+  const firstDropClassName = classNames({
+    'drop': true,
+    'show': isDragging,
+    'over': isOverFirst
   })
 
   const dragClassName = classNames({
@@ -50,6 +67,10 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
   if (!disabled) {
     drag(dragRef)
     drop(dropRef)
+
+    if (index === 0) {
+      firstDrop(firstDropRef)
+    }
   }
 
   const styles = {
@@ -58,6 +79,10 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
 
   return (
     <>
+      {
+        index === 0 &&
+        <div ref={firstDropRef} className={firstDropClassName}></div>
+      }
       <div className="ordered-multi-select-item">
         <div className="ordered-multi-select-item-options">
           <Link className="fa fa-pencil" title={gettext('Edit')}
@@ -192,7 +217,9 @@ class OrderedMultiSelect extends Component {
 
     const dragValue = values[dragIndex]
     values.splice(dragIndex, 1)
-    values.splice(dropIndex, 0, dragValue)
+
+    const insertIndex = dragIndex < dropIndex ? dropIndex - 1 : dropIndex
+    values.splice(insertIndex, 0, dragValue)
 
     // re-order the array
     values.forEach((value, index) => {

--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -14,32 +14,13 @@ import maxBy from 'lodash/maxBy'
 import Link from 'rdmo/core/assets/js/components/Link'
 import { getId, getLabel, getHelp } from 'rdmo/management/assets/js/utils/forms'
 
-// const formatOptionLabel = ({ label }) => (
-//   <span>
-//     {label.split('/').map((part, index) => (
-//       index === 0 ? part : [<wbr key={index} />, '/', part]
-//     ))}
-//   </span>
-// )
-
-const formatOptionLabel = ({ label }, { context }) => {
-  if (context === 'value') {
-    const separatorIndex = label.indexOf(': ')
-    const prefix = separatorIndex >= 0 ? label.slice(0, separatorIndex + 2) : ''
-    const value = separatorIndex >= 0 ? label.slice(separatorIndex + 2) : label
-    const lastSegment = value.split('/').filter(Boolean).pop()
-
-    return `${prefix}${lastSegment}`
-  }
-
-  return (
-    <span>
-      {label.split('/').map((part, index) => (
-        index === 0 ? part : [<wbr key={index} />, '/', part]
-      ))}
-    </span>
-  )
-}
+const formatOptionLabel = ({ label }) => (
+  <span>
+    {label.split('/').map((part, index) => (
+      index === 0 ? part : [<wbr key={index} />, '/', part]
+    ))}
+  </span>
+)
 
 const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, errors, disabled, ariaLabelledBy,
                                   handleChange, handleEdit, handleRemove, handleDrag }) => {

--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -12,7 +12,6 @@ import get from 'lodash/get'
 import maxBy from 'lodash/maxBy'
 
 import Link from 'rdmo/core/assets/js/components/Link'
-
 import { getId, getLabel, getHelp } from 'rdmo/management/assets/js/utils/forms'
 
 const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, errors, disabled, ariaLabelledBy,
@@ -77,6 +76,19 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
     container: provided => ({...provided, marginRight: 8 + 12 + 4 + 11 + 4 + 14})
   }
 
+  const handleMenuOpen = () => {
+    setTimeout(() => {
+      document
+        .querySelector(
+          '.react-select__menu-portal .react-select__option--is-selected'
+        )
+        ?.scrollIntoView({
+          block: 'center',
+          inline: 'nearest'
+        })
+    }, 0)
+  }
+
   return (
     <>
       {
@@ -96,7 +108,8 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
                        options={selectOptions} value={selectValue}
                        onChange={option => handleChange(option, index)}
                        menuPortalTarget={document.body} styles={styles} isDisabled={disabled}
-                       aria-labelledby={ariaLabelledBy} />
+                       aria-labelledby={ariaLabelledBy}
+                       onMenuOpen={handleMenuOpen} />
         </div>
         {
           errors && errors[index] &&

--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -109,10 +109,7 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
         .querySelector(
           '.react-select__menu-portal .react-select__option--is-selected'
         )
-        ?.scrollIntoView({
-          block: 'center',
-          inline: 'nearest'
-        })
+        ?.scrollIntoView({ block: 'nearest'})
     }, 0)
   }
 

--- a/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
+++ b/rdmo/management/assets/js/components/edit/common/OrderedMultiSelect.js
@@ -14,6 +14,33 @@ import maxBy from 'lodash/maxBy'
 import Link from 'rdmo/core/assets/js/components/Link'
 import { getId, getLabel, getHelp } from 'rdmo/management/assets/js/utils/forms'
 
+// const formatOptionLabel = ({ label }) => (
+//   <span>
+//     {label.split('/').map((part, index) => (
+//       index === 0 ? part : [<wbr key={index} />, '/', part]
+//     ))}
+//   </span>
+// )
+
+const formatOptionLabel = ({ label }, { context }) => {
+  if (context === 'value') {
+    const separatorIndex = label.indexOf(': ')
+    const prefix = separatorIndex >= 0 ? label.slice(0, separatorIndex + 2) : ''
+    const value = separatorIndex >= 0 ? label.slice(separatorIndex + 2) : label
+    const lastSegment = value.split('/').filter(Boolean).pop()
+
+    return `${prefix}${lastSegment}`
+  }
+
+  return (
+    <span>
+      {label.split('/').map((part, index) => (
+        index === 0 ? part : [<wbr key={index} />, '/', part]
+      ))}
+    </span>
+  )
+}
+
 const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, errors, disabled, ariaLabelledBy,
                                   handleChange, handleEdit, handleRemove, handleDrag }) => {
   const dragRef = useRef(null)
@@ -106,6 +133,7 @@ const OrderedMultiSelectItem = ({ index, field, selectValue, selectOptions, erro
         <div className="ordered-multi-select-item-select">
           <ReactSelect classNamePrefix="react-select" className="react-select"
                        options={selectOptions} value={selectValue}
+                       formatOptionLabel={formatOptionLabel}
                        onChange={option => handleChange(option, index)}
                        menuPortalTarget={document.body} styles={styles} isDisabled={disabled}
                        aria-labelledby={ariaLabelledBy}

--- a/rdmo/management/assets/scss/management.scss
+++ b/rdmo/management/assets/scss/management.scss
@@ -284,3 +284,21 @@
         }
     }
 }
+
+.truncate-option-label {
+    display: flex;
+    max-width: 100%;
+    min-width: 0;
+
+    .truncate-option-label-head {
+        flex: 0 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .truncate-option-label-tail {
+        flex: 0 0 auto;
+        white-space: nowrap;
+    }
+}

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -154,6 +154,12 @@ $variant-background-color: #f5f5f5 !default;
     }
 }
 
+@media (min-width: 992px) {
+  .interview-question.col-md-6:nth-child(2n + 1) {
+    clear: left;
+  }
+}
+
 .interview-questionset {
     .interview-questionset-label {
         margin-bottom: 10px;

--- a/rdmo/projects/assets/scss/interview.scss
+++ b/rdmo/projects/assets/scss/interview.scss
@@ -154,12 +154,6 @@ $variant-background-color: #f5f5f5 !default;
     }
 }
 
-@media (min-width: 992px) {
-  .interview-question.col-md-6:nth-child(2n + 1) {
-    clear: left;
-  }
-}
-
 .interview-questionset {
     .interview-questionset-label {
         margin-bottom: 10px;


### PR DESCRIPTION
In management questionset config:
Fixed drag and drop to work as expected.
Made some improvements to readability and usability of select dropdown options:
<img width="1836" height="934" alt="Bildschirmfoto 2026-08-03 um 10 16 02" src="https://github.com/user-attachments/assets/ce99280f-418f-42ee-8d98-92676673a05d" />

Related issue: https://github.com/rdmorganiser/rdmo/issues/1678