### PR TITLE
Fix parent handling in Attribute export and AttributeExportSerializer…

### DIFF
--- a/rdmo/domain/renderers/mixins.py
+++ b/rdmo/domain/renderers/mixins.py
@@ -9,9 +9,7 @@ class AttributeRendererMixin:
             self.render_text_element(xml, 'key', {}, attribute['key'])
             self.render_text_element(xml, 'path', {}, attribute['path'])
             self.render_text_element(xml, 'dc:comment', {}, attribute['comment'])
-            self.render_text_element(xml, 'parent', {
-                'dc:uri': attribute['parent']['uri'] if attribute['parent'] is not None else None
-            }, None)
+            self.render_text_element(xml, 'parent', {'dc:uri': attribute['parent_uri']}, None)
             xml.endElement('attribute')
 
         if include_children:

--- a/rdmo/domain/serializers/export.py
+++ b/rdmo/domain/serializers/export.py
@@ -6,6 +6,7 @@ from ..models import Attribute
 class AttributeExportSerializer(serializers.ModelSerializer):
 
     parent = serializers.SerializerMethodField()
+    parent_uri = serializers.SerializerMethodField()
 
     class Meta:
         model = Attribute
@@ -16,9 +17,20 @@ class AttributeExportSerializer(serializers.ModelSerializer):
             'path',
             'comment',
             'parent',
+            'parent_uri',
         )
 
+    def __init__(self, *args, include_parent=True, **kwargs):
+        self.include_parent = include_parent
+        super().__init__(*args, **kwargs)
+
     def get_parent(self, obj):
+        if self.include_parent:
+            parent = self.context.get('attribute_map', {}).get(obj.parent_id)
+            if parent:
+                return AttributeExportSerializer(parent, context=self.context).data
+
+    def get_parent_uri(self, obj):
         parent = self.context.get('attribute_map', {}).get(obj.parent_id)
         if parent:
-            return AttributeExportSerializer(parent, context=self.context).data
+            return parent.uri

--- a/rdmo/domain/tests/test_viewset_attribute.py
+++ b/rdmo/domain/tests/test_viewset_attribute.py
@@ -253,7 +253,7 @@ def test_delete(db, client, username, password):
 @pytest.mark.parametrize('export_format', export_formats)
 def test_detail_export(db, client, username, password, export_format):
     client.login(username=username, password=password)
-    instance = Attribute.objects.first()
+    instance = Attribute.objects.get(pk=1)
 
     url = reverse(urlnames['detail_export'], args=[instance.pk]) + export_format + '/'
     response = client.get(url)
@@ -262,5 +262,6 @@ def test_detail_export(db, client, username, password, export_format):
     if response.status_code == 200 and export_format == 'xml':
         root = et.fromstring(response.content)
         assert root.tag == 'rdmo'
+        assert root.find('attribute/parent').attrib[r'{http://purl.org/dc/elements/1.1/}uri'] == instance.parent.uri
         for child in root:
             assert child.tag in ['attribute']

--- a/rdmo/domain/viewsets.py
+++ b/rdmo/domain/viewsets.py
@@ -37,8 +37,10 @@ class AttributeViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = Attribute.objects.all().order_by('path')
-        if self.action in ('index', 'nested', 'export', 'detail_export'):
+        if self.action in ('index', 'nested'):
             return queryset
+        elif self.action in ('export', 'detail_export'):
+            return queryset.select_related('parent')
         else:
             return queryset.annotate(
                 values_count=models.Count('values')
@@ -97,7 +99,8 @@ class AttributeViewSet(ModelViewSet):
             serializer = AttributeExportSerializer(
                 attributes,
                 many=True,
-                context=self.get_export_serializer_context(attributes),
+                include_parent=False,
+                context=self.get_export_serializer_context(attributes, parent=instance.parent),
             )
             xml = AttributeRenderer().render(serializer.data)
             return XMLResponse(xml, name=instance.key)
@@ -112,9 +115,11 @@ class AttributeViewSet(ModelViewSet):
                 }
             )
 
-    def get_export_serializer_context(self, attributes):
+    def get_export_serializer_context(self, attributes, parent=None):
+        attribute_list = [parent, *attributes] if parent else attributes
+
         return {
             'attribute_map': {
-                attribute.pk: attribute for attribute in attributes
+                attribute.pk: attribute for attribute in attribute_list
             }
         }


### PR DESCRIPTION
This PR aims to resolve #1724. The main fix is to include `instance.parent` into the `attribute_map` of the prefetched attributes. Then, instead of always recusing over all `parents` in the `AttributeExportSerializer`, the attribute export only uses the `parent_uri`. 

All other (full) exports still need full `parent` (and it's `parent` ...).

The change in `get_queryset` prevents one additional query for the parent's uri to be performed.