### PR TITLE
Show visibility info+fix

### DIFF
--- a/rdmo/projects/assets/js/project/actions/projectActions.js
+++ b/rdmo/projects/assets/js/project/actions/projectActions.js
@@ -212,7 +212,6 @@ export function deleteProjectVisibility() {
       .then(() => {
         dispatch(removeFromPending('deleteProjectVisibility'))
         dispatch({ type: actionTypes.DELETE_PROJECT_VISIBILITY_SUCCESS })
-        return dispatch(fetchProjectVisibility())
       })
       .catch(error => {
         dispatch(removeFromPending('deleteProjectVisibility'))

--- a/rdmo/projects/assets/js/project/components/Sidebar.js
+++ b/rdmo/projects/assets/js/project/components/Sidebar.js
@@ -48,8 +48,9 @@ const Sidebar = () => {
           <h2 className="font-large mb-2">{project.project.title}</h2>
           <p className="font-normal text-muted m-0">{catalog.title}</p>
           {
-            visibility && project.project?.visibility ? (
-              <p className="font-normal text-muted m-0 mt-2">{project.project.visibility}</p>) : null
+            visibility?.help_display && (
+              <p className="font-normal text-muted m-0 mt-2">{visibility?.help_display}</p>
+            )
           }
         </div>
       </div>

--- a/rdmo/projects/assets/js/project/components/areas/information/ProjectVisibilityForm.js
+++ b/rdmo/projects/assets/js/project/components/areas/information/ProjectVisibilityForm.js
@@ -66,7 +66,7 @@ const ProjectVisibilityForm = () => {
         <h3 className="mb-0">{gettext('Project visibility')}</h3>
         <span className="text-muted small">
           {
-            visibility ? project?.visibility : gettext('Not set')
+            visibility ? visibility.help_display : gettext('Not set')
           }
         </span>
       </div>

--- a/rdmo/projects/assets/js/project/store/configureStore.js
+++ b/rdmo/projects/assets/js/project/store/configureStore.js
@@ -93,7 +93,7 @@ export default function configureStore() {
         store.dispatch(sitesActions.fetchSites())
         store.dispatch(groupsActions.fetchGroups())
         const project = store.getState().project.project.project
-        if (project.visibility) {
+        if (project.has_visibility) {
           store.dispatch(projectActions.fetchProjectVisibility(projectId))
         }
       }

--- a/rdmo/projects/assets/js/project/store/configureStore.js
+++ b/rdmo/projects/assets/js/project/store/configureStore.js
@@ -1,5 +1,6 @@
 import { applyMiddleware, combineReducers, createStore } from 'redux'
 import thunk from 'redux-thunk'
+import { isNil } from 'lodash'
 
 import * as configActions from 'rdmo/core/assets/js/actions/configActions'
 import * as groupsActions from 'rdmo/core/assets/js/actions/groupsActions'
@@ -93,7 +94,7 @@ export default function configureStore() {
         store.dispatch(sitesActions.fetchSites())
         store.dispatch(groupsActions.fetchGroups())
         const project = store.getState().project.project.project
-        if (project.has_visibility) {
+        if (!isNil(project.visibility)) {
           store.dispatch(projectActions.fetchProjectVisibility(projectId))
         }
       }

--- a/rdmo/projects/assets/js/projects/components/Main.js
+++ b/rdmo/projects/assets/js/projects/components/Main.js
@@ -251,7 +251,7 @@ const Main = () => {
             row.highest_role && <div className="text-secondary">{highestRoleString}</div>
           }
           {
-            row.visibility && <div className="text-secondary">{row.visibility}</div>
+            row.visibility_display && <div className="text-secondary">{row.visibility_display}</div>
           }
         </>
       )
@@ -262,7 +262,7 @@ const Main = () => {
           {row.owners.map(owner => owner.full_name).join('; ')}
         </div>
         {
-          row.visibility && <div className="text-secondary">{row.visibility}</div>
+          row.visibility_display && <div className="text-secondary">{row.visibility_display}</div>
         }
       </>
     ),

--- a/rdmo/projects/assets/js/projects/components/Main.js
+++ b/rdmo/projects/assets/js/projects/components/Main.js
@@ -251,7 +251,7 @@ const Main = () => {
             row.highest_role && <div className="text-secondary">{highestRoleString}</div>
           }
           {
-            row.visibility_display && <div className="text-secondary">{row.visibility_display}</div>
+            row.visibility?.help_display && <div className="text-secondary">{row.visibility?.help_display}</div>
           }
         </>
       )
@@ -262,7 +262,7 @@ const Main = () => {
           {row.owners.map(owner => owner.full_name).join('; ')}
         </div>
         {
-          row.visibility_display && <div className="text-secondary">{row.visibility_display}</div>
+          row.visibility?.help_display && <div className="text-secondary">{row.visibility?.help_display}</div>
         }
       </>
     ),

--- a/rdmo/projects/models/project.py
+++ b/rdmo/projects/models/project.py
@@ -134,6 +134,10 @@ class Project(MPTTModel, Model):
         return ', '.join(str(i) for i in self.groups if i is not None)
 
     @property
+    def has_visibility(self) -> bool:
+        return hasattr(self, 'visibility')
+
+    @property
     def file_size(self) -> int:
         queryset = self.values.filter(snapshot=None).exclude(models.Q(file='') | models.Q(file=None))
         return sum([value.file.size for value in queryset])

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -144,8 +144,6 @@ class ProjectSerializer(serializers.ModelSerializer):
     highest_role = serializers.SerializerMethodField()
     last_changed = serializers.DateTimeField(read_only=True)
 
-    visibility = serializers.CharField(source='visibility.get_help_display', read_only=True)
-
     class Meta:
         model = Project
         fields = (
@@ -169,7 +167,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'views',
             'progress_total',
             'progress_count',
-            'visibility',
+            'has_visibility',
             'ancestors',
             'permissions',
         )
@@ -291,13 +289,15 @@ class ProjectResolveSerializer(serializers.Serializer):
 
 
 class ProjectVisibilitySerializer(serializers.ModelSerializer):
+    help_display = serializers.CharField(source='get_help_display', read_only=True)
 
     class Meta:
         model = Visibility
         fields = (
             'project',
             'sites',
-            'groups'
+            'groups',
+            'help_display',
         )
 
 

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -144,7 +144,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     highest_role = serializers.SerializerMethodField()
     last_changed = serializers.DateTimeField(read_only=True)
 
-    visibility_display = serializers.CharField(source='visibility.get_help_display', read_only=True)
+    visibility = serializers.SerializerMethodField()
 
     class Meta:
         model = Project
@@ -169,8 +169,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'views',
             'progress_total',
             'progress_count',
-            'has_visibility',
-            'visibility_display',
+            'visibility',
             'ancestors',
             'permissions',
         )
@@ -258,6 +257,12 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_ancestors(self, obj) -> list[dict[str, Any]]:
         return ProjectAncestorSerializer(obj.get_cached_ancestors(), many=True, context=self.context).data
+
+    def get_visibility(self, obj) -> dict:
+        if hasattr(obj, 'visibility'):
+            return {
+                'help_display': obj.visibility.get_help_display()
+            }
 
 
 class ProjectListSerializer(ProjectSerializer):

--- a/rdmo/projects/serializers/v1/__init__.py
+++ b/rdmo/projects/serializers/v1/__init__.py
@@ -144,6 +144,8 @@ class ProjectSerializer(serializers.ModelSerializer):
     highest_role = serializers.SerializerMethodField()
     last_changed = serializers.DateTimeField(read_only=True)
 
+    visibility_display = serializers.CharField(source='visibility.get_help_display', read_only=True)
+
     class Meta:
         model = Project
         fields = (
@@ -168,6 +170,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'progress_total',
             'progress_count',
             'has_visibility',
+            'visibility_display',
             'ancestors',
             'permissions',
         )


### PR DESCRIPTION
I tried a few things 🙄, and added `help_display` to the visibility serializer (so it can be used in the dashboard. The same text is needed in the project serializer as well, to be displayed in the projects list/table. I nested this in an object:

```
    "visibility": {
        "help_display": "This project can be accessed by all users."
    },
```

to hopefully make it less confusing. Please check if I messed anything up.