### PR TITLE
Render info text and button inside empty snapshot table

### DIFF
--- a/rdmo/projects/assets/js/project/components/areas/Snapshots.js
+++ b/rdmo/projects/assets/js/project/components/areas/Snapshots.js
@@ -26,7 +26,7 @@ const Snapshots = () => {
       </div>
       {
         perms.can_view_snapshot && (
-          <SnapshotTable snapshots={snapshots} onClick={openSnapshot}/>
+          <SnapshotTable snapshots={snapshots} onCreate={openSnapshot}/>
         )
       }
       <SnapshotModal show={showSnapshot} onClose={closeSnapshot} />

--- a/rdmo/projects/assets/js/project/components/areas/Snapshots.js
+++ b/rdmo/projects/assets/js/project/components/areas/Snapshots.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { isEmpty } from 'lodash'
 
 import { useModal } from 'rdmo/core/assets/js/hooks'
 
@@ -26,8 +25,8 @@ const Snapshots = () => {
         }
       </div>
       {
-        !isEmpty(snapshots) && perms.can_view_snapshot && (
-          <SnapshotTable snapshots={snapshots} />
+        perms.can_view_snapshot && (
+          <SnapshotTable snapshots={snapshots} onClick={openSnapshot}/>
         )
       }
       <SnapshotModal show={showSnapshot} onClose={closeSnapshot} />

--- a/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
+++ b/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
@@ -13,7 +13,7 @@ import SnapshotDeleteModal from './SnapshotDeleteModal'
 import SnapshotModal from './SnapshotModal'
 import SnapshotRollbackModal from './SnapshotRollbackModal'
 
-const SnapshotTable = ({ snapshots }) => {
+const SnapshotTable = ({ snapshots, onClick}) => {
   const dispatch = useDispatch()
   const { project } = useSelector((state) => state.project.project) || {}
   const perms = project?.permissions || {}
@@ -51,76 +51,99 @@ const SnapshotTable = ({ snapshots }) => {
         </thead>
         <tbody>
           {
-            snapshots?.map((snapshot) => {
-              const documentsLocation = { area: 'snapshots', snapshotId: snapshot.id }
-              return (
-                <tr key={snapshot.id}>
-                  <td>
-                    <strong>{snapshot.title}</strong>
-                  </td>
-                  <td>
-                    {snapshot.description}
-                  </td>
-                  <td>
-                    {formatDateTime(snapshot.created, 'long')}
-                  </td>
-                  <td>
-                    <div className="d-flex justify-content-end align-items-center gap-1">
-                      {
-                        perms.can_view_snapshot && (
-                          <Link
-                            title={gettext('View documents')}
-                            href={buildPath(documentsLocation)}
-                            onClick={() => dispatch(navigateDashboard(documentsLocation))}
-                          >
-                            <i className={'bi bi-file-text'} aria-hidden="true" />
-                          </Link>
-                        )
-                      }
-                      {
-                        perms.can_change_snapshot && (
-                          <button
-                            type="button"
-                            className="link"
-                            aria-label={gettext('Update snapshot')}
-                            title={gettext('Update snapshot')}
-                            onClick={() => openUpdateModal(snapshot)}
-                          >
-                            <i className={'bi bi-pencil'} aria-hidden="true" />
-                          </button>
-                        )
-                      }
-                      {
-                        perms.can_rollback_snapshot && (
-                          <button
-                            type="button"
-                            className="link"
-                            aria-label={gettext('Rollback to snapshot')}
-                            title={gettext('Rollback to snapshot')}
-                            onClick={() => openRollbackModal(snapshot)}
-                          >
-                            <i className={'bi bi-reply-fill'} aria-hidden="true" />
-                          </button>
-                        )
-                      }
-                      {
-                        perms.can_delete_snapshot && (
-                          <button
-                            type="button"
-                            className="link"
-                            aria-label={gettext('Delete snapshot')}
-                            title={gettext('Delete snapshot')}
-                            onClick={() => openDeleteModal(snapshot)}
-                          >
-                            <i className={'bi bi-trash'} aria-hidden="true" />
-                          </button>
-                        )
-                      }
-                    </div>
-                  </td>
-                </tr>
-              )
-            })
+            snapshots?.length ? (
+              snapshots?.map((snapshot) => {
+                const documentsLocation = { area: 'snapshots', snapshotId: snapshot.id }
+                return (
+                  <tr key={snapshot.id}>
+                    <td>
+                      <strong>{snapshot.title}</strong>
+                    </td>
+                    <td>
+                      {snapshot.description}
+                    </td>
+                    <td>
+                      {formatDateTime(snapshot.created, 'long')}
+                    </td>
+                    <td>
+                      <div className="d-flex justify-content-end align-items-center gap-1">
+                        {
+                          perms.can_view_snapshot && (
+                            <Link
+                              title={gettext('View documents')}
+                              href={buildPath(documentsLocation)}
+                              onClick={() => dispatch(navigateDashboard(documentsLocation))}
+                            >
+                              <i className={'bi bi-file-text'} aria-hidden="true" />
+                            </Link>
+                          )
+                        }
+                        {
+                          perms.can_change_snapshot && (
+                            <button
+                              type="button"
+                              className="link"
+                              aria-label={gettext('Update snapshot')}
+                              title={gettext('Update snapshot')}
+                              onClick={() => openUpdateModal(snapshot)}
+                            >
+                              <i className={'bi bi-pencil'} aria-hidden="true" />
+                            </button>
+                          )
+                        }
+                        {
+                          perms.can_rollback_snapshot && (
+                            <button
+                              type="button"
+                              className="link"
+                              aria-label={gettext('Rollback to snapshot')}
+                              title={gettext('Rollback to snapshot')}
+                              onClick={() => openRollbackModal(snapshot)}
+                            >
+                              <i className={'bi bi-reply-fill'} aria-hidden="true" />
+                            </button>
+                          )
+                        }
+                        {
+                          perms.can_delete_snapshot && (
+                            <button
+                              type="button"
+                              className="link"
+                              aria-label={gettext('Delete snapshot')}
+                              title={gettext('Delete snapshot')}
+                              onClick={() => openDeleteModal(snapshot)}
+                            >
+                              <i className={'bi bi-trash'} aria-hidden="true" />
+                            </button>
+                          )
+                        }
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })
+            ) : (
+              <tr>
+                <td colSpan={4}>
+                  <div
+                    className="d-flex flex-column align-items-center justify-content-center py-5"
+                    style={{ minHeight: '250px' }}
+                  >
+                    <p className="text-muted mb-3">
+                      {gettext('There are currently no snapshots.')}
+                    </p>
+
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={() => onClick()}
+                    >
+                      {gettext('Create new snapshot')}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            )
           }
         </tbody>
       </table>
@@ -147,7 +170,8 @@ const SnapshotTable = ({ snapshots }) => {
 }
 
 SnapshotTable.propTypes = {
-  snapshots: PropTypes.array.isRequired,
+  snapshots: PropTypes.array,
+  onClick: PropTypes.func
 }
 
 export default SnapshotTable

--- a/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
+++ b/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
@@ -13,7 +13,7 @@ import SnapshotDeleteModal from './SnapshotDeleteModal'
 import SnapshotModal from './SnapshotModal'
 import SnapshotRollbackModal from './SnapshotRollbackModal'
 
-const SnapshotTable = ({ snapshots, onClick}) => {
+const SnapshotTable = ({ snapshots, onCreate}) => {
   const dispatch = useDispatch()
   const { project } = useSelector((state) => state.project.project) || {}
   const perms = project?.permissions || {}
@@ -136,7 +136,7 @@ const SnapshotTable = ({ snapshots, onClick}) => {
                     <button
                       type="button"
                       className="btn btn-primary"
-                      onClick={() => onClick()}
+                      onClick={() => onCreate()}
                     >
                       {gettext('Create new snapshot')}
                     </button>
@@ -171,7 +171,7 @@ const SnapshotTable = ({ snapshots, onClick}) => {
 
 SnapshotTable.propTypes = {
   snapshots: PropTypes.array,
-  onClick: PropTypes.func
+  onCreate: PropTypes.func
 }
 
 export default SnapshotTable

--- a/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
+++ b/rdmo/projects/assets/js/project/components/areas/snapshots/SnapshotTable.js
@@ -132,14 +132,17 @@ const SnapshotTable = ({ snapshots, onCreate}) => {
                     <p className="text-muted mb-3">
                       {gettext('There are currently no snapshots.')}
                     </p>
-
-                    <button
-                      type="button"
-                      className="btn btn-primary"
-                      onClick={() => onCreate()}
-                    >
-                      {gettext('Create new snapshot')}
-                    </button>
+                    {
+                      perms.can_add_snapshot && (
+                        <button
+                          type="button"
+                          className="btn btn-primary"
+                          onClick={() => onCreate()}
+                        >
+                          {gettext('Create new snapshot')}
+                        </button>
+                      )
+                    }
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
If there are no snapshots there is now the table with an info text and button displayed, like in the mockups.

<img width="2312" height="1048" alt="Bildschirmfoto 2026-07-24 um 12 54 53" src="https://github.com/user-attachments/assets/ef94b02f-c6fd-4d03-b96b-75a72dcdeaa2" />
