### PR TITLE
Add `'site'` and `'catalog'` to `ProjectAdmin` display and filter

### DIFF
--- a/rdmo/projects/admin.py
+++ b/rdmo/projects/admin.py
@@ -45,11 +45,12 @@ class ProjectAdmin(admin.ModelAdmin):
     form = ProjectAdminForm
 
     search_fields = ('title', 'user__username')
-    list_display = ('title', 'owners', 'updated', 'created')
+    list_display = ('title', 'site', 'catalog', 'owners', 'updated', 'created')
+    list_filter = ('site', 'catalog')
     readonly_fields = ('progress_count', 'progress_total')
 
     def get_queryset(self, request):
-        return Project.objects.prefetch_related(
+        return Project.objects.select_related('site', 'catalog').prefetch_related(
             Prefetch(
                 'memberships',
                 queryset=Membership.objects.filter(role='owner').select_related('user'),

--- a/rdmo/projects/tests/test_admin.py
+++ b/rdmo/projects/tests/test_admin.py
@@ -4,10 +4,12 @@ from django.urls import reverse
 def test_project_search(db, client):
     client.login(username='admin', password='admin')
 
-    url = reverse('admin:projects_project_changelist') + '?q=test'
-    response = client.get(url)
+    url = reverse('admin:projects_project_changelist')
 
-    assert response.status_code == 200
+    for params in ({'q': 'test'}, {'site__id__exact': 1}, {'catalog__id__exact': 1}):
+        response = client.get(url, params)
+
+        assert response.status_code == 200
 
 
 def test_membership_search(db, client):


### PR DESCRIPTION
I was trying to find a Project that was using a certain Catalog at a certain Site. 
This makes it easier to find the Project via the Admin UI.