### PR TITLE
2.5.2/fix/validation + drag&drop

### DIFF
--- a/rdmo/core/assets/js/api/BaseApi.js
+++ b/rdmo/core/assets/js/api/BaseApi.js
@@ -121,6 +121,29 @@ class BaseApi {
     })
   }
 
+  static patch(url, data) {
+    return fetch(baseUrl + url, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': Cookies.get('csrftoken')
+      },
+      body: JSON.stringify(data)
+    }).catch(error => {
+      throw new ApiError(error.message)
+    }).then(response => {
+      if (response.ok) {
+        return response.json()
+      } else if (response.status == 400) {
+        return response.json().then(errors => {
+          throw new ValidationError(errors)
+        })
+      } else {
+        throw new ApiError(response.statusText, response.status)
+      }
+    })
+  }
+
   static delete(url) {
     return fetch(baseUrl + url, {
       method: 'DELETE',

--- a/rdmo/core/permissions.py
+++ b/rdmo/core/permissions.py
@@ -79,7 +79,7 @@ class HasObjectPermission(DjangoObjectPermissions):
 class CanToggleElementCurrentSite(DjangoModelPermissions):
 
     perms_map = {
-        'PUT': ['%(app_label)s.change_%(model_name)s_toggle_site'],
+        'PATCH': ['%(app_label)s.change_%(model_name)s_toggle_site'],
     }
 
     @log_result

--- a/rdmo/core/permissions.py
+++ b/rdmo/core/permissions.py
@@ -79,7 +79,7 @@ class HasObjectPermission(DjangoObjectPermissions):
 class CanToggleElementCurrentSite(DjangoModelPermissions):
 
     perms_map = {
-        'PATCH': ['%(app_label)s.change_%(model_name)s_toggle_site'],
+        'POST': ['%(app_label)s.change_%(model_name)s_toggle_site'],
     }
 
     @log_result

--- a/rdmo/core/tests/test_validators.py
+++ b/rdmo/core/tests/test_validators.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from django.core.exceptions import ValidationError
@@ -7,56 +9,70 @@ from rest_framework import serializers
 from ..validators import InstanceValidator
 
 
-def test_instance_validator():
+def test_empty():
     validator = InstanceValidator()
     assert validator.instance is None
-    assert validator.serializer is None
 
 
-def test_instance_validator_instance():
-    instance = object()
-    validator = InstanceValidator(instance)
-    assert validator.instance is instance
-    assert validator.serializer is None
-
-
-def test_instance_validator_serializer():
+def test_not_implemented():
     validator = InstanceValidator()
     serializer = serializers.Serializer()
 
-    validator({}, serializer)
-
-    assert validator.serializer == serializer
-    assert validator.serializer.instance is None
+    with pytest.raises(NotImplementedError):
+        validator({}, serializer)
 
 
-def test_instance_validator_serializer_instance():
+def test_get_instance():
+    instance = Mock()
+    validator = InstanceValidator(instance)
+    assert validator.instance is instance
+    assert validator.get_instance(None) is instance
+
+
+def test_get_instance_serializer():
     validator = InstanceValidator()
-    instance = object()
+    instance = Mock()
     serializer = serializers.Serializer(instance=instance)
-
-    validator({}, serializer)
-
-    assert validator.serializer == serializer
-    assert validator.serializer.instance == serializer.instance
+    assert validator.instance is None
+    assert validator.get_instance(serializer) is instance
 
 
-def test_instance_validator_validation_error():
+def test_get_instance_none():
+    validator = InstanceValidator()
+    assert validator.instance is None
+    assert validator.get_instance(None) is None
+
+
+def test_get_value_data():
+    validator = InstanceValidator()
+    data = {
+        'foo': 'bar'
+    }
+    assert validator.get_value(data, None, 'foo') == 'bar'
+
+
+def test_get_value_instance():
+    validator = InstanceValidator()
+    data = {}
+    instance = Mock()
+    instance.foo = 'baz'
+    assert validator.get_value(data, instance, 'foo') == 'baz'
+
+
+def test_get_value_data_instance():
+    validator = InstanceValidator()
+    data = {
+        'foo': 'bar'
+    }
+    instance = Mock()
+    instance.foo = 'baz'
+    assert validator.get_value(data, instance, 'foo') == 'bar'
+
+
+def test_raise_validation_error():
     validator = InstanceValidator()
 
     with pytest.raises(ValidationError):
-        validator.raise_validation_error({
-            'foo': 'bar'
-        })
-
-
-def test_instance_validator_validation_serializer_error():
-    validator = InstanceValidator()
-    serializer = serializers.Serializer()
-
-    validator({}, serializer)
-
-    with pytest.raises(serializers.ValidationError):
         validator.raise_validation_error({
             'foo': 'bar'
         })

--- a/rdmo/core/validators.py
+++ b/rdmo/core/validators.py
@@ -11,8 +11,8 @@ class InstanceValidator:
     '''
     BaseValidator which should work with model instances, used by
 
-    1) the DRF serializer (having self.serializer)
-    2) the form clean method through the admin interface
+    1) the DRF serializer (providing serializer to __call__)
+    2) the form clean method through the admin interface (providing instance to __init__)
 
     It is used as InstanceValidator() for (1) and InstanceValidator(instance)(self.cleaned_data) for (2)
     '''
@@ -20,19 +20,23 @@ class InstanceValidator:
     requires_context = True
 
     def __init__(self, instance=None):
+        # admin interface case, where a fresh validator is built per call
         self.instance = instance
-        self.serializer = None
 
-    def __call__(self, data, serializer=None):
+    def get_instance(self, serializer):
         if serializer is not None:
-            self.instance = serializer.instance
-            self.serializer = serializer
+            return serializer.instance
+        return self.instance
 
-    def raise_validation_error(self, errors):
-        if self.serializer:
+    def get_value(self, data, instance, field):
+        if field in data:
+            return data[field]
+        return getattr(instance, field, None)
+
+    def raise_validation_error(self, errors, serializer=None):
+        if serializer is not None:
             raise serializers.ValidationError(errors)
-        else:
-            raise ValidationError(errors)
+        raise ValidationError(errors)
 
 
 class UniqueURIValidator(InstanceValidator):
@@ -43,12 +47,10 @@ class UniqueURIValidator(InstanceValidator):
     path_pattern = re.compile(r'^[\w\-\/]+\Z')
 
     def __call__(self, data, serializer=None):
-        super().__call__(data, serializer)
+        models = self.models or [self.model]
+        instance = self.get_instance(serializer)
 
-        self.validate(self.model, self.instance, self.get_uri(data))
-
-    def validate(self, model, instance, uri):
-        models = self.models or [model]
+        uri = self.get_uri(data, instance, serializer)
 
         for model in models:
             try:
@@ -69,20 +71,20 @@ class UniqueURIValidator(InstanceValidator):
             self.raise_validation_error({
                 'uri_path': message,
                 'key': message
-            })
+            }, serializer)
 
-    def get_uri(self, data):
-        uri_prefix = data.get('uri_prefix')
-        uri_path = data.get('uri_path')
+    def get_uri(self, data, instance, serializer):
+        uri_prefix = self.get_value(data, instance, 'uri_prefix')
+        uri_path = self.get_value(data, instance, 'uri_path')
 
         if not uri_path:
             self.raise_validation_error({
                 'uri_path': _('This field is required.')
-            })
+            }, serializer)
         elif not self.path_pattern.match(uri_path):
             self.raise_validation_error({
                 'uri_path': _('This value may contain only letters, numbers, slashes, hyphens and underscores.')
-            })
+            }, serializer)
         else:
             uri = self.model.build_uri(uri_prefix, uri_path)
             return uri
@@ -93,8 +95,6 @@ class LockedValidator(InstanceValidator):
     parent_fields = ()
 
     def __call__(self, data, serializer=None):
-        super().__call__(data, serializer)
-
         is_locked = False
 
         # lock if parent_fields are set and a parent is locked
@@ -109,10 +109,11 @@ class LockedValidator(InstanceValidator):
                 except TypeError:
                     pass
 
-        if self.instance:
+        instance = self.get_instance(serializer)
+        if instance:
             # lock if the instance itself has locked parents
             for parent_field in self.parent_fields:
-                parent = getattr(self.instance, parent_field)
+                parent = getattr(instance, parent_field)
 
                 try:
                     is_locked |= parent.is_locked
@@ -125,13 +126,14 @@ class LockedValidator(InstanceValidator):
 
         # lock if a superior element is locked
         if is_locked:
-            raise self.raise_validation_error({
+            self.raise_validation_error({
                 'locked': _('A superior element is locked.')
-            })
+            }, serializer)
 
         # lock if the instance is now locked and was locked before
-        if data.get('locked', False) and self.instance and self.instance.locked:
+        locked = self.get_value(data, instance, 'locked')
+        if locked and instance is not None and instance.locked:
             if data.get('locked'):
-                raise self.raise_validation_error({
+                self.raise_validation_error({
                     'locked': _('The element is locked.')
-                })
+                }, serializer)

