### PR TITLE
Fix project rules

### DIFF
--- a/rdmo/accounts/models.py
+++ b/rdmo/accounts/models.py
@@ -218,6 +218,10 @@ class Role(models.Model):
     def is_site_manager(self):
         return self.manager.filter(id=settings.SITE_ID).exists()
 
+    @cached_property
+    def manager_set(self):
+        return {site.id for site in self.manager.all()}
+
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def post_save_user(sender, **kwargs):

--- a/rdmo/projects/assets/js/project/store/configureStore.js
+++ b/rdmo/projects/assets/js/project/store/configureStore.js
@@ -3,9 +3,9 @@ import thunk from 'redux-thunk'
 import { isNil } from 'lodash'
 
 import * as configActions from 'rdmo/core/assets/js/actions/configActions'
-import * as groupsActions from 'rdmo/core/assets/js/actions/groupsActions'
+// import * as groupsActions from 'rdmo/core/assets/js/actions/groupsActions'
 import * as settingsActions from 'rdmo/core/assets/js/actions/settingsActions'
-import * as sitesActions from 'rdmo/core/assets/js/actions/sitesActions'
+// import * as sitesActions from 'rdmo/core/assets/js/actions/sitesActions'
 import * as templateActions from 'rdmo/core/assets/js/actions/templateActions'
 import * as userActions from 'rdmo/core/assets/js/actions/userActions'
 import configReducer from 'rdmo/core/assets/js/reducers/configReducer'
