### PR TITLE
3.0.0/api/integrations

### DIFF
--- a/rdmo/core/tests/test_openapi.py
+++ b/rdmo/core/tests/test_openapi.py
@@ -14,7 +14,7 @@ users = (
     'anonymous'
 )
 
-n_path = 142
+n_path = 143
 
 @pytest.mark.parametrize('username', users)
 def test_openapi_schema(db, client, login, username):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -423,7 +423,7 @@ class ProjectIntegrationSerializer(serializers.ModelSerializer):
 
     def get_provider(self, obj):
         return {
-            getattr(obj.provider, attr, None)
+            attr: getattr(obj.provider, attr, None)
             for attr in ['send_label', 'description']
         }
 
@@ -744,7 +744,7 @@ class IntegrationSerializer(serializers.ModelSerializer):
 
     def get_provider(self, obj):
         return {
-            getattr(obj.provider, attr, None)
+            attr: getattr(obj.provider, attr, None)
             for attr in ['send_label', 'description']
         }
 

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -388,7 +388,7 @@ class ProjectIntegrationOptionSerializer(serializers.ModelSerializer):
 
 
 class ProjectIntegrationSerializer(serializers.ModelSerializer):
-
+    provider = serializers.SerializerMethodField()
     options = ProjectIntegrationOptionSerializer(many=True)
 
     class Meta:
@@ -396,6 +396,7 @@ class ProjectIntegrationSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'provider_key',
+            'provider',
             'options'
         )
         validators = [
@@ -419,6 +420,12 @@ class ProjectIntegrationSerializer(serializers.ModelSerializer):
         integration.save_options(options)
 
         return integration
+
+    def get_provider(self, obj):
+        return {
+            getattr(obj.provider, attr, None)
+            for attr in ['send_label', 'description']
+        }
 
 
 class ProjectInviteSerializer(serializers.ModelSerializer):
@@ -722,7 +729,7 @@ class MembershipSerializer(serializers.ModelSerializer):
 
 
 class IntegrationSerializer(serializers.ModelSerializer):
-
+    provider = serializers.SerializerMethodField()
     options = ProjectIntegrationOptionSerializer(many=True, read_only=True)
 
     class Meta:
@@ -731,8 +738,15 @@ class IntegrationSerializer(serializers.ModelSerializer):
             'id',
             'project',
             'provider_key',
+            'provider',
             'options'
         )
+
+    def get_provider(self, obj):
+        return {
+            getattr(obj.provider, attr, None)
+            for attr in ['send_label', 'description']
+        }
 
 
 class InviteSerializer(serializers.ModelSerializer):

--- a/rdmo/projects/tests/test_viewset_project.py
+++ b/rdmo/projects/tests/test_viewset_project.py
@@ -59,7 +59,8 @@ urlnames = {
     'options': 'v1-projects:project-options',
     'resolve': 'v1-projects:project-resolve',
     'upload_accept': 'v1-projects:project-upload-accept',
-    'imports': 'v1-projects:project-imports'
+    'imports': 'v1-projects:project-imports',
+    'providers': 'v1-projects:project-providers'
 }
 
 projects = [1, 2, 3, 4, 5, 12]
@@ -898,5 +899,21 @@ def test_imports(db, client, username, password):
         assert response.status_code == 200
         assert len(response.json()) == 1
         assert response.json()[0]['key'] == 'url'
+    else:
+        assert response.status_code == 401
+
+
+@pytest.mark.parametrize('username,password', users)
+def test_providers(db, client, username, password):
+    client.login(username=username, password=password)
+
+    url = reverse(urlnames['providers'])
+    response = client.get(url)
+
+    if password:
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()['simple']['add_label']
+        assert response.json()['simple']['description']
     else:
         assert response.status_code == 401

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -26,6 +26,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from rdmo.conditions.models import Condition
 from rdmo.core.constants import VALUE_TYPE_FILE
 from rdmo.core.permissions import HasModelPermission
+from rdmo.core.plugins import get_plugins
 from rdmo.core.utils import human2bytes, is_truthy, render_to_format, return_file_response
 from rdmo.core.views import ChoicesViewSet
 from rdmo.options.models import OptionSet
@@ -706,6 +707,15 @@ class ProjectViewSet(ModelViewSet):
             'href': reverse('project_create_import', args=[key])
         } for key, label, class_name in settings.PROJECT_IMPORTS if key in settings.PROJECT_IMPORTS_LIST] )
 
+    @action(detail=False, permission_classes=(IsAuthenticated, ))
+    def providers(self, request):
+        return Response({
+            key: {
+                'add_label': plugin.add_label,
+                'description': plugin.description,
+            }
+            for key, plugin in get_plugins('PROJECT_ISSUE_PROVIDERS').items()
+        })
 
     def create(self, request, *args, **kwargs):
         response = super().create(request, *args, **kwargs)


### PR DESCRIPTION
This PR adds an endpoint for the issue providers available to projects and the providers to the corresponding integrations. See:

```
http://localhost:8000/api/v1/projects/projects/providers/
http://localhost:8000/api/v1/projects/projects/1/integrations/
http://localhost:8000/api/v1/projects/integrations/1/
```