--- a/rdmo/core/validators.py
+++ b/rdmo/core/validators.py
@@ -136,7 +136,6 @@ class LockedValidator(InstanceValidator):
         # lock if the instance is now locked and was locked before
         locked = self.get_value(data, instance, 'locked')
         if locked and instance is not None and instance.locked:
-            if data.get('locked'):
-                self.raise_validation_error({
-                    'locked': _('The element is locked.')
-                }, serializer)
+            self.raise_validation_error({
+                'locked': _('The element is locked.')
+            }, serializer)

--- a/rdmo/core/validators.py
+++ b/rdmo/core/validators.py
@@ -23,6 +23,9 @@ class InstanceValidator:
         # admin interface case, where a fresh validator is built per call
         self.instance = instance
 
+    def __call__(self, data, serializer=None):
+        raise NotImplementedError
+
     def get_instance(self, serializer):
         if serializer is not None:
             return serializer.instance

--- a/rdmo/domain/tests/test_validator_locked.py
+++ b/rdmo/domain/tests/test_validator_locked.py
@@ -155,6 +155,15 @@ def test_serializer_update_error(db):
         }, serializer)
 
 
+def test_serializer_update_partial(db):
+    attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
+
+    validator = AttributeLockedValidator()
+    serializer = AttributeSerializer(instance=attribute, partial=True)
+
+    validator({}, serializer)
+
+
 def test_serializer_update_partial_error(db):
     attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
     attribute.locked = True
@@ -164,6 +173,24 @@ def test_serializer_update_partial_error(db):
     serializer = AttributeSerializer(instance=attribute, partial=True)
 
     with pytest.raises(RestFrameworkValidationError):
-        validator({
-            'comment': 'Updated comment'
-        }, serializer)
+        validator({}, serializer)
+
+
+def test_serializer_update_partial_unlock(db):
+    attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
+    attribute.locked = True
+    attribute.save()
+
+    validator = AttributeLockedValidator()
+    serializer = AttributeSerializer(instance=attribute, partial=True)
+
+    validator({'locked': False}, serializer)
+
+def test_serializer_update_partial_lock(db):
+    attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
+    attribute.save()
+
+    validator = AttributeLockedValidator()
+    serializer = AttributeSerializer(instance=attribute, partial=True)
+
+    validator({'locked': True}, serializer)

--- a/rdmo/domain/tests/test_validator_locked.py
+++ b/rdmo/domain/tests/test_validator_locked.py
@@ -153,3 +153,17 @@ def test_serializer_update_error(db):
         validator({
             'locked': True
         }, serializer)
+
+
+def test_serializer_update_partial_error(db):
+    attribute = Attribute.objects.get(uri='http://example.com/terms/domain/individual/single/text')
+    attribute.locked = True
+    attribute.save()
+
+    validator = AttributeLockedValidator()
+    serializer = AttributeSerializer(instance=attribute, partial=True)
+
+    with pytest.raises(RestFrameworkValidationError):
+        validator({
+            'comment': 'Updated comment'
+        }, serializer)

--- a/rdmo/domain/validators.py
+++ b/rdmo/domain/validators.py
@@ -9,55 +9,62 @@ class AttributeUniqueURIValidator(UniqueURIValidator):
 
     model = Attribute
 
-    def get_uri(self, data):
-        if not data.get('key'):
-            self.raise_validation_error({'key': _('This field is required.')})
+    def get_uri(self, data, instance, serializer):
+        key = self.get_value(data, instance, 'key')
+        parent = self.get_value(data, instance, 'parent')
+        uri_prefix = self.get_value(data, instance, 'uri_prefix')
+
+        if not key:
+            self.raise_validation_error({'key': _('This field is required.')}, serializer)
         else:
-            parent = data.get('parent')
             if parent is None:
                 # workaround for import
                 parent_id = data.get('parent_id')
                 if parent_id:
-                    parent = Attribute.objects.get(id=data.get('parent_id'))
+                    parent = self.model.objects.filter(id=parent_id).first()
+                    if parent is None:
+                        self.raise_validation_error({'parent': [_('The parent does not exist.')]}, serializer)
 
-            path = self.model.build_path(data.get('key'), parent)
-            uri = self.model.build_uri(data.get('uri_prefix'), path)
+            path = self.model.build_path(key, parent)
+            uri = self.model.build_uri(uri_prefix, path)
             return uri
 
 
 class AttributeParentValidator(InstanceValidator):
 
     def __call__(self, data, serializer=None):
-        super().__call__(data, serializer)
+        instance = self.get_instance(serializer)
 
         parent = data.get('parent')
         if parent is None:
             # workaround for import
             parent_id = data.get('parent_id')
             if parent_id:
-                parent = Attribute.objects.get(id=data.get('parent_id'))
+                parent = Attribute.objects.filter(id=parent_id).first()
+                if parent is None:
+                    self.raise_validation_error({'parent': [_('The parent does not exist.')]}, serializer)
 
         if parent:
-            if self.serializer:
+            if serializer is not None:
                 # check copied attributes
-                view = self.serializer.context.get('view')
-                if view and view.action == 'copy':
+                view = serializer.context.get('view')
+                if view and getattr(view, 'action', None) == 'copy':
                     # get the original from the view when cloning an attribute
                     if parent in view.get_object().get_descendants(include_self=True):
                         self.raise_validation_error({
                             'parent': [
                                 _('An attribute may not be cloned to be a child of itself or one of its descendants.')
                             ]
-                        })
+                        }, serializer)
 
             # only check updated attributes
-            if self.instance:
-                if parent in self.instance.get_descendants(include_self=True):
+            if instance is not None and instance.pk:
+                if parent in instance.get_descendants(include_self=True):
                     self.raise_validation_error({
                         'parent': [
                             _('An attribute may not be moved to be a child of itself or one of its descendants.')
                         ]
-                    })
+                    }, serializer)
 
 
 class AttributeLockedValidator(LockedValidator):