@@ -90,9 +90,11 @@ export default function configureStore() {
       if (permissions.can_view_invite) {
         store.dispatch(projectActions.fetchProjectInvites(projectId))
       }
+
       if (permissions.can_view_visibility) {
-        store.dispatch(sitesActions.fetchSites())
-        store.dispatch(groupsActions.fetchGroups())
+        // TODO: enable again and guard with the new user permissions
+        // store.dispatch(sitesActions.fetchSites())
+        // store.dispatch(groupsActions.fetchGroups())
         const project = store.getState().project.project.project
         if (!isNil(project.visibility)) {
           store.dispatch(projectActions.fetchProjectVisibility(projectId))

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -75,8 +75,7 @@ def is_visible(user, project):
 
 @rules.predicate
 def is_project_site_manager(user, project):
-    return user.is_authenticated and user.role.manager.filter(id=project.site_id).exists()
-
+    return user.is_authenticated and project.site_id in user.role.manager_set
 
 rules.add_perm('projects.add_project', can_add_project)
 rules.add_perm('projects.view_project_object', is_project_member | is_visible | is_project_site_manager)

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -74,57 +74,57 @@ def is_visible(user, project):
 
 
 @rules.predicate
-def is_site_manager(user, project):
-    return user.is_authenticated and user.role.manager.filter(id=project.site.id).exists()
+def is_project_site_manager(user, project):
+    return user.is_authenticated and user.role.manager.filter(id=project.site_id).exists()
 
 
 rules.add_perm('projects.add_project', can_add_project)
-rules.add_perm('projects.view_project_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.change_project_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.change_project_progress_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)  # noqa: E501
-rules.add_perm('projects.delete_project_object', is_project_owner | is_site_manager)
+rules.add_perm('projects.view_project_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.change_project_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.change_project_progress_object', is_project_author | is_project_manager | is_project_owner | is_project_site_manager)  # noqa: E501
+rules.add_perm('projects.delete_project_object', is_project_owner | is_project_site_manager)
 rules.add_perm('projects.leave_project_object', is_current_project_member & ~is_last_owner)
-rules.add_perm('projects.export_project_object', is_project_owner | is_project_manager | is_site_manager)
-rules.add_perm('projects.import_project_object', is_project_owner | is_project_manager | is_site_manager)
+rules.add_perm('projects.export_project_object', is_project_owner | is_project_manager | is_project_site_manager)
+rules.add_perm('projects.import_project_object', is_project_owner | is_project_manager | is_project_site_manager)
 
-rules.add_perm('projects.view_visibility_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_visibility_object', is_site_manager)
-rules.add_perm('projects.change_visibility_object', is_site_manager)
-rules.add_perm('projects.delete_visibility_object', is_site_manager)
+rules.add_perm('projects.view_visibility_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_visibility_object', is_project_site_manager)
+rules.add_perm('projects.change_visibility_object', is_project_site_manager)
+rules.add_perm('projects.delete_visibility_object', is_project_site_manager)
 
-rules.add_perm('projects.view_membership_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_membership_object', is_site_manager)
-rules.add_perm('projects.change_membership_object', is_project_owner | is_site_manager)
-rules.add_perm('projects.delete_membership_object', is_project_owner | is_site_manager)
+rules.add_perm('projects.view_membership_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_membership_object', is_project_site_manager)
+rules.add_perm('projects.change_membership_object', is_project_owner | is_project_site_manager)
+rules.add_perm('projects.delete_membership_object', is_project_owner | is_project_site_manager)
 
-rules.add_perm('projects.view_invite_object', is_project_owner | is_site_manager)
-rules.add_perm('projects.add_invite_object', is_project_owner | is_site_manager)
-rules.add_perm('projects.change_invite_object', is_project_owner | is_site_manager)
-rules.add_perm('projects.delete_invite_object', is_project_owner | is_site_manager)
+rules.add_perm('projects.view_invite_object', is_project_owner | is_project_site_manager)
+rules.add_perm('projects.add_invite_object', is_project_owner | is_project_site_manager)
+rules.add_perm('projects.change_invite_object', is_project_owner | is_project_site_manager)
+rules.add_perm('projects.delete_invite_object', is_project_owner | is_project_site_manager)
 
-rules.add_perm('projects.view_integration_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_integration_object', is_project_owner | is_project_manager | is_site_manager)
-rules.add_perm('projects.change_integration_object', is_project_owner | is_project_manager | is_site_manager)
-rules.add_perm('projects.delete_integration_object', is_project_owner | is_project_manager | is_site_manager)
+rules.add_perm('projects.view_integration_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_integration_object', is_project_owner | is_project_manager | is_project_site_manager)
+rules.add_perm('projects.change_integration_object', is_project_owner | is_project_manager | is_project_site_manager)
+rules.add_perm('projects.delete_integration_object', is_project_owner | is_project_manager | is_project_site_manager)
 
-rules.add_perm('projects.view_issue_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_issue_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.change_issue_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)  # noqa: E501
-rules.add_perm('projects.delete_issue_object', is_project_manager | is_project_owner | is_site_manager)
+rules.add_perm('projects.view_issue_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_issue_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.change_issue_object', is_project_author | is_project_manager | is_project_owner | is_project_site_manager)  # noqa: E501
+rules.add_perm('projects.delete_issue_object', is_project_manager | is_project_owner | is_project_site_manager)
 
-rules.add_perm('projects.view_snapshot_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.change_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.delete_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.rollback_snapshot_object', is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.export_snapshot_object', is_project_owner | is_project_manager | is_site_manager)
+rules.add_perm('projects.view_snapshot_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_snapshot_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.change_snapshot_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.delete_snapshot_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.rollback_snapshot_object', is_project_manager | is_project_owner | is_project_site_manager)
+rules.add_perm('projects.export_snapshot_object', is_project_owner | is_project_manager | is_project_site_manager)
 
-rules.add_perm('projects.view_value_object', is_project_member | is_visible | is_site_manager)
-rules.add_perm('projects.add_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)
-rules.add_perm('projects.change_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)  # noqa: E501
-rules.add_perm('projects.delete_value_object', is_project_author | is_project_manager | is_project_owner | is_site_manager)  # noqa: E501
+rules.add_perm('projects.view_value_object', is_project_member | is_visible | is_project_site_manager)
+rules.add_perm('projects.add_value_object', is_project_author | is_project_manager | is_project_owner | is_project_site_manager)  # noqa: E501
+rules.add_perm('projects.change_value_object', is_project_author | is_project_manager | is_project_owner | is_project_site_manager)  # noqa: E501
+rules.add_perm('projects.delete_value_object', is_project_author | is_project_manager | is_project_owner | is_project_site_manager)  # noqa: E501
 
-rules.add_perm('projects.view_page_object', is_project_member | is_visible | is_site_manager)
+rules.add_perm('projects.view_page_object', is_project_member | is_visible | is_project_site_manager)
 
 # TODO: use one of the permissions above
 rules.add_perm('projects.is_project_owner', is_project_owner)

--- a/rdmo/projects/rules.py
+++ b/rdmo/projects/rules.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 import rules
-from rules.predicates import is_superuser
 
 
 @rules.predicate
@@ -76,11 +75,8 @@ def is_visible(user, project):
 
 @rules.predicate
 def is_site_manager(user, project):
-    return user.is_authenticated and user.role.is_site_manager
+    return user.is_authenticated and user.role.manager.filter(id=project.site.id).exists()
 
-
-# Add rule for check in template
-rules.add_rule('projects.can_view_all_projects', is_site_manager | is_superuser)
 
 rules.add_perm('projects.add_project', can_add_project)
 rules.add_perm('projects.view_project_object', is_project_member | is_visible | is_site_manager)
@@ -91,7 +87,7 @@ rules.add_perm('projects.leave_project_object', is_current_project_member & ~is_
 rules.add_perm('projects.export_project_object', is_project_owner | is_project_manager | is_site_manager)
 rules.add_perm('projects.import_project_object', is_project_owner | is_project_manager | is_site_manager)
 
-rules.add_perm('projects.view_visibility_object', is_site_manager)
+rules.add_perm('projects.view_visibility_object', is_project_member | is_visible | is_site_manager)
 rules.add_perm('projects.add_visibility_object', is_site_manager)
 rules.add_perm('projects.change_visibility_object', is_site_manager)
 rules.add_perm('projects.delete_visibility_object', is_site_manager)

--- a/rdmo/projects/tests/test_queries.py
+++ b/rdmo/projects/tests/test_queries.py
@@ -4,6 +4,8 @@ from django.urls import reverse
 
 max_queries = [
     # method, urlname, max_queries, url_args
+    ('get', 'v1-projects:project-list', 16, []),
+    ('get', 'v1-projects:project-detail', 12, [1]),
     ('get', 'v1-projects:project-navigation', 43, [1]),
     ('get', 'v1-projects:project-answers', 43, [1]),
     ('post', 'v1-projects:project-progress', 44, [1]),

--- a/rdmo/projects/tests/test_queries.py
+++ b/rdmo/projects/tests/test_queries.py
@@ -2,23 +2,50 @@ import pytest
 
 from django.urls import reverse
 
-max_queries = [
+max_queries = {
     # method, urlname, max_queries, url_args
-    ('get', 'v1-projects:project-list', 16, []),
-    ('get', 'v1-projects:project-detail', 12, [1]),
-    ('get', 'v1-projects:project-navigation', 43, [1]),
-    ('get', 'v1-projects:project-answers', 43, [1]),
-    ('post', 'v1-projects:project-progress', 44, [1]),
-    ('get', 'v1-projects:project-page-detail', 46, [1, 1]),
-    ('get', 'v1-projects:project-page-detail', 50, [1, 42]),
-    ('get', 'v1-projects:project-page-detail', 62, [1, 87]),
-]
+    'owner': (
+        ('get', 'v1-projects:project-list', 16, []),
+        ('get', 'v1-projects:project-detail', 12, [1]),
+        ('get', 'v1-projects:project-navigation', 43, [1]),
+        ('get', 'v1-projects:project-answers', 43, [1]),
+        ('post', 'v1-projects:project-progress', 44, [1]),
+        ('get', 'v1-projects:project-page-detail', 46, [1, 1]),
+        ('get', 'v1-projects:project-page-detail', 50, [1, 42]),
+        ('get', 'v1-projects:project-page-detail', 62, [1, 87]),
+    ),
+    'site': (
+        ('get', 'v1-projects:project-list', 18, []),              # 2 more
+        ('get', 'v1-projects:project-detail', 12, [1]),
+        ('get', 'v1-projects:project-navigation', 43, [1]),
+        ('get', 'v1-projects:project-answers', 43, [1]),
+        ('post', 'v1-projects:project-progress', 44, [1]),
+        ('get', 'v1-projects:project-page-detail', 48, [1, 1]),   # 2 more
+        ('get', 'v1-projects:project-page-detail', 52, [1, 42]),  # 2 more
+        ('get', 'v1-projects:project-page-detail', 64, [1, 87]),  # 2 more
+    )
+}
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize('method,urlname,max_queries,url_args', max_queries)
-def test_queries(db, client, django_assert_max_num_queries, method, urlname, max_queries, url_args):
+@pytest.mark.parametrize('method,urlname,max_queries,url_args', max_queries['owner'])
+def test_queries_owner(db, client, django_assert_max_num_queries, method, urlname, max_queries, url_args):
     client.login(username='owner', password='owner')
+    url = reverse(urlname, args=url_args)
+
+    with django_assert_max_num_queries(max_queries):
+        if method == 'get':
+            response = client.get(url)
+        elif method == 'post':
+            response = client.post(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize('method,urlname,max_queries,url_args', max_queries['site'])
+def test_queries_site(db, client, django_assert_max_num_queries, method, urlname, max_queries, url_args):
+    client.login(username='site', password='site')
     url = reverse(urlname, args=url_args)
 
     with django_assert_max_num_queries(max_queries):

--- a/rdmo/projects/tests/test_rules.py
+++ b/rdmo/projects/tests/test_rules.py
@@ -1,0 +1,222 @@
+import pytest
+
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+
+from ..models import Project
+
+users = (
+    'owner',
+    'manager',
+    'author',
+    'guest',
+    'admin',
+    'api',
+    'site',
+    'example-manager',
+    'foo-manager',
+    'bar-manager',
+    'user',
+)
+
+permissions = (
+    # project
+    'projects.add_project',
+    'projects.view_project_object',
+    'projects.change_project_object',
+    'projects.change_project_progress_object',
+    'projects.delete_project_object',
+    'projects.leave_project_object',
+    'projects.export_project_object',
+    'projects.import_project_object',
+    # visibility
+    'projects.view_visibility_object',
+    'projects.add_visibility_object',
+    'projects.change_visibility_object',
+    'projects.delete_visibility_object',
+    # membership
+    'projects.view_membership_object',
+    'projects.add_membership_object',
+    'projects.change_membership_object',
+    'projects.delete_membership_object',
+    # invite
+    'projects.view_invite_object',
+    'projects.add_invite_object',
+    'projects.change_invite_object',
+    'projects.delete_invite_object',
+    # integration
+    'projects.view_integration_object',
+    'projects.add_integration_object',
+    'projects.change_integration_object',
+    'projects.delete_integration_object',
+    # issue
+    'projects.view_issue_object',
+    'projects.add_issue_object',
+    'projects.change_issue_object',
+    'projects.delete_issue_object',
+    # snapshot
+    'projects.view_snapshot_object',
+    'projects.add_snapshot_object',
+    'projects.change_snapshot_object',
+    'projects.delete_snapshot_object',
+    'projects.rollback_snapshot_object',
+    'projects.export_snapshot_object',
+    # value
+    'projects.view_value_object',
+    'projects.add_value_object',
+    'projects.change_value_object',
+    'projects.delete_value_object',
+    # page
+    'projects.view_page_object',
+)
+
+@pytest.mark.parametrize('permission', permissions)
+@pytest.mark.parametrize('username', users)
+def test_project(db, permission, username):
+    user = User.objects.get(username=username)
+    project = Project.objects.get(id=1)
+    result = user.has_perm(permission, project)
+
+    if permission == 'projects.add_project':
+        # all users can create projects
+        allowed = users
+
+    elif permission in (
+        'projects.add_visibility_object',
+        'projects.add_membership_object',
+        'projects.change_visibility_object',
+        'projects.delete_visibility_object'
+    ):
+        # all users who act as site managers
+        allowed = ('admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.delete_project_object',
+        'projects.change_membership_object',
+        'projects.delete_membership_object',
+        'projects.view_invite_object',
+        'projects.add_invite_object',
+        'projects.change_invite_object',
+        'projects.delete_invite_object',
+    ):
+        # all users who act as owners of the project
+        allowed = ('owner', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.change_project_object',
+        'projects.import_project_object',
+        'projects.export_project_object',
+        'projects.add_integration_object',
+        'projects.change_integration_object',
+        'projects.delete_integration_object',
+        'projects.add_issue_object',
+        'projects.delete_issue_object',
+        'projects.add_snapshot_object',
+        'projects.change_snapshot_object',
+        'projects.delete_snapshot_object',
+        'projects.rollback_snapshot_object',
+        'projects.export_snapshot_object',
+    ):
+        # all users who act as managers of the project
+        allowed = ('owner', 'manager', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.change_project_progress_object',
+        'projects.add_value_object',
+        'projects.change_value_object',
+        'projects.delete_value_object',
+        'projects.change_issue_object'
+    ):
+        # all users who act as authors of the project
+        allowed = ('owner', 'manager', 'author', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission.startswith('projects.view'):
+        # all users who can access the project
+        allowed = ('owner', 'manager', 'author', 'guest', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission == 'projects.leave_project_object':
+        # any project member, but the last owner
+        allowed = ('manager', 'author', 'guest', 'admin')  # TODO: check if admin can be removed
+
+    else:
+        allowed = []
+
+    assert result == (username in allowed)
+
+
+@pytest.mark.parametrize('permission', permissions)
+@pytest.mark.parametrize('username', users)
+def test_visible_project(db, sites, permission, username):
+    sites.activate('foo.com')
+
+    user = User.objects.get(username=username)
+    project = Project.objects.get(id=12)
+    project.visibility.sites.add(Site.objects.get(id=2))
+
+    result = user.has_perm(permission, project)
+
+    if permission == 'projects.add_project':
+        # all users can create projects
+        allowed = users
+
+    elif permission in (
+        'projects.add_visibility_object',
+        'projects.add_membership_object',
+        'projects.change_visibility_object',
+        'projects.delete_visibility_object'
+    ):
+        # all users who act as site managers
+        allowed = ('admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.delete_project_object',
+        'projects.change_membership_object',
+        'projects.delete_membership_object',
+        'projects.view_invite_object',
+        'projects.add_invite_object',
+        'projects.change_invite_object',
+        'projects.delete_invite_object',
+    ):
+        # all users who act as owners of the project
+        allowed = ('owner', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.change_project_object',
+        'projects.import_project_object',
+        'projects.export_project_object',
+        'projects.add_integration_object',
+        'projects.change_integration_object',
+        'projects.delete_integration_object',
+        'projects.add_issue_object',
+        'projects.delete_issue_object',
+        'projects.add_snapshot_object',
+        'projects.change_snapshot_object',
+        'projects.delete_snapshot_object',
+        'projects.rollback_snapshot_object',
+        'projects.export_snapshot_object',
+    ):
+        # all users who act as managers of the project
+        allowed = ('owner', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission in (
+        'projects.change_project_progress_object',
+        'projects.add_value_object',
+        'projects.change_value_object',
+        'projects.delete_value_object',
+        'projects.change_issue_object'
+    ):
+        # all users who act as authors of the project
+        allowed = ('owner', 'admin', 'api', 'site', 'example-manager')
+
+    elif permission.startswith('projects.view'):
+        # all users who can access the project
+        allowed = users
+
+    elif permission == 'projects.leave_project_object':
+        # any project member, but the last owner
+        allowed = ('admin', )  # TODO: check if admin can be removed
+
+    else:
+        allowed = []
+
+    assert result == (username in allowed)

--- a/rdmo/projects/tests/test_viewset_project_visibility.py
+++ b/rdmo/projects/tests/test_viewset_project_visibility.py
@@ -25,13 +25,10 @@ def test_project_visibility_get(db, client, username, password):
     url = reverse('v1-projects:project-visibility', args=[project_id])
     response = client.get(url)
 
-    if username in ['admin', 'site', 'api']:
+    if password:
         assert response.status_code == 200
     else:
-        if password:
-            assert response.status_code == 404
-        else:
-            assert response.status_code == 401
+        assert response.status_code == 401
 
 
 @pytest.mark.parametrize('username,password', users)
@@ -65,7 +62,10 @@ def test_project_visibility_post_create(db, client, username, password):
         assert response.status_code == 200
         assert Project.objects.get(pk=project_id).visibility
     else:
-        if password:
+        if username in ['owner']:
+            # owner has access to the project, but not to visibility
+            assert response.status_code == 403
+        elif password:
             assert response.status_code == 404
         else:
             assert response.status_code == 401
@@ -95,7 +95,8 @@ def test_project_visibility_post_update(db, client, username, password):
         assert response.status_code == 200
     else:
         if password:
-            assert response.status_code == 404
+            # all users can access the project, but not the visibility, because it is visible
+            assert response.status_code == 403
         else:
             assert response.status_code == 401
 
@@ -126,7 +127,9 @@ def test_project_visibility_post_update_group(db, client, settings, username, pa
         assert project.visibility
         assert [group.id for group in project.visibility.groups.all()] == [2]
     else:
-        if password:
+        if username in ['owner']:
+            assert response.status_code == 403
+        elif password:
             assert response.status_code == 404
         else:
             assert response.status_code == 401
@@ -161,7 +164,9 @@ def test_project_visibility_post_update_site(db, client, settings, username, pas
         assert project.visibility
         assert {site.id for site in project.visibility.sites.all()} == {1, 3}
     else:
-        if password:
+        if username in ['owner']:
+            assert response.status_code == 403
+        elif password:
             assert response.status_code == 404
         else:
             assert response.status_code == 401
@@ -188,7 +193,8 @@ def test_project_visibility_post_delete(db, client, username, password):
             assert project.visibility
     else:
         if password:
-            assert response.status_code == 404
+            # all users can access the project, but not the visibility, because it is visible
+            assert response.status_code == 403
         else:
             assert response.status_code == 401
 
@@ -219,7 +225,8 @@ def test_project_visibility_post_delete_site(db, client, settings, username, pas
         assert {site.id for site in project.visibility.sites.all()} == {2, 3}
     else:
         if password:
-            assert response.status_code == 404
+            # all users can access the project, but not the visibility, because it is visible
+            assert response.status_code == 403
         else:
             assert response.status_code == 401
 
@@ -246,9 +253,11 @@ def test_project_visibility_post_delete_site_last(db, client, settings, username
             assert project.visibility
     else:
         if password:
-            assert response.status_code == 404
+            # all users can access the project, but not the visibility, because it is visible
+            assert response.status_code == 403
         else:
             assert response.status_code == 401
+
         assert project.visibility
 
 
@@ -276,9 +285,11 @@ def test_project_visibility_post_delete_site_empty(db, client, settings, usernam
         assert {site.id for site in project.visibility.sites.all()} == {2, 3}
     else:
         if password:
-            assert response.status_code == 404
+            # all users can access the project, but not the visibility, because it is visible
+            assert response.status_code == 403
         else:
             assert response.status_code == 401
+
         assert project.visibility
 
 
@@ -292,7 +303,9 @@ def test_project_visibility_post_delete_not_found(db, client, username, password
     url = reverse('v1-projects:project-visibility', args=[project_id])
     response = client.delete(url)
 
-    if password:
+    if username in ['owner']:
+        assert response.status_code == 403
+    elif password:
         assert response.status_code == 404
     else:
         assert response.status_code == 401


### PR DESCRIPTION
This PR aims to fix the Bug in RDMO 3.0, where `foo-manager` gets permissions on projects from `example.com` which are visible to them. The bug was introduces with the rewrite of the `site_manager` check.

It also gives `project.view_visibility_object` to all users who can access the project (as discussed).

I also adds a comprehensive test for the permissions in `rdmo/project/rules.py`. I'am not sure if this is the ideal form, I wanted something human readable to cross check if the permissions are as expected.

Tha last part is an update of the visibility api tests. It is a bit confusion who gets an `403` and a `404`. I needed some time to understand this and added some comments.