### PR TITLE
2.5.2/fix/default external id+fixes

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -182,14 +182,34 @@ export function fetchOptionsError(error) {
   return {type: FETCH_OPTIONS_ERROR, error}
 }
 
-export function fetchValues(page) {
+export function fetchValues(page, preserveUnsaved = false) {
   const pendingId = `fetchValues/${page.id}`
 
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch(addToPending(pendingId))
     dispatch(fetchValuesInit())
     return ValueApi.fetchValues(projectId, { attribute: page.attributes })
       .then((values) => {
+        if (preserveUnsaved) {
+          const unsavedValues = getState().interview.values.filter((value) => isNil(value.id))
+
+          unsavedValues.forEach((value) => {
+            const question = page.questions.find((question) => question.attribute === value.attribute)
+            const widgetType = question && question.widget_type
+
+            if (!values.some((fetchedValue) => compareValues(fetchedValue, value, widgetType))) {
+              values.push(value)
+            }
+          })
+
+          values.sort((a, b) => (
+            (a.attribute - b.attribute) ||
+            a.set_prefix.localeCompare(b.set_prefix) ||
+            (a.set_index - b.set_index) ||
+            (a.collection_index - b.collection_index)
+          ))
+        }
+
         const sets = gatherSets(values, page)
 
         initSets(sets, page)
@@ -314,8 +334,9 @@ export function storeValue(value) {
 
           if (refresh) {
             // if the refresh flag is set, reload all values for the page,
-            // resolveConditions will be called in fetchValues
-            dispatch(fetchValues(page))
+            // resolveConditions will be called in fetchValues. Preserve unsaved values,
+            // since they are not included in the response from the backend.
+            dispatch(fetchValues(page, true))
           } else {
             dispatch(resolveConditions(page, sets))
           }
@@ -466,8 +487,9 @@ export function copyValue(question, ...originalValues) {
 
       if (refresh) {
         // if the refresh flag is set, reload all values for the page,
-        // resolveConditions will be called in fetchValues
-        dispatch(fetchValues(page))
+        // resolveConditions will be called in fetchValues. Preserve unsaved values,
+        // since they are not included in the response from the backend.
+        dispatch(fetchValues(page, true))
       } else {
         dispatch(resolveConditions(page, sets))
       }
@@ -491,6 +513,7 @@ export function deleteValue(value) {
       dispatch(deleteValueInit(valueId))
 
       if (isNil(value.id)) {
+        dispatch(removeFromPending(pendingId))
         return dispatch(deleteValueSuccess(valueId))
       } else {
         return ValueApi.deleteValue(projectId, value)
@@ -505,8 +528,9 @@ export function deleteValue(value) {
 
             if (refresh) {
               // if the refresh flag is set, reload all values for the page,
-              // resolveConditions will be called in fetchValues
-              dispatch(fetchValues(page))
+              // resolveConditions will be called in fetchValues. Preserve unsaved values,
+              // since they are not included in the response from the backend.
+              dispatch(fetchValues(page, true))
             } else {
               dispatch(resolveConditions(page, sets))
             }

--- a/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
+++ b/rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js
@@ -2,18 +2,40 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { maxBy, upperFirst } from 'lodash'
 
-const AddValue = ({ question, values, currentSet, disabled, createValue }) => {
+import { isDefaultValue } from '../../../utils/value'
+
+const AddValue = ({ question, values, currentSet, disabled, createValue, updateValue }) => {
   const handleClick = () => {
     const lastValue = maxBy(values, (v) => v.collection_index)
     const collectionIndex = lastValue ? lastValue.collection_index + 1 : 0
 
-    createValue({
-      attribute: question.attribute,
-      set_prefix: currentSet.set_prefix,
-      set_index: currentSet.set_index,
-      collection_index: collectionIndex,
-      set_collection: question.set_collection
-    })
+    const createCollectionValue = () => {
+      createValue({
+        attribute: question.attribute,
+        set_prefix: currentSet.set_prefix,
+        set_index: currentSet.set_index,
+        collection_index: collectionIndex,
+        set_collection: question.set_collection,
+        text: lastValue ? '' : question.default_text,
+        option: lastValue ? null : question.default_option,
+        external_id: lastValue ? '' : question.default_external_id,
+        unit: question.unit,
+        value_type: question.value_type
+      })
+    }
+
+    const defaultValue = values.find((value) => isDefaultValue(question, value))
+    if (defaultValue) {
+      Promise.resolve(updateValue(defaultValue, {
+        text: defaultValue.text,
+        option: defaultValue.option,
+        external_id: defaultValue.external_id,
+        unit: question.unit,
+        value_type: question.value_type
+      })).then(createCollectionValue)
+    } else {
+      createCollectionValue()
+    }
   }
 
   return !disabled && question.is_collection && (
@@ -29,7 +51,8 @@ AddValue.propTypes = {
   values: PropTypes.array.isRequired,
   currentSet: PropTypes.object.isRequired,
   disabled: PropTypes.bool.isRequired,
-  createValue: PropTypes.func.isRequired
+  createValue: PropTypes.func.isRequired,
+  updateValue: PropTypes.func.isRequired
 }
 
 export default AddValue

--- a/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js
@@ -60,6 +60,7 @@ const DateWidget = ({ page, question, sets, values, siblings, currentSet, disabl
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
         copyValue={copyValue}
       />
       <QuestionCopyValues

--- a/rdmo/projects/assets/js/interview/components/main/widget/FileWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/FileWidget.js
@@ -48,6 +48,7 @@ const FileWidget = ({ question, values, currentSet, disabled, createValue, updat
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
       />
     </div>
   )

--- a/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js
@@ -63,6 +63,7 @@ const RadioWidget = ({ page, question, sets, values, siblings, currentSet, disab
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
         copyValue={copyValue}
       />
       <QuestionCopyValues

--- a/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js
@@ -73,6 +73,7 @@ const RangeWidget = ({ page, question, sets, values, siblings, currentSet, disab
         currentSet={currentSet}
         disabled={disabled}
         createValue={handleCreateValue}
+        updateValue={updateValue}
         copyValue={copyValue}
       />
       <QuestionCopyValues

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectInput.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectInput.js
@@ -81,7 +81,7 @@ const SelectInput = ({ question, value, options, disabled, creatable, updateValu
     loadOptions(search, callback)
   }, 500)
 
-  // handle default external ids by loading the options an set a default value option
+  // handle default external ids by loading the options and setting a default value option
   useEffect(() => {
     setDefaultValueOption(null)
 
@@ -112,6 +112,7 @@ const SelectInput = ({ question, value, options, disabled, creatable, updateValu
     classNamePrefix: 'react-select',
     className: classnames,
     backspaceRemovesValue: false,
+    autoFocus: value.focus,
     isDisabled: disabled,
     placeholder: gettext('Select ...'),
     'aria-label': getQuestionTextId(question),

--- a/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js
@@ -64,6 +64,7 @@ const SelectWidget = ({ page, question, sets, values, siblings, currentSet, disa
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
       />
       <QuestionCopyValues
         question={question}

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js
@@ -58,6 +58,7 @@ const TextWidget = ({ page, question, sets, values, siblings, currentSet, disabl
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
       />
       <QuestionCopyValues
         question={question}

--- a/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js
@@ -58,6 +58,7 @@ const TextareaWidget = ({ page, question, sets, values, siblings, currentSet, di
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
       />
       <QuestionCopyValues
         question={question}

--- a/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
+++ b/rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
@@ -60,6 +60,7 @@ const YesNoWidget = ({ page, question, sets, values, siblings, currentSet, disab
         currentSet={currentSet}
         disabled={disabled}
         createValue={createValue}
+        updateValue={updateValue}
       />
       <QuestionCopyValues
         question={question}


### PR DESCRIPTION
I was testing around with the collection question multi select i.c.w. the ROR provider and found some quirks.
Here are some possible fixes for https://github.com/rdmorganiser/rdmo/pull/1691

Quirks and changes:

### 1. `Fix pending state when deleting unsaved values`

The pending state got stuck in a forever-loop after try to delete some value

```bash
rdmo/projects/assets/js/interview/actions/interviewActions.js
```

   - Only the `removeFromPending(pendingId)` hunk in `deleteValue`.

```js
dispatch(removeFromPending(pendingId))
```


### 2. `Preserve unsaved values during provider refreshes`
```bash
 rdmo/projects/assets/js/interview/actions/interviewActions.js
```
   - Add `preserveUnsaved` handling to `fetchValues`.
   - Preserve and deduplicate local unsaved values.
   - Use it after storing, copying, or deleting values when a provider requires refresh.


### 3. `Preserve defaults when adding collection values`
What I found:
> When I see the first default option already filled in and want to add another value (via `AddValue`) , then I can search and select it but it will replace the first value instead adding it to the collection of that question.

It happens when the plugin has `refresh = True`, so (`has_refresh: true`).

The fix what Codex found was:

> `AddValue` was already creating a second temporary value at the next collection_index and marking it with focus: true. The problem was that `SelectInput` ignored this focus marker, unlike text inputs. The still-focused default select therefore received the next selection, making it appear to be replaced.
> `SelectInput` now attaches the existing focus hook to every React Select variant. After clicking Add, keyboard input goes to the newly added select, preserving the default as collection index 0 and storing the new selection at index 1.
> 

```bash
  rdmo/projects/assets/js/interview/components/main/question/QuestionAddValue.js \
  rdmo/projects/assets/js/interview/components/main/widget/DateWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/FileWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/RadioWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/RangeWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/SelectWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/TextWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/TextareaWidget.js \
  rdmo/projects/assets/js/interview/components/main/widget/YesNoWidget.js
```

   - All widget wrapper files passing `updateValue`.
   - Persist an existing untouched default before adding another value.
   - Reapply the configured default when adding the first value to an empty collection.

### 4. `Focus newly added select values`

So that the cursor jumps right into the search box after opening/clicking on it.

```bash

  rdmo/projects/assets/js/interview/components/main/widget/SelectInput.js
```
   - Add `autoFocus: value.focus`.
   - A comment typo correction.


