### PR TITLE
Add permissions to user API

### DIFF
--- a/rdmo/accounts/serializers/v1.py
+++ b/rdmo/accounts/serializers/v1.py
@@ -68,6 +68,7 @@ class UserSerializer(serializers.ModelSerializer):
     groups = UserGroupSerializer(many=True)
     role = UserRoleSerializer()
     memberships = UserMembershipSerializer(many=True)
+    permissions = serializers.SerializerMethodField()
 
     is_site_manager = serializers.BooleanField(source='role.is_site_manager')
 
@@ -78,6 +79,7 @@ class UserSerializer(serializers.ModelSerializer):
             'groups',
             'role',
             'memberships',
+            'permissions',
             'is_superuser',
             'is_staff',
             'is_site_manager'
@@ -91,6 +93,12 @@ class UserSerializer(serializers.ModelSerializer):
                 'last_login',
                 'date_joined',
             ]
+
+    def get_permissions(self, obj) -> dict[str, bool]:
+        return {
+            'can_change_visibility': obj.has_perm('projects.change_visibility'),
+        }
+
 
 class UserLookupSerializer(serializers.Serializer):
     first_name = serializers.CharField(source='user.first_name', read_only=True)

--- a/rdmo/accounts/serializers/v1.py
+++ b/rdmo/accounts/serializers/v1.py
@@ -68,7 +68,6 @@ class UserSerializer(serializers.ModelSerializer):
     groups = UserGroupSerializer(many=True)
     role = UserRoleSerializer()
     memberships = UserMembershipSerializer(many=True)
-    permissions = serializers.SerializerMethodField()
 
     is_site_manager = serializers.BooleanField(source='role.is_site_manager')
 
@@ -79,7 +78,6 @@ class UserSerializer(serializers.ModelSerializer):
             'groups',
             'role',
             'memberships',
-            'permissions',
             'is_superuser',
             'is_staff',
             'is_site_manager'
@@ -94,9 +92,54 @@ class UserSerializer(serializers.ModelSerializer):
                 'date_joined',
             ]
 
+
+class CurrentUserSerializer(UserSerializer):
+    permissions = serializers.SerializerMethodField()
+
+    class Meta(UserSerializer.Meta):
+        fields = [
+            *UserSerializer.Meta.fields,
+            'permissions',
+        ]
+
     def get_permissions(self, obj) -> dict[str, bool]:
         return {
+            'can_view_project': obj.has_perm('projects.view_project'),
+            'can_change_project': obj.has_perm('projects.change_project'),
+            'can_delete_project': obj.has_perm('projects.delete_project'),
+            'can_leave_project': obj.has_perm('projects.leave_project'),
+            'can_export_project': obj.has_perm('projects.export_project'),
+            'can_import_project': obj.has_perm('projects.import_project'),
+            'can_view_visibility': obj.has_perm('projects.view_visibility'),
+            'can_add_visibility': obj.has_perm('projects.add_visibility'),
             'can_change_visibility': obj.has_perm('projects.change_visibility'),
+            'can_delete_visibility': obj.has_perm('projects.delete_visibility'),
+            'can_view_membership': obj.has_perm('projects.view_membership'),
+            'can_add_membership': obj.has_perm('projects.add_membership'),
+            'can_change_membership': obj.has_perm('projects.change_membership'),
+            'can_delete_membership': obj.has_perm('projects.delete_membership'),
+            'can_view_invite': obj.has_perm('projects.view_invite'),
+            'can_add_invite': obj.has_perm('projects.add_invite'),
+            'can_change_invite': obj.has_perm('projects.change_invite'),
+            'can_delete_invite': obj.has_perm('projects.delete_invite'),
+            'can_view_integration': obj.has_perm('projects.view_integration'),
+            'can_add_integration': obj.has_perm('projects.add_integration'),
+            'can_change_integration': obj.has_perm('projects.change_integration'),
+            'can_delete_integration': obj.has_perm('projects.delete_integration'),
+            'can_view_issue': obj.has_perm('projects.view_issue'),
+            'can_add_issue': obj.has_perm('projects.add_issue'),
+            'can_change_issue': obj.has_perm('projects.change_issue'),
+            'can_delete_issue': obj.has_perm('projects.delete_issue'),
+            'can_view_snapshot': obj.has_perm('projects.view_snapshot'),
+            'can_add_snapshot': obj.has_perm('projects.add_snapshot'),
+            'can_change_snapshot': obj.has_perm('projects.change_snapshot'),
+            'can_delete_snapshot': obj.has_perm('projects.delete_snapshot'),
+            'can_rollback_snapshot': obj.has_perm('projects.rollback_snapshot'),
+            'can_export_snapshot': obj.has_perm('projects.export_snapshot'),
+            'can_view_value': obj.has_perm('projects.view_value'),
+            'can_add_value': obj.has_perm('projects.add_value'),
+            'can_change_value': obj.has_perm('projects.change_value'),
+            'can_delete_value': obj.has_perm('projects.delete_value')
         }
 
 

