### PR TITLE
Add default sort and change sort behaviour

### DIFF
--- a/rdmo/projects/assets/js/projects/components/helper/Table.js
+++ b/rdmo/projects/assets/js/projects/components/helper/Table.js
@@ -32,17 +32,12 @@ const Table = ({
 
   const handleHeaderClick = (column) => {
     if (sortableColumns.includes(column)) {
-      if (sortColumn === column) {
-        if (sortOrder === 'asc') {
-          configActions.updateConfig('params.ordering', `-${column}`)
-        } else if (sortOrder === 'desc') {
-          configActions.deleteConfig('params.ordering')
-        } else {
-        configActions.updateConfig('params.ordering', column)
-        }
+      if (sortColumn === column && sortOrder === 'asc') {
+        configActions.updateConfig('params.ordering', `-${column}`)
       } else {
         configActions.updateConfig('params.ordering', column)
       }
+
       projectsActions.fetchProjects()
     }
   }

--- a/rdmo/projects/assets/js/projects/store/configureStore.js
+++ b/rdmo/projects/assets/js/projects/store/configureStore.js
@@ -29,7 +29,10 @@ export default function configureStore() {
   const initialState = {
     config: {
       myProjects: true,
-      prefix: 'rdmo.projects.config'
+      prefix: 'rdmo.projects.config',
+      params: {
+        ordering: '-last_changed'
+      }
     }
   }
 


### PR DESCRIPTION
In the projects list:
* added a default sort option (`last_changed` descending)
* third click on column arrows to delete the sort option is no longer possible (-> list has to be sorted always by a column)