--- a/rdmo/management/assets/js/actions/elementActions.js
+++ b/rdmo/management/assets/js/actions/elementActions.js
@@ -379,9 +379,8 @@ export function fetchElementError(error) {
 
 // store element
 
-export function storeElement(elementType, element, elementAction = null, back = false) {
+export function storeElement(elementType, element, back = false) {
   const pendingId = `storeElement/${elementType}` + (isNil(element.id) ? '' : `/${element.id}`)
-                                                  + (isNil(elementAction) ? '' : `/${elementAction}`)
 
   return function(dispatch, getState) {
 
@@ -391,7 +390,7 @@ export function storeElement(elementType, element, elementAction = null, back = 
     let action
     switch (elementType) {
       case 'catalogs':
-        action = () => QuestionsApi.storeCatalog(element, elementAction)
+        action = () => QuestionsApi.storeCatalog(element)
         break
 
       case 'sections':
@@ -427,11 +426,11 @@ export function storeElement(elementType, element, elementAction = null, back = 
         break
 
       case 'tasks':
-        action = () => TasksApi.storeTask(element, elementAction)
+        action = () => TasksApi.storeTask(element)
         break
 
       case 'views':
-        action = () => ViewsApi.storeView(element, elementAction)
+        action = () => ViewsApi.storeView(element)
         break
     }
 
@@ -463,9 +462,8 @@ export function storeElementError(element, error) {
 
 // patch element
 
-export function patchElement(elementType, element, elementAction = null) {
+export function patchElement(elementType, element) {
   const pendingId = `patchElement/${elementType}/${element.id}`
-                                                  + (isNil(elementAction) ? '' : `/${elementAction}`)
 
   return function(dispatch) {
     dispatch(addToPending(pendingId))
@@ -474,7 +472,7 @@ export function patchElement(elementType, element, elementAction = null) {
     let action
     switch (elementType) {
       case 'catalogs':
-        action = () => QuestionsApi.patchCatalog(element, elementAction)
+        action = () => QuestionsApi.patchCatalog(element)
         break
 
       case 'sections':
@@ -510,11 +508,11 @@ export function patchElement(elementType, element, elementAction = null) {
         break
 
       case 'tasks':
-        action = () => TasksApi.patchTask(element, elementAction)
+        action = () => TasksApi.patchTask(element)
         break
 
       case 'views':
-        action = () => ViewsApi.patchView(element, elementAction)
+        action = () => ViewsApi.patchView(element)
         break
     }
 
@@ -535,6 +533,49 @@ export function patchElementSuccess(element) {
 
 export function patchElementError(element, error) {
   return {type: 'elements/patchElementError', element, error}
+}
+
+// toggle element site
+
+export function toggleElementSite(elementType, element) {
+  const pendingId = `toggleElementSite/${elementType}/${element.id}`
+
+  return function(dispatch) {
+    dispatch(addToPending(pendingId))
+    dispatch(toggleElementSiteInit(element))
+
+    let action
+    switch (elementType) {
+      case 'catalogs':
+        action = () => QuestionsApi.toggleCatalogSite(element)
+        break
+
+      case 'tasks':
+        action = () => TasksApi.toggleTaskSite(element)
+        break
+
+      case 'views':
+        action = () => ViewsApi.toggleViewSite(element)
+        break
+    }
+
+    return dispatch(action)
+      .then(element => dispatch(toggleElementSiteSuccess(element)))
+      .catch(error => dispatch(toggleElementSiteError(element, error)))
+      .finally(() => dispatch(removeFromPending(pendingId)))
+  }
+}
+
+export function toggleElementSiteInit(element) {
+  return {type: 'elements/toggleElementSiteInit', element}
+}
+
+export function toggleElementSiteSuccess(element) {
+  return {type: 'elements/toggleElementSiteSuccess', element}
+}
+
+export function toggleElementSiteError(element, error) {
+  return {type: 'elements/toggleElementSiteError', element, error}
 }
 
 // createElement

--- a/rdmo/management/assets/js/actions/elementActions.js
+++ b/rdmo/management/assets/js/actions/elementActions.js
@@ -1,4 +1,4 @@
-import { get, isNil } from 'lodash'
+import { get, isNil, pick } from 'lodash'
 
 import { addToPending, removeFromPending } from 'rdmo/core/assets/js/actions/pendingActions'
 import { updateConfig } from 'rdmo/core/assets/js/actions/configActions'
@@ -109,7 +109,7 @@ export function fetchElementsError(error) {
 
 // fetch element
 
-export function fetchElement(elementType, elementId, elementAction=null) {
+export function fetchElement(elementType, elementId, elementAction = null) {
   const pendingId = `fetchElement/${elementType}/${elementId}` + (isNil(elementAction) ? '' : `/${elementAction}`)
 
   return function(dispatch, getState) {
@@ -461,6 +461,81 @@ export function storeElementError(element, error) {
   return {type: 'elements/storeElementError', element, error}
 }
 
+// patch element
+
+export function patchElement(elementType, element) {
+  const pendingId = `patchElement/${elementType}/${element.id}`
+
+  return function(dispatch) {
+    dispatch(addToPending(pendingId))
+    dispatch(patchElementInit(element))
+
+    let action
+    switch (elementType) {
+      case 'catalogs':
+        action = () => QuestionsApi.patchCatalog(element)
+        break
+
+      case 'sections':
+        action = () => QuestionsApi.patchSection(element)
+        break
+
+      case 'pages':
+        action = () => QuestionsApi.patchPage(element)
+        break
+
+      case 'questionsets':
+        action = () => QuestionsApi.patchQuestionSet(element)
+        break
+
+      case 'questions':
+        action = () => QuestionsApi.patchQuestion(element)
+        break
+
+      case 'attributes':
+        action = () => DomainApi.patchAttribute(element)
+        break
+
+      case 'optionsets':
+        action = () => OptionsApi.patchOptionSet(element)
+        break
+
+      case 'options':
+        action = () => OptionsApi.patchOption(element)
+        break
+
+      case 'conditions':
+        action = () => ConditionsApi.patchCondition(element)
+        break
+
+      case 'tasks':
+        action = () => TasksApi.patchTask(element)
+        break
+
+      case 'views':
+        action = () => ViewsApi.patchView(element)
+        break
+    }
+
+    return dispatch(action)
+      .then(element => dispatch(patchElementSuccess(element)))
+      .catch(error => dispatch(patchElementError(element, error)))
+      .finally(() => dispatch(removeFromPending(pendingId)))
+  }
+}
+
+export function patchElementInit(element) {
+  return {type: 'elements/patchElementInit', element}
+}
+
+export function patchElementSuccess(element) {
+  return {type: 'elements/patchElementSuccess', element}
+}
+
+export function patchElementError(element, error) {
+  return {type: 'elements/patchElementError', element, error}
+}
+
 // createElement
 
 export function createElement(elementType, parent={}) {
@@ -701,12 +776,27 @@ export function dropElement(dragElement, dropElement, mode) {
     // an element cannot be dropped on itself or on one of its descendants
     if (canMoveElement(dragElement, dropElement)) {
       const element = {...getState().elements.element}
+
+      // dragParent is the element where the element is dragged from and dropParent where it has been dropped on
+      // dropParent is empty when the element is dragged onto the same parent, i.e. dragParent == dropParent
       const { dragParent, dropParent } = moveElement(element, dragElement, dropElement, mode)
 
-    dispatch(storeElement(elementTypes[dragParent.model], dragParent))
-    if (!isNil(dropParent)) {
-      dispatch(storeElement(elementTypes[dropParent.model], dropParent))
-      }
+      const payloads = [dragParent, dropParent].filter(parent => !isNil(parent)).map(parent => {
+        const elementType = elementTypes[parent.model]
+        switch(elementType) {
+          case 'catalogs':
+            return [elementType, pick(parent, ['id', 'uri_prefix', 'uri_path', 'sections'])]
+          case 'sections':
+            return [elementType, pick(parent, ['id', 'uri_prefix', 'uri_path', 'pages'])]
+          case 'pages':
+          case 'questionsets':
+            return [elementType, pick(parent, ['id', 'uri_prefix', 'uri_path', 'questionsets', 'questions'])]
+        }
+      })
+
+      payloads.forEach(([elementType, payload]) => {
+        dispatch(patchElement(elementType, payload))
+      })
     }
   }
 }

--- a/rdmo/management/assets/js/actions/elementActions.js
+++ b/rdmo/management/assets/js/actions/elementActions.js
@@ -463,8 +463,9 @@ export function storeElementError(element, error) {
 
 // patch element
 
-export function patchElement(elementType, element) {
+export function patchElement(elementType, element, elementAction = null) {
   const pendingId = `patchElement/${elementType}/${element.id}`
+                                                  + (isNil(elementAction) ? '' : `/${elementAction}`)
 
   return function(dispatch) {
     dispatch(addToPending(pendingId))
@@ -473,7 +474,7 @@ export function patchElement(elementType, element) {
     let action
     switch (elementType) {
       case 'catalogs':
-        action = () => QuestionsApi.patchCatalog(element)
+        action = () => QuestionsApi.patchCatalog(element, elementAction)
         break
 
       case 'sections':
@@ -509,11 +510,11 @@ export function patchElement(elementType, element) {
         break
 
       case 'tasks':
-        action = () => TasksApi.patchTask(element)
+        action = () => TasksApi.patchTask(element, elementAction)
         break
 
       case 'views':
-        action = () => ViewsApi.patchView(element)
+        action = () => ViewsApi.patchView(element, elementAction)
         break
     }
 

--- a/rdmo/management/assets/js/api/ConditionsApi.js
+++ b/rdmo/management/assets/js/api/ConditionsApi.js
@@ -22,8 +22,12 @@ class ConditionsApi extends BaseApi {
     }
   }
 
-  static deleteCondition(question) {
-    return this.delete(`/api/v1/conditions/conditions/${question.id}/`)
+  static patchCondition(condition) {
+    return this.patch(`/api/v1/conditions/conditions/${condition.id}/`, condition)
+  }
+
+  static deleteCondition(condition) {
+    return this.delete(`/api/v1/conditions/conditions/${condition.id}/`)
   }
 
   static fetchRelations() {

--- a/rdmo/management/assets/js/api/DomainApi.js
+++ b/rdmo/management/assets/js/api/DomainApi.js
@@ -25,6 +25,10 @@ class DomainApi extends BaseApi {
     }
   }
 
+  static patchAttribute(attribute) {
+    return this.patch(`/api/v1/domain/attributes/${attribute.id}/`, attribute)
+  }
+
   static deleteAttribute(attribute) {
     return this.delete(`/api/v1/domain/attributes/${attribute.id}/`)
   }

--- a/rdmo/management/assets/js/api/OptionsApi.js
+++ b/rdmo/management/assets/js/api/OptionsApi.js
@@ -25,6 +25,10 @@ class OptionsApi extends BaseApi {
     }
   }
 
+  static patchOptionSet(optionset) {
+    return this.patch(`/api/v1/options/optionsets/${optionset.id}/`, optionset)
+  }
+
   static deleteOptionSet(optionset) {
     return this.delete(`/api/v1/options/optionsets/${optionset.id}/`)
   }
@@ -45,6 +49,10 @@ class OptionsApi extends BaseApi {
     } else {
       return this.put(`/api/v1/options/options/${option.id}/`, option)
     }
+  }
+
+  static patchOption(option) {
+    return this.patch(`/api/v1/options/options/${option.id}/`, option)
   }
 
   static deleteOption(option) {

--- a/rdmo/management/assets/js/api/QuestionsApi.js
+++ b/rdmo/management/assets/js/api/QuestionsApi.js
@@ -26,8 +26,9 @@ class QuestionsApi extends BaseApi {
     }
   }
 
-  static patchCatalog(catalog) {
-    return this.patch(`/api/v1/questions/catalogs/${catalog.id}/`, catalog)
+  static patchCatalog(catalog, action) {
+    const actionPath = isNil(action) ? '' : `${action}/`
+    return this.patch(`/api/v1/questions/catalogs/${catalog.id}/${actionPath}`, catalog)
   }
 
   static deleteCatalog(catalog) {

--- a/rdmo/management/assets/js/api/QuestionsApi.js
+++ b/rdmo/management/assets/js/api/QuestionsApi.js
@@ -17,18 +17,20 @@ class QuestionsApi extends BaseApi {
     return this.get(url)
   }
 
-  static storeCatalog(catalog, action) {
+  static storeCatalog(catalog) {
     if (isNil(catalog.id)) {
       return this.post('/api/v1/questions/catalogs/', catalog)
     } else {
-      const actionPath = isNil(action) ? '' : `${action}/`
-      return this.put(`/api/v1/questions/catalogs/${catalog.id}/${actionPath}`, catalog)
+      return this.put(`/api/v1/questions/catalogs/${catalog.id}/`, catalog)
     }
   }
 
-  static patchCatalog(catalog, action) {
-    const actionPath = isNil(action) ? '' : `${action}/`
-    return this.patch(`/api/v1/questions/catalogs/${catalog.id}/${actionPath}`, catalog)
+  static patchCatalog(catalog) {
+    return this.patch(`/api/v1/questions/catalogs/${catalog.id}/`, catalog)
+  }
+
+  static toggleCatalogSite(catalog) {
+    return this.post(`/api/v1/questions/catalogs/${catalog.id}/toggle-site/`, {})
   }
 
   static deleteCatalog(catalog) {

--- a/rdmo/management/assets/js/api/QuestionsApi.js
+++ b/rdmo/management/assets/js/api/QuestionsApi.js
@@ -26,6 +26,10 @@ class QuestionsApi extends BaseApi {
     }
   }
 
+  static patchCatalog(catalog) {
+    return this.patch(`/api/v1/questions/catalogs/${catalog.id}/`, catalog)
+  }
+
   static deleteCatalog(catalog) {
     return this.delete(`/api/v1/questions/catalogs/${catalog.id}/`)
   }
@@ -49,6 +53,10 @@ class QuestionsApi extends BaseApi {
     } else {
       return this.put(`/api/v1/questions/sections/${section.id}/`, section)
     }
+  }
+
+  static patchSection(section) {
+    return this.patch(`/api/v1/questions/sections/${section.id}/`, section)
   }
 
   static deleteSection(section) {
@@ -76,6 +84,10 @@ class QuestionsApi extends BaseApi {
     }
   }
 
+  static patchPage(page) {
+    return this.patch(`/api/v1/questions/pages/${page.id}/`, page)
+  }
+
   static deletePage(page) {
     return this.delete(`/api/v1/questions/pages/${page.id}/`)
   }
@@ -101,6 +113,10 @@ class QuestionsApi extends BaseApi {
     }
   }
 
+  static patchQuestionSet(questionset) {
+    return this.patch(`/api/v1/questions/questionsets/${questionset.id}/`, questionset)
+  }
+
   static deleteQuestionSet(questionset) {
     return this.delete(`/api/v1/questions/questionsets/${questionset.id}/`)
   }
@@ -121,6 +137,10 @@ class QuestionsApi extends BaseApi {
     } else {
       return this.put(`/api/v1/questions/questions/${question.id}/`, question)
     }
+  }
+
+  static patchQuestion(question) {
+    return this.patch(`/api/v1/questions/questions/${question.id}/`, question)
   }
 
   static deleteQuestion(question) {

--- a/rdmo/management/assets/js/api/TasksApi.js
+++ b/rdmo/management/assets/js/api/TasksApi.js
@@ -26,8 +26,8 @@ class TasksApi extends BaseApi {
     return this.patch(`/api/v1/tasks/tasks/${task.id}/`, task)
   }
 
-  static toggleTaskSite(catalog) {
-    return this.post(`/api/v1/tasks/tasks/${catalog.id}/toggle-site/`, {})
+  static toggleTaskSite(task) {
+    return this.post(`/api/v1/tasks/tasks/${task.id}/toggle-site/`, {})
   }
 
   static deleteTask(task) {

--- a/rdmo/management/assets/js/api/TasksApi.js
+++ b/rdmo/management/assets/js/api/TasksApi.js
@@ -23,6 +23,10 @@ class TasksApi extends BaseApi {
     }
   }
 
+  static patchTask(task) {
+    return this.patch(`/api/v1/tasks/tasks/${task.id}/`, task)
+  }
+
   static deleteTask(task) {
     return this.delete(`/api/v1/tasks/tasks/${task.id}/`)
   }

--- a/rdmo/management/assets/js/api/TasksApi.js
+++ b/rdmo/management/assets/js/api/TasksApi.js
@@ -14,18 +14,20 @@ class TasksApi extends BaseApi {
     return this.get(`/api/v1/tasks/tasks/${id}/`)
   }
 
-  static storeTask(task, action) {
+  static storeTask(task) {
     if (isNil(task.id)) {
       return this.post('/api/v1/tasks/tasks/', task)
     } else {
-      const actionPath = isNil(action) ? '' : `${action}/`
-      return this.put(`/api/v1/tasks/tasks/${task.id}/${actionPath}`, task)
+      return this.put(`/api/v1/tasks/tasks/${task.id}/`, task)
     }
   }
 
-  static patchTask(task, action) {
-    const actionPath = isNil(action) ? '' : `${action}/`
-    return this.patch(`/api/v1/tasks/tasks/${task.id}/${actionPath}`, task)
+  static patchTask(task) {
+    return this.patch(`/api/v1/tasks/tasks/${task.id}/`, task)
+  }
+
+  static toggleTaskSite(catalog) {
+    return this.post(`/api/v1/tasks/tasks/${catalog.id}/toggle-site/`, {})
   }
 
   static deleteTask(task) {

--- a/rdmo/management/assets/js/api/TasksApi.js
+++ b/rdmo/management/assets/js/api/TasksApi.js
@@ -23,8 +23,9 @@ class TasksApi extends BaseApi {
     }
   }
 
-  static patchTask(task) {
-    return this.patch(`/api/v1/tasks/tasks/${task.id}/`, task)
+  static patchTask(task, action) {
+    const actionPath = isNil(action) ? '' : `${action}/`
+    return this.patch(`/api/v1/tasks/tasks/${task.id}/${actionPath}`, task)
   }
 
   static deleteTask(task) {

--- a/rdmo/management/assets/js/api/ViewsApi.js
+++ b/rdmo/management/assets/js/api/ViewsApi.js
@@ -14,18 +14,20 @@ class ViewsApi extends BaseApi {
     return this.get(`/api/v1/views/views/${id}/`)
   }
 
-  static storeView(view, action) {
+  static storeView(view) {
     if (isNil(view.id)) {
       return this.post('/api/v1/views/views/', view)
     } else {
-      const actionPath = isNil(action) ? '' : `${action}/`
-      return this.put(`/api/v1/views/views/${view.id}/${actionPath}`, view)
+      return this.put(`/api/v1/views/views/${view.id}/`, view)
     }
   }
 
-  static patchView(view, action) {
-    const actionPath = isNil(action) ? '' : `${action}/`
-    return this.patch(`/api/v1/views/views/${view.id}/${actionPath}`, view)
+  static patchView(view) {
+    return this.patch(`/api/v1/views/views/${view.id}/`, view)
+  }
+
+  static toggleViewSite(view) {
+    return this.post(`/api/v1/views/views/${view.id}/toggle-site/`, {})
   }
 
   static deleteView(view) {

--- a/rdmo/management/assets/js/api/ViewsApi.js
+++ b/rdmo/management/assets/js/api/ViewsApi.js
@@ -23,8 +23,9 @@ class ViewsApi extends BaseApi {
     }
   }
 
-  static patchView(view) {
-    return this.patch(`/api/v1/views/views/${view.id}/`, view)
+  static patchView(view, action) {
+    const actionPath = isNil(action) ? '' : `${action}/`
+    return this.patch(`/api/v1/views/views/${view.id}/${actionPath}`, view)
   }
 
   static deleteView(view) {

--- a/rdmo/management/assets/js/api/ViewsApi.js
+++ b/rdmo/management/assets/js/api/ViewsApi.js
@@ -23,6 +23,10 @@ class ViewsApi extends BaseApi {
     }
   }
 
+  static patchView(view) {
+    return this.patch(`/api/v1/views/views/${view.id}/`, view)
+  }
+
   static deleteView(view) {
     return this.delete(`/api/v1/views/views/${view.id}/`)
   }

--- a/rdmo/management/assets/js/components/common/DragAndDrop.js
+++ b/rdmo/management/assets/js/components/common/DragAndDrop.js
@@ -65,7 +65,11 @@ const Drop = ({ element, elementActions, indent=0, mode='in', children=null }) =
   if (mode == 'in') {
     return <div className={dropClassName} ref={dropRef}>{children}</div>
   } else {
-    return <div className={dropClassName} ref={dropRef} style={{ marginLeft: 30 * indent }}></div>
+    const style = {
+      zIndex: indent,
+      marginLeft: 30 * indent
+    }
+    return <div className={dropClassName} ref={dropRef} style={style}></div>
   }
 }
 

--- a/rdmo/management/assets/js/components/edit/EditAttribute.js
+++ b/rdmo/management/assets/js/components/edit/EditAttribute.js
@@ -23,7 +23,7 @@ const EditAttribute = ({ config, attribute, elements, elementActions }) => {
 
   const editAttribute = (attribute) => elementActions.fetchElement('attributes', attribute)
   const updateAttribute = (key, value) => elementActions.updateElement(attribute, {[key]: value})
-  const storeAttribute = (back) => elementActions.storeElement('attributes', attribute, elementAction, back)
+  const storeAttribute = (back) => elementActions.storeElement('attributes', attribute, back)
   const deleteAttribute = () => elementActions.deleteElement('attributes', attribute)
 
   const [showDeleteModal, openDeleteModal, closeDeleteModal] = useDeleteModal()

--- a/rdmo/management/assets/js/components/edit/EditCatalog.js
+++ b/rdmo/management/assets/js/components/edit/EditCatalog.js
@@ -25,7 +25,7 @@ const EditCatalog = ({ config, catalog, elements, elementActions }) => {
   const { elementAction, sections } = elements
 
   const updateCatalog = (key, value) => elementActions.updateElement(catalog, {[key]: value})
-  const storeCatalog = (back) => elementActions.storeElement('catalogs', catalog, elementAction, back)
+  const storeCatalog = (back) => elementActions.storeElement('catalogs', catalog, back)
   const deleteCatalog = () => elementActions.deleteElement('catalogs', catalog)
 
   const editSection = (value) => elementActions.fetchElement('sections', value.section)

--- a/rdmo/management/assets/js/components/edit/EditCondition.js
+++ b/rdmo/management/assets/js/components/edit/EditCondition.js
@@ -22,7 +22,7 @@ const EditCondition = ({ config, condition, elements, elementActions }) => {
   const { elementAction, parent, attributes, options } = elements
 
   const updateCondition = (key, value) => elementActions.updateElement(condition, {[key]: value})
-  const storeCondition = (back) => elementActions.storeElement('conditions', condition, elementAction, back)
+  const storeCondition = (back) => elementActions.storeElement('conditions', condition, back)
   const deleteCondition = () => elementActions.deleteElement('conditions', condition)
 
   const editAttribute = (attribute) => elementActions.fetchElement('attributes', attribute)

--- a/rdmo/management/assets/js/components/edit/EditOption.js
+++ b/rdmo/management/assets/js/components/edit/EditOption.js
@@ -24,7 +24,7 @@ const EditOption = ({ config, option, elements, elementActions }) => {
   const { elementAction, parent } = elements
 
   const updateOption = (key, value) => elementActions.updateElement(option, {[key]: value})
-  const storeOption = (back) => elementActions.storeElement('options', option, elementAction, back)
+  const storeOption = (back) => elementActions.storeElement('options', option, back)
   const deleteOption = () => elementActions.deleteElement('options', option)
 
   const [showDeleteModal, openDeleteModal, closeDeleteModal] = useDeleteModal()

--- a/rdmo/management/assets/js/components/edit/EditOptionSet.js
+++ b/rdmo/management/assets/js/components/edit/EditOptionSet.js
@@ -25,7 +25,7 @@ const EditOptionSet = ({ config, optionset, elements, elementActions }) => {
   const { elementAction, parent, conditions, options } = elements
 
   const updateOptionSet = (key, value) => elementActions.updateElement(optionset, {[key]: value})
-  const storeOptionSet = (back) => elementActions.storeElement('optionsets', optionset, elementAction, back)
+  const storeOptionSet = (back) => elementActions.storeElement('optionsets', optionset, back)
   const deleteOptionSet = () => elementActions.deleteElement('optionsets', optionset)
 
   const editOption = (value) => elementActions.fetchElement('options', value.option)

--- a/rdmo/management/assets/js/components/edit/EditPage.js
+++ b/rdmo/management/assets/js/components/edit/EditPage.js
@@ -45,7 +45,7 @@ const EditPage = ({ config, page, elements, elementActions }) => {
       elementActions.updateElement(page, { [key]: value })
     }
   }
-  const storePage = (back) => elementActions.storeElement('pages', page, elementAction, back)
+  const storePage = (back) => elementActions.storeElement('pages', page, back)
   const deletePage = () => elementActions.deleteElement('pages', page)
 
   const editElement = (value) => {

--- a/rdmo/management/assets/js/components/edit/EditQuestion.js
+++ b/rdmo/management/assets/js/components/edit/EditQuestion.js
@@ -24,7 +24,7 @@ const EditQuestion = ({ config, question, elements, elementActions}) => {
   const { elementAction, parent, attributes, optionsets, options, conditions } = elements
 
   const updateQuestion = (key, value) => elementActions.updateElement(question, {[key]: value})
-  const storeQuestion = (back) => elementActions.storeElement('questions', question, elementAction, back)
+  const storeQuestion = (back) => elementActions.storeElement('questions', question, back)
   const deleteQuestion = () => elementActions.deleteElement('questions', question)
 
   const editOptionSet = (optionset) => elementActions.fetchElement('optionsets', optionset)

--- a/rdmo/management/assets/js/components/edit/EditQuestionSet.js
+++ b/rdmo/management/assets/js/components/edit/EditQuestionSet.js
@@ -45,7 +45,7 @@ const EditQuestionSet = ({ config, questionset, elements, elementActions }) => {
       elementActions.updateElement(questionset, { [key]: value })
     }
   }
-  const storeQuestionSet = (back) => elementActions.storeElement('questionsets', questionset, elementAction, back)
+  const storeQuestionSet = (back) => elementActions.storeElement('questionsets', questionset, back)
   const deleteQuestionSet = () => elementActions.deleteElement('questionsets', questionset)
 
   const editElement = (value) => {

--- a/rdmo/management/assets/js/components/edit/EditSection.js
+++ b/rdmo/management/assets/js/components/edit/EditSection.js
@@ -24,7 +24,7 @@ const EditSection = ({ config, section, elements, elementActions }) => {
   const { elementAction, parent, pages } = elements
 
   const updateSection = (key, value) => elementActions.updateElement(section, {[key]: value})
-  const storeSection = (back) => elementActions.storeElement('sections', section, elementAction, back)
+  const storeSection = (back) => elementActions.storeElement('sections', section, back)
   const deleteSection = () => elementActions.deleteElement('sections', section)
 
   const editPage = (value) => elementActions.fetchElement('pages', value.page)

--- a/rdmo/management/assets/js/components/edit/EditTask.js
+++ b/rdmo/management/assets/js/components/edit/EditTask.js
@@ -25,7 +25,7 @@ const EditTask = ({ config, task, elements, elementActions}) => {
   const { elementAction, attributes, catalogs, conditions } = elements
 
   const updateTask = (key, value) => elementActions.updateElement(task, {[key]: value})
-  const storeTask = (back) => elementActions.storeElement('tasks', task, elementAction, back)
+  const storeTask = (back) => elementActions.storeElement('tasks', task, back)
   const deleteTask = () => elementActions.deleteElement('tasks', task)
 
   const editCondition = (condition) => elementActions.fetchElement('conditions', condition)

--- a/rdmo/management/assets/js/components/edit/EditView.js
+++ b/rdmo/management/assets/js/components/edit/EditView.js
@@ -25,7 +25,7 @@ const EditView = ({ config, view, elements, elementActions }) => {
   const { elementAction, catalogs } = elements
 
   const updateView = (key, value) => elementActions.updateElement(view, {[key]: value})
-  const storeView = (back) => elementActions.storeElement('views', view, elementAction, back)
+  const storeView = (back) => elementActions.storeElement('views', view, back)
   const deleteView = () => elementActions.deleteElement('views', view)
 
   const [showDeleteModal, openDeleteModal, closeDeleteModal] = useDeleteModal()

--- a/rdmo/management/assets/js/components/element/Attribute.js
+++ b/rdmo/management/assets/js/components/element/Attribute.js
@@ -21,7 +21,7 @@ const Attribute = ({ config, attribute, elementActions, display='list', indent=0
   const fetchEdit = () => elementActions.fetchElement('attributes', attribute.id)
   const fetchCopy = () => elementActions.fetchElement('attributes', attribute.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('attributes', attribute.id, 'nested')
-  const toggleLocked = () => elementActions.storeElement('attributes', {...attribute, locked: !attribute.locked })
+  const toggleLocked = () => elementActions.patchElement('attributes', { id: attribute.id, locked: !attribute.locked })
 
   const createAttribute = () => elementActions.createElement('attributes', { attribute })
 

--- a/rdmo/management/assets/js/components/element/Catalog.js
+++ b/rdmo/management/assets/js/components/element/Catalog.js
@@ -26,8 +26,8 @@ const Catalog = ({ config, catalog, elementActions, display='list',
   const fetchCopy = () => elementActions.fetchElement('catalogs', catalog.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('catalogs', catalog.id, 'nested')
 
-  const toggleAvailable = () => elementActions.storeElement('catalogs', {...catalog, available: !catalog.available })
-  const toggleLocked = () => elementActions.storeElement('catalogs', {...catalog, locked: !catalog.locked })
+  const toggleAvailable = () => elementActions.patchElement('catalogs', { id: catalog.id, available: !catalog.available })
+  const toggleLocked = () => elementActions.patchElement('catalogs', { id: catalog.id, locked: !catalog.locked })
 
   const toggleCurrentSite = () => elementActions.storeElement('catalogs', catalog, 'toggle-site')
 

--- a/rdmo/management/assets/js/components/element/Catalog.js
+++ b/rdmo/management/assets/js/components/element/Catalog.js
@@ -29,7 +29,7 @@ const Catalog = ({ config, catalog, elementActions, display='list',
   const toggleAvailable = () => elementActions.patchElement('catalogs', { id: catalog.id, available: !catalog.available })
   const toggleLocked = () => elementActions.patchElement('catalogs', { id: catalog.id, locked: !catalog.locked })
 
-  const toggleCurrentSite = () => elementActions.patchElement('catalogs', catalog, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.toggleElementSite('catalogs', catalog)
 
   const createSection = () => elementActions.createElement('sections', { catalog })
 

--- a/rdmo/management/assets/js/components/element/Catalog.js
+++ b/rdmo/management/assets/js/components/element/Catalog.js
@@ -29,7 +29,7 @@ const Catalog = ({ config, catalog, elementActions, display='list',
   const toggleAvailable = () => elementActions.patchElement('catalogs', { id: catalog.id, available: !catalog.available })
   const toggleLocked = () => elementActions.patchElement('catalogs', { id: catalog.id, locked: !catalog.locked })
 
-  const toggleCurrentSite = () => elementActions.storeElement('catalogs', catalog, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.patchElement('catalogs', catalog, 'toggle-site')
 
   const createSection = () => elementActions.createElement('sections', { catalog })
 

--- a/rdmo/management/assets/js/components/element/Condition.js
+++ b/rdmo/management/assets/js/components/element/Condition.js
@@ -18,7 +18,7 @@ const Condition = ({ config, condition, elementActions, filter=false, filterEdit
 
   const fetchEdit = () => elementActions.fetchElement('conditions', condition.id)
   const fetchCopy = () => elementActions.fetchElement('conditions', condition.id, 'copy')
-  const toggleLocked = () => elementActions.storeElement('conditions', {...condition, locked: !condition.locked })
+  const toggleLocked = () => elementActions.patchElement('conditions', { id: condition.id, locked: !condition.locked })
 
   return showElement && (
     <li className="list-group-item">

--- a/rdmo/management/assets/js/components/element/Option.js
+++ b/rdmo/management/assets/js/components/element/Option.js
@@ -19,7 +19,7 @@ const Option = ({ config, option, elementActions, display='list', indent=0, filt
 
   const fetchEdit = () => elementActions.fetchElement('options', option.id)
   const fetchCopy = () => elementActions.fetchElement('options', option.id, 'copy')
-  const toggleLocked = () => elementActions.storeElement('options', {...option, locked: !option.locked })
+  const toggleLocked = () => elementActions.patchElement('options', { id: option.id, locked: !option.locked })
 
   const elementNode = (
     <div className="element">

--- a/rdmo/management/assets/js/components/element/OptionSet.js
+++ b/rdmo/management/assets/js/components/element/OptionSet.js
@@ -24,7 +24,7 @@ const OptionSet = ({ config, optionset, elementActions, display='list', filter=f
   const fetchEdit = () => elementActions.fetchElement('optionsets', optionset.id)
   const fetchCopy = () => elementActions.fetchElement('optionsets', optionset.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('optionsets', optionset.id, 'nested')
-  const toggleLocked = () => elementActions.storeElement('optionsets', {...optionset, locked: !optionset.locked })
+  const toggleLocked = () => elementActions.patchElement('optionsets', { id: optionset.id, locked: !optionset.locked })
 
   const createOption = () => elementActions.createElement('options', { optionset })
   const fetchCondition = (index) => elementActions.fetchElement('conditions', optionset.conditions[index])

--- a/rdmo/management/assets/js/components/element/Page.js
+++ b/rdmo/management/assets/js/components/element/Page.js
@@ -30,7 +30,7 @@ const Page = ({ config, page, configActions, elementActions, display='list', ind
   const fetchEdit = () => elementActions.fetchElement('pages', page.id)
   const fetchCopy = () => elementActions.fetchElement('pages', page.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('pages', page.id, 'nested')
-  const toggleLocked = () => elementActions.storeElement('pages', {...page, locked: !page.locked })
+  const toggleLocked = () => elementActions.patchElement('pages', { id: page.id, locked: !page.locked })
   const toggleElements = () => elementActions.toggleElements(page)
 
   const createQuestionSet = () => elementActions.createElement('questionsets', { page })

--- a/rdmo/management/assets/js/components/element/Page.js
+++ b/rdmo/management/assets/js/components/element/Page.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import get from 'lodash/get'
+import { get, isEmpty } from 'lodash'
 
 import { filterElement } from '../../utils/filter'
 import { buildApiPath, buildPath } from '../../utils/location'
@@ -118,6 +118,10 @@ const Page = ({ config, page, configActions, elementActions, display='list', ind
                 </div>
               </Drop>
             )
+          }
+          {
+            !isEmpty(page.elements) &&
+            <Drop element={page.elements[0]} elementActions={elementActions} indent={indent + 1} mode="before" />
           }
           {
             showElements && page.elements.map((element, index) => {

--- a/rdmo/management/assets/js/components/element/Question.js
+++ b/rdmo/management/assets/js/components/element/Question.js
@@ -25,7 +25,7 @@ const Question = ({ config, question, elementActions, display='list', indent=0,
 
   const fetchEdit = () => elementActions.fetchElement('questions', question.id)
   const fetchCopy = () => elementActions.fetchElement('questions', question.id, 'copy')
-  const toggleLocked = () => elementActions.storeElement('questions', {...question, locked: !question.locked })
+  const toggleLocked = () => elementActions.patchElement('questions', { id: question.id, locked: !question.locked })
 
   const fetchAttribute = () => elementActions.fetchElement('attributes', question.attribute)
   const fetchCondition = (index) => elementActions.fetchElement('conditions', question.conditions[index])

--- a/rdmo/management/assets/js/components/element/QuestionSet.js
+++ b/rdmo/management/assets/js/components/element/QuestionSet.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import get from 'lodash/get'
+import { get, isEmpty } from 'lodash'
 
 import { filterElement } from '../../utils/filter'
 import { buildApiPath, buildPath } from '../../utils/location'
@@ -117,6 +117,10 @@ const QuestionSet = ({ config, questionset, configActions, elementActions, displ
                 </div>
               </Drop>
             )
+          }
+          {
+            !isEmpty(questionset.elements) &&
+            <Drop element={questionset.elements[0]} elementActions={elementActions} indent={indent + 1} mode="before" />
           }
           {
             showElements && questionset.elements.map((element, index) => {

--- a/rdmo/management/assets/js/components/element/QuestionSet.js
+++ b/rdmo/management/assets/js/components/element/QuestionSet.js
@@ -29,7 +29,7 @@ const QuestionSet = ({ config, questionset, configActions, elementActions, displ
   const fetchEdit = () => elementActions.fetchElement('questionsets', questionset.id)
   const fetchCopy = () => elementActions.fetchElement('questionsets', questionset.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('questionsets', questionset.id, 'nested')
-  const toggleLocked = () => elementActions.storeElement('questionsets', {...questionset, locked: !questionset.locked })
+  const toggleLocked = () => elementActions.patchElement('questionsets', { id: questionset.id, locked: !questionset.locked })
   const toggleElements = () => elementActions.toggleElements(questionset)
 
   const createQuestionSet = () => elementActions.createElement('questionsets', { questionset })

--- a/rdmo/management/assets/js/components/element/Section.js
+++ b/rdmo/management/assets/js/components/element/Section.js
@@ -28,7 +28,7 @@ const Section = ({ config, section, configActions, elementActions, display='list
   const fetchEdit = () => elementActions.fetchElement('sections', section.id)
   const fetchCopy = () => elementActions.fetchElement('sections', section.id, 'copy')
   const fetchNested = () => elementActions.fetchElement('sections', section.id, 'nested')
-  const toggleLocked = () => elementActions.storeElement('sections', {...section, locked: !section.locked })
+  const toggleLocked = () => elementActions.patchElement('sections', { id: section.id, locked: !section.locked })
   const toggleElements = () => elementActions.toggleElements(section)
 
   const createPage = () => elementActions.createElement('pages', { section })

--- a/rdmo/management/assets/js/components/element/Task.js
+++ b/rdmo/management/assets/js/components/element/Task.js
@@ -23,9 +23,11 @@ const Task = ({ config, task, elementActions, filter=false, filterSites=false, f
 
   const fetchEdit = () => elementActions.fetchElement('tasks', task.id)
   const fetchCopy = () => elementActions.fetchElement('tasks', task.id, 'copy')
+
   const toggleAvailable = () => elementActions.patchElement('tasks', { id: task.id, available: !task.available })
   const toggleLocked = () => elementActions.patchElement('tasks', { id: task.id, locked: !task.locked })
-  const toggleCurrentSite = () => elementActions.patchElement('tasks', task, 'toggle-site')
+
+  const toggleCurrentSite = () => elementActions.toggleElementSite('tasks', task, 'toggle-site')
 
   const fetchCondition = (index) => elementActions.fetchElement('conditions', task.conditions[index])
 

--- a/rdmo/management/assets/js/components/element/Task.js
+++ b/rdmo/management/assets/js/components/element/Task.js
@@ -25,7 +25,7 @@ const Task = ({ config, task, elementActions, filter=false, filterSites=false, f
   const fetchCopy = () => elementActions.fetchElement('tasks', task.id, 'copy')
   const toggleAvailable = () => elementActions.patchElement('tasks', { id: task.id, available: !task.available })
   const toggleLocked = () => elementActions.patchElement('tasks', { id: task.id, locked: !task.locked })
-  const toggleCurrentSite = () => elementActions.storeElement('tasks', task, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.patchElement('tasks', task, 'toggle-site')
 
   const fetchCondition = (index) => elementActions.fetchElement('conditions', task.conditions[index])
 

--- a/rdmo/management/assets/js/components/element/Task.js
+++ b/rdmo/management/assets/js/components/element/Task.js
@@ -23,8 +23,8 @@ const Task = ({ config, task, elementActions, filter=false, filterSites=false, f
 
   const fetchEdit = () => elementActions.fetchElement('tasks', task.id)
   const fetchCopy = () => elementActions.fetchElement('tasks', task.id, 'copy')
-  const toggleAvailable = () => elementActions.storeElement('tasks', {...task, available: !task.available })
-  const toggleLocked = () => elementActions.storeElement('tasks', {...task, locked: !task.locked })
+  const toggleAvailable = () => elementActions.patchElement('tasks', { id: task.id, available: !task.available })
+  const toggleLocked = () => elementActions.patchElement('tasks', { id: task.id, locked: !task.locked })
   const toggleCurrentSite = () => elementActions.storeElement('tasks', task, 'toggle-site')
 
   const fetchCondition = (index) => elementActions.fetchElement('conditions', task.conditions[index])

--- a/rdmo/management/assets/js/components/element/Task.js
+++ b/rdmo/management/assets/js/components/element/Task.js
@@ -27,7 +27,7 @@ const Task = ({ config, task, elementActions, filter=false, filterSites=false, f
   const toggleAvailable = () => elementActions.patchElement('tasks', { id: task.id, available: !task.available })
   const toggleLocked = () => elementActions.patchElement('tasks', { id: task.id, locked: !task.locked })
 
-  const toggleCurrentSite = () => elementActions.toggleElementSite('tasks', task, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.toggleElementSite('tasks', task)
 
   const fetchCondition = (index) => elementActions.fetchElement('conditions', task.conditions[index])
 

--- a/rdmo/management/assets/js/components/element/View.js
+++ b/rdmo/management/assets/js/components/element/View.js
@@ -20,8 +20,8 @@ const View = ({ config, view, elementActions, filter=false, filterSites=false, f
 
   const fetchEdit = () => elementActions.fetchElement('views', view.id)
   const fetchCopy = () => elementActions.fetchElement('views', view.id, 'copy')
-  const toggleAvailable = () => elementActions.storeElement('views', {...view, available: !view.available })
-  const toggleLocked = () => elementActions.storeElement('views', {...view, locked: !view.locked })
+  const toggleAvailable = () => elementActions.patchElement('views', { id: view.id, available: !view.available })
+  const toggleLocked = () => elementActions.patchElement('views', { id: view.id, locked: !view.locked })
   const toggleCurrentSite = () => elementActions.storeElement('views', view, 'toggle-site')
 
   return showElement && (

--- a/rdmo/management/assets/js/components/element/View.js
+++ b/rdmo/management/assets/js/components/element/View.js
@@ -24,7 +24,7 @@ const View = ({ config, view, elementActions, filter=false, filterSites=false, f
   const toggleAvailable = () => elementActions.patchElement('views', { id: view.id, available: !view.available })
   const toggleLocked = () => elementActions.patchElement('views', { id: view.id, locked: !view.locked })
 
-  const toggleCurrentSite = () => elementActions.toggleElementSite('views', view, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.toggleElementSite('views', view)
 
   return showElement && (
     <li className="list-group-item">

--- a/rdmo/management/assets/js/components/element/View.js
+++ b/rdmo/management/assets/js/components/element/View.js
@@ -20,9 +20,11 @@ const View = ({ config, view, elementActions, filter=false, filterSites=false, f
 
   const fetchEdit = () => elementActions.fetchElement('views', view.id)
   const fetchCopy = () => elementActions.fetchElement('views', view.id, 'copy')
+
   const toggleAvailable = () => elementActions.patchElement('views', { id: view.id, available: !view.available })
   const toggleLocked = () => elementActions.patchElement('views', { id: view.id, locked: !view.locked })
-  const toggleCurrentSite = () => elementActions.patchElement('views', view, 'toggle-site')
+
+  const toggleCurrentSite = () => elementActions.toggleElementSite('views', view, 'toggle-site')
 
   return showElement && (
     <li className="list-group-item">

--- a/rdmo/management/assets/js/components/element/View.js
+++ b/rdmo/management/assets/js/components/element/View.js
@@ -22,7 +22,7 @@ const View = ({ config, view, elementActions, filter=false, filterSites=false, f
   const fetchCopy = () => elementActions.fetchElement('views', view.id, 'copy')
   const toggleAvailable = () => elementActions.patchElement('views', { id: view.id, available: !view.available })
   const toggleLocked = () => elementActions.patchElement('views', { id: view.id, locked: !view.locked })
-  const toggleCurrentSite = () => elementActions.storeElement('views', view, 'toggle-site')
+  const toggleCurrentSite = () => elementActions.patchElement('views', view, 'toggle-site')
 
   return showElement && (
     <li className="list-group-item">

--- a/rdmo/management/assets/js/reducers/elementsReducer.js
+++ b/rdmo/management/assets/js/reducers/elementsReducer.js
@@ -58,6 +58,7 @@ export default function elementsReducer(state = initialState, action) {
     // store/patch element
     case 'elements/storeElementInit':
     case 'elements/patchElementInit':
+    case 'elements/toggleElementSiteInit':
       if (isNil(state.element)) {
         return state
       } else {
@@ -66,6 +67,7 @@ export default function elementsReducer(state = initialState, action) {
       }
     case 'elements/storeElementError':
     case 'elements/patchElementError':
+    case 'elements/toggleElementSiteError':
       if (isNil(state.element) || state.elementAction == 'nested') {
         // create a fake element with just the id and the model and the error for updateElement works,
         // but the element won't get updated in the view
@@ -76,6 +78,7 @@ export default function elementsReducer(state = initialState, action) {
       // there is not break here on purpose
     case 'elements/storeElementSuccess':  // eslint-disable-line no-fallthrough
     case 'elements/patchElementSuccess':
+    case 'elements/toggleElementSiteSuccess':
       if (isNil(state.element)) {
         return {...state,
           [state.elementType]: state[state.elementType].map(element => updateElement(element, action.element))

--- a/rdmo/management/assets/js/reducers/elementsReducer.js
+++ b/rdmo/management/assets/js/reducers/elementsReducer.js
@@ -55,8 +55,9 @@ export default function elementsReducer(state = initialState, action) {
     case 'elements/fetchElementError':
       return {...state, errors: action.error.errors}
 
-    // store element
+    // store/patch element
     case 'elements/storeElementInit':
+    case 'elements/patchElementInit':
       if (isNil(state.element)) {
         return state
       } else {
@@ -64,6 +65,7 @@ export default function elementsReducer(state = initialState, action) {
         return {...state, element: resetElement(state.element)}
       }
     case 'elements/storeElementError':
+    case 'elements/patchElementError':
       if (isNil(state.element) || state.elementAction == 'nested') {
         // create a fake element with just the id and the model and the error for updateElement works,
         // but the element won't get updated in the view
@@ -73,6 +75,7 @@ export default function elementsReducer(state = initialState, action) {
       }
       // there is not break here on purpose
     case 'elements/storeElementSuccess':  // eslint-disable-line no-fallthrough
+    case 'elements/patchElementSuccess':
       if (isNil(state.element)) {
         return {...state,
           [state.elementType]: state[state.elementType].map(element => updateElement(element, action.element))

--- a/rdmo/management/assets/scss/management.scss
+++ b/rdmo/management/assets/scss/management.scss
@@ -20,6 +20,8 @@
 }
 
 .management {
+    position: relative;
+
     .panel {
         p {
             margin-bottom: 5px;
@@ -152,6 +154,11 @@
     }
 
     .drop {
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: 8px;
+
         display: none;
         margin-top: -10px;
         padding: 4px 0;

--- a/rdmo/management/viewsets.py
+++ b/rdmo/management/viewsets.py
@@ -86,7 +86,7 @@ class ImportViewSet(viewsets.ViewSet):
 
 class ElementToggleCurrentSiteViewSetMixin:
 
-    @action(detail=True, methods=['put'], url_path="toggle-site", permission_classes=[CanToggleElementCurrentSite])
+    @action(detail=True, methods=['patch'], url_path="toggle-site", permission_classes=[CanToggleElementCurrentSite])
     def toggle_site(self, request, pk=None):
         obj = self.get_object()
         current_site = get_current_site(request)

--- a/rdmo/management/viewsets.py
+++ b/rdmo/management/viewsets.py
@@ -86,7 +86,7 @@ class ImportViewSet(viewsets.ViewSet):
 
 class ElementToggleCurrentSiteViewSetMixin:
 
-    @action(detail=True, methods=['patch'], url_path="toggle-site", permission_classes=[CanToggleElementCurrentSite])
+    @action(detail=True, methods=['post'], url_path="toggle-site", permission_classes=[CanToggleElementCurrentSite])
     def toggle_site(self, request, pk=None):
         obj = self.get_object()
         current_site = get_current_site(request)

--- a/rdmo/projects/validators.py
+++ b/rdmo/projects/validators.py
@@ -26,13 +26,13 @@ from rdmo.core.validators import InstanceValidator
 class ProjectParentValidator(InstanceValidator):
 
     def __call__(self, data, serializer=None):
-        super().__call__(data, serializer)
+        instance = self.get_instance(serializer)
 
-        if self.instance and self.instance.id \
-                and data.get('parent') in self.instance.get_descendants(include_self=True):
-            raise self.raise_validation_error({
+        parent = data.get('parent')
+        if instance and instance.id and parent in instance.get_descendants(include_self=True):
+            self.raise_validation_error({
                 'parent': [_('A project may not be moved to be a child of itself or one of its descendants.')]
-            })
+            }, serializer)
 
 
 class ValueConflictValidator:

--- a/rdmo/questions/tests/test_viewset_catalog_multisite.py
+++ b/rdmo/questions/tests/test_viewset_catalog_multisite.py
@@ -301,19 +301,19 @@ def test_update_catalog_toggle_site(db, client, username, password, add_or_remov
         instance.locked = locked
         instance.save()
 
-        before_has_current_site = instance.sites.filter(id=current_site.id).exists()
+        before_put_has_current_site = instance.sites.filter(id=current_site.id).exists()
 
         url = reverse(urlnames['catalog-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.patch(url, {}, content_type='application/json')
+        response = client.post(url, {}, content_type='application/json')
         assert response.status_code == (
             STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username]
         ), response.json()
         instance.refresh_from_db()
-        after_has_current_site = instance.sites.filter(id=current_site.id).exists()
+        after_put_has_current_site = instance.sites.filter(id=current_site.id).exists()
         if response.status_code == 200:
             # check if instance now has the current site or not
-            assert after_has_current_site is has_current_site_check
+            assert after_put_has_current_site is has_current_site_check
         else:
             # check that the instance was not updated
-            assert after_has_current_site is before_has_current_site
+            assert after_put_has_current_site is before_put_has_current_site

--- a/rdmo/questions/tests/test_viewset_catalog_multisite.py
+++ b/rdmo/questions/tests/test_viewset_catalog_multisite.py
@@ -301,19 +301,19 @@ def test_update_catalog_toggle_site(db, client, username, password, add_or_remov
         instance.locked = locked
         instance.save()
 
-        before_put_has_current_site = instance.sites.filter(id=current_site.id).exists()
+        before_has_current_site = instance.sites.filter(id=current_site.id).exists()
 
         url = reverse(urlnames['catalog-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.put(url, {}, content_type='application/json')
+        response = client.patch(url, {}, content_type='application/json')
         assert response.status_code == (
             STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username]
         ), response.json()
         instance.refresh_from_db()
-        after_put_has_current_site = instance.sites.filter(id=current_site.id).exists()
+        after_has_current_site = instance.sites.filter(id=current_site.id).exists()
         if response.status_code == 200:
             # check if instance now has the current site or not
-            assert after_put_has_current_site is has_current_site_check
+            assert after_has_current_site is has_current_site_check
         else:
             # check that the instance was not updated
-            assert after_put_has_current_site is before_put_has_current_site
+            assert after_has_current_site is before_has_current_site

--- a/rdmo/questions/validators.py
+++ b/rdmo/questions/validators.py
@@ -38,7 +38,7 @@ class QuestionUniqueURIValidator(UniqueURIValidator):
 class QuestionSetQuestionSetValidator(InstanceValidator):
 
     def __call__(self, data, serializer=None):
-        super().__call__(data, serializer)
+        instance = self.get_instance(serializer)
 
         questionsets = data.get('questionsets') or [
             questionset_questionset.get('questionset')
@@ -47,12 +47,12 @@ class QuestionSetQuestionSetValidator(InstanceValidator):
         if not questionsets:
             return
 
-        if not self.serializer and not self.instance:
+        if not serializer and not instance:
             return
 
-        if self.serializer:
+        if serializer:
             # check copied attributes
-            view = self.serializer.context.get('view')
+            view = serializer.context.get('view')
             if view and view.action == 'copy':
                 # get the original from the view when cloning an attribute
                 obj = view.get_object()
@@ -61,19 +61,19 @@ class QuestionSetQuestionSetValidator(InstanceValidator):
                         self.raise_validation_error({
                             'questionset': [_('A question set may not be cloned to be a child of itself or one of '
                                               'its descendants.')]
-                        })
-            if not self.instance:
+                        }, serializer)
+            if not instance:
                 return
 
         # only check updated attributes
-        if not self.instance:
+        if not instance:
             return
 
         for questionset in questionsets:
-            if self.instance in [questionset, *questionset.descendants]:
+            if instance in [questionset, *questionset.descendants]:
                 self.raise_validation_error({
                     'questionsets': [_('A question set may not be a child of itself or one of its descendants.')]
-                })
+                }, serializer)
 
 
 class CatalogLockedValidator(LockedValidator):

--- a/rdmo/tasks/tests/test_viewset_task_multisite.py
+++ b/rdmo/tasks/tests/test_viewset_task_multisite.py
@@ -228,7 +228,7 @@ def test_update_task_toggle_site(db, client, username, password, add_or_remove, 
 
         url = reverse(urlnames['task-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.put(url, {}, content_type='application/json')
+        response = client.patch(url, {}, content_type='application/json')
         assert response.status_code == STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username], (  # noqa: E501
             response.json()
         )

--- a/rdmo/tasks/tests/test_viewset_task_multisite.py
+++ b/rdmo/tasks/tests/test_viewset_task_multisite.py
@@ -228,10 +228,10 @@ def test_update_task_toggle_site(db, client, username, password, add_or_remove, 
 
         url = reverse(urlnames['task-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.patch(url, {}, content_type='application/json')
-        assert response.status_code == STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username], (  # noqa: E501
-            response.json()
-        )
+        response = client.post(url, {}, content_type='application/json')
+        assert response.status_code == (
+            STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username]
+        ), response.json()
         instance.refresh_from_db()
         after_has_current_site = instance.sites.filter(id=current_site.id).exists()
         if response.status_code == 200:

--- a/rdmo/views/tests/test_viewset_view_multisite.py
+++ b/rdmo/views/tests/test_viewset_view_multisite.py
@@ -210,7 +210,7 @@ def test_update_view_toggle_site(db, client, username, password, add_or_remove, 
 
         url = reverse(urlnames['view-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.put(url, {}, content_type='application/json')
+        response = client.patch(url, {}, content_type='application/json')
         assert response.status_code == (
             STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username]
         ), response.json()

--- a/rdmo/views/tests/test_viewset_view_multisite.py
+++ b/rdmo/views/tests/test_viewset_view_multisite.py
@@ -210,7 +210,7 @@ def test_update_view_toggle_site(db, client, username, password, add_or_remove, 
 
         url = reverse(urlnames['view-toggle-site'], kwargs={'pk': instance.pk})
 
-        response = client.patch(url, {}, content_type='application/json')
+        response = client.post(url, {}, content_type='application/json')
         assert response.status_code == (
             STATUS_CODES['toggle-site'].get(instance.uri, status_map['toggle-site'])[username]
         ), response.json()


### PR DESCRIPTION
This PR aims to fix three things:

1) Resolve #1685, by using `PATCH` for the drag and drop as well as `locked`/`available` (introducing dedicated actions for `patchElement`).

2) Fixing an issue Claude pointed be to: Validators used by serializers are initialized at startup and are not copied for each request. Setting `self.instance` and `self.serializer` on the validator instances is therefore faulty. All requests write into the same attribute of the same instance. The solution is to process the `serializer` arg provided to `__call__`.

3) For `PATCH` requests, where only (small) parts of the instance is in `data`, missing values from the instance which is updated should be used for validation. This is done by using the new `get_values` method in `InstanceValidator`.