### PR TITLE
Fix Html rendering of element titles in interview #1692

### DIFF
--- a/rdmo/projects/assets/js/interview/components/main/Breadcrumb.js
+++ b/rdmo/projects/assets/js/interview/components/main/Breadcrumb.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Html from 'rdmo/core/assets/js/components/Html'
 import { baseUrl } from 'rdmo/core/assets/js/utils/meta'
 
 const Breadcrumb = ({ overview, page, fetchPage }) => {
@@ -26,7 +27,7 @@ const Breadcrumb = ({ overview, page, fetchPage }) => {
         page && (
           <li>
             <a href={`${baseUrl}/projects/${overview.id}/interview/${page.section.first}/`} onClick={handleClick}>
-              {page.section.title}
+              <Html html={page.section.title} />
             </a>
           </li>
         )

--- a/rdmo/projects/assets/js/interview/components/main/page/Page.js
+++ b/rdmo/projects/assets/js/interview/components/main/page/Page.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import { isNil, minBy } from 'lodash'
 
+import Html from 'rdmo/core/assets/js/components/Html'
+
 import Question from '../question/Question'
 import QuestionSet from '../questionset/QuestionSet'
 
@@ -55,7 +57,7 @@ const Page = ({ config, settings, templates, overview, page, sets, values, fetch
 
   return (
     <div className="interview-page">
-      <h2>{page.title}</h2>
+      <h2><Html html={page.title} /></h2>
       <PageHelp page={page} />
       <PageManagement config={config} page={page} isManager={isManager} />
       <PageHead

--- a/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
+++ b/rdmo/projects/assets/js/interview/components/main/questionset/QuestionSet.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { isEmpty } from 'lodash'
 
+import Html from 'rdmo/core/assets/js/components/Html'
+
 import { checkQuestionSet } from '../../../utils/page'
 import { getChildPrefix } from '../../../utils/set'
 
@@ -29,7 +31,7 @@ const QuestionSet = ({ config, settings, templates, page, questionset, sets, val
   return checkQuestionSet(questionset, parentSet) && (
     <div className="interview-questionset col-md-12">
       <div className="interview-questionset-label">
-        <strong>{questionset.title}</strong>
+        <strong><Html html={questionset.title} /></strong>
       </div>
       <QuestionSetHelp questionset={questionset} />
       <QuestionSetHelpTemplate templates={templates} />

--- a/rdmo/projects/assets/js/interview/components/sidebar/Navigation.js
+++ b/rdmo/projects/assets/js/interview/components/sidebar/Navigation.js
@@ -37,7 +37,7 @@ const Navigation = ({ overview, currentPage, navigation, help, fetchPage }) => {
                                     onClick={() => fetchPage(page.id)}
                                   />
                                 ) : (
-                                  <span className="text-muted">{page.title}</span>
+                                  <span className="text-muted"><Html html={page.title} /></span>
                                 )
                               }
                             </li>

--- a/rdmo/projects/assets/js/interview/components/sidebar/NavigationLink.js
+++ b/rdmo/projects/assets/js/interview/components/sidebar/NavigationLink.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Html from 'rdmo/core/assets/js/components/Html'
+
 const NavigationLink = ({ element, href, onClick }) => {
 
   const label = interpolate(gettext('(%s of %s)'), [element.count, element.total])
@@ -12,7 +14,7 @@ const NavigationLink = ({ element, href, onClick }) => {
 
   return (
     <a href={href} onClick={handleClick}>
-      {element.title}
+      <Html html={element.title} />
       {
         element.count > 0 && element.count == element.total && (
           <span aria-label={gettext('Complete')}>

--- a/rdmo/projects/assets/js/interview/components/sidebar/Overview.js
+++ b/rdmo/projects/assets/js/interview/components/sidebar/Overview.js
@@ -32,7 +32,7 @@ const Overview = ({ config, overview, help, configActions }) => {
             {gettext('Project')}: <a href={projectUrl}>{overview.title}</a>
           </li>
           <li>
-            {gettext('Catalog')}: {overview.catalog.title}
+            {gettext('Catalog')}: <Html html={overview.catalog.title} />
           </li>
         </ul>
 


### PR DESCRIPTION
Related issue: #1692

We don't need to add a test for this right? 
We expect that those titles would come as html to the front-end those React `Html` components were just missing.