--- a/rdmo/accounts/serializers/v1.py
+++ b/rdmo/accounts/serializers/v1.py
@@ -104,6 +104,7 @@ class CurrentUserSerializer(UserSerializer):
 
     def get_permissions(self, obj) -> dict[str, bool]:
         return {
+            'can_add_project': obj.has_perm('projects.add_project'),
             'can_view_project': obj.has_perm('projects.view_project'),
             'can_change_project': obj.has_perm('projects.change_project'),
             'can_delete_project': obj.has_perm('projects.delete_project'),

--- a/rdmo/accounts/tests/test_viewsets.py
+++ b/rdmo/accounts/tests/test_viewsets.py
@@ -52,7 +52,8 @@ status_map = {
 
 urlnames = {
     'list': 'v1-accounts:user-list',
-    'detail': 'v1-accounts:user-detail'
+    'detail': 'v1-accounts:user-detail',
+    'current': 'v1-accounts:user-current',
 }
 
 
@@ -85,6 +86,21 @@ def test_detail(db, client, username, password):
             assert response.status_code == 404, response.json()
         else:
             assert response.status_code == status_map['detail'][username], response.json()
+
+
+@pytest.mark.parametrize('username,password', users)
+def test_current(db, client, username, password):
+    client.login(username=username, password=password)
+
+    url = reverse(urlnames['current'])
+    response = client.get(url)
+    response_data = response.json()
+
+    if password:
+        assert response.status_code == 200
+        assert response_data['permissions']
+    else:
+        assert response.status_code == 401
 
 
 @pytest.mark.parametrize('username,password', users)

--- a/rdmo/accounts/viewsets.py
+++ b/rdmo/accounts/viewsets.py
@@ -43,7 +43,10 @@ class UserViewSet(UserViewSetMixin, ReadOnlyModelViewSet):
                                      'role__editor', 'role__reviewer',
                                      'memberships')
 
-    @action(detail=False, permission_classes=(IsAuthenticated, ))
+    @action(
+        detail=False,
+        permission_classes=(IsAuthenticated,),
+        serializer_class=CurrentUserSerializer,
+    )
     def current(self, request):
-        serializer = CurrentUserSerializer(request.user)
-        return Response(serializer.data)
+        return Response(self.get_serializer(request.user).data)

--- a/rdmo/accounts/viewsets.py
+++ b/rdmo/accounts/viewsets.py
@@ -9,7 +9,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from rdmo.core.permissions import HasModelPermission, HasObjectPermission
 
-from .serializers.v1 import UserSerializer
+from .serializers.v1 import CurrentUserSerializer, UserSerializer
 
 
 class UserViewSetMixin:
@@ -45,5 +45,5 @@ class UserViewSet(UserViewSetMixin, ReadOnlyModelViewSet):
 
     @action(detail=False, permission_classes=(IsAuthenticated, ))
     def current(self, request):
-        serializer = UserSerializer(request.user)
+        serializer = CurrentUserSerializer(request.user)
         return Response(serializer.data)


### PR DESCRIPTION
This is my idea on how to separate the model based permissions (e.g. `projects.change_visibility`, which admins and users with manually assigned permissions or in groups with manually assigned permissions have) from object (project) based permissions (e.g. `projects.change_visibility_object`, which are configured using `rules`. I think the former should be part of `/api/v1/accounts/users/` and the latter stay in `/api/v1/projects/projects/<id>/`.

Another idea (which we first need to discuss): we could put an array in the settings, which permissions are needed in the API and only include those which are actually needed by the front end.