### PR TITLE
Make visibility info accessible for regular users

### DIFF
--- a/rdmo/projects/assets/js/project/actions/projectActions.js
+++ b/rdmo/projects/assets/js/project/actions/projectActions.js
@@ -204,14 +204,25 @@ export function updateProjectVisibility(data) {
 }
 
 export function deleteProjectVisibility() {
-  return function (dispatch) {
+  return function (dispatch, getState) {
     dispatch(addToPending('deleteProjectVisibility'))
     dispatch({ type: actionTypes.DELETE_PROJECT_VISIBILITY_INIT })
 
     return ProjectApi.deleteProjectVisibility(projectId)
       .then(() => {
-        dispatch(removeFromPending('deleteProjectVisibility'))
         dispatch({ type: actionTypes.DELETE_PROJECT_VISIBILITY_SUCCESS })
+        const state = getState()
+        const currentBundle = state.project.project
+        return ProjectApi.fetchProject(projectId).then(project => ({ project, currentBundle }))
+      })
+      .then(({ project, currentBundle }) => {
+        const updatedBundle = {
+          ...currentBundle,
+          project
+        }
+        dispatch(removeFromPending('deleteProjectVisibility'))
+        dispatch(fetchProjectVisibility())
+        dispatch({ type: actionTypes.UPDATE_PROJECT_SUCCESS, project: updatedBundle })
       })
       .catch(error => {
         dispatch(removeFromPending('deleteProjectVisibility'))

--- a/rdmo/projects/assets/js/project/components/Sidebar.js
+++ b/rdmo/projects/assets/js/project/components/Sidebar.js
@@ -12,7 +12,7 @@ const Sidebar = () => {
   const dispatch = useDispatch()
 
   const { area } = useSelector((state) => state.config)
-  const { project, visibility } = useSelector((state) => state.project)
+  const { project } = useSelector((state) => state.project)
 
   const catalog = project?.catalogs.find(catalog => catalog.id == project.project.catalog)
 
@@ -48,8 +48,8 @@ const Sidebar = () => {
           <h2 className="font-large mb-2">{project.project.title}</h2>
           <p className="font-normal text-muted m-0">{catalog.title}</p>
           {
-            visibility?.help_display && (
-              <p className="font-normal text-muted m-0 mt-2">{visibility?.help_display}</p>
+            project.project.visibility?.help_display && (
+              <p className="font-normal text-muted m-0 mt-2">{project.project.visibility?.help_display}</p>
             )
           }
         </div>


### PR DESCRIPTION
Visibility info was not displayed for regular users in project detail view.

Solution was to display visibility info from project.

That made it necessary to re-fetch the project after all visibility changes for admin users, as the information would otherwise not accurately updated for them.