### PR TITLE
Draft: Add tests for max queries and resolve count on projects endpoints

### DIFF
--- a/rdmo/projects/tests/test_queries.py
+++ b/rdmo/projects/tests/test_queries.py
@@ -2,29 +2,62 @@ import pytest
 
 from django.urls import reverse
 
+from .test_viewset_project import urlnames
+
 max_queries = [
-    # method, urlname, max_queries, url_args
-    ('get', 'project_answers', 38, [1]),
-    ('get', 'project_answers_export', 31, [1, 'html']),
-    ('get', 'v1-projects:project-navigation', 43, [1]),
-    ('get', 'v1-projects:project-answers', 43, [1]),
-    ('post', 'v1-projects:project-progress', 44, [1]),
-    ('get', 'v1-projects:project-page-detail', 46, [1, 1]),
-    ('get', 'v1-projects:project-page-detail', 50, [1, 42]),
-    ('get', 'v1-projects:project-page-detail', 62, [1, 87]),
+    # action, max_queries, url_kwargs, url_params
+    ('project_answers', 38, {'pk': 1}, {}),
+    ('project_answers_export', 31, {'pk': 1, 'format': 'html'}, {}),
+    ('navigation', 43, {'pk': 1}, {}),
+    ('answers', 43, {'pk': 1}, {}),
+    ('page_detail', 46, {'parent_lookup_project': 1, 'pk': 1}, {}),
+    ('page_detail', 50, {'parent_lookup_project': 1, 'pk': 42}, {}),
+    ('page_detail', 62, {'parent_lookup_project': 1, 'pk': 87}, {}),
+    ('progress', 44, {'pk': 1}, {}),
 ]
 
 
 @pytest.mark.performance
-@pytest.mark.parametrize('method,urlname,max_queries,url_args', max_queries)
-def test_queries(db, client, django_assert_max_num_queries, method, urlname, max_queries, url_args):
+@pytest.mark.parametrize('action,max_queries,url_kwargs,url_params', max_queries)
+def test_queries(db, client, django_assert_max_num_queries, action, max_queries, url_kwargs, url_params):
     client.login(username='owner', password='owner')
-    url = reverse(urlname, args=url_args)
+    url = reverse(urlnames[action], kwargs=url_kwargs)
 
     with django_assert_max_num_queries(max_queries):
-        if method == 'get':
-            response = client.get(url)
-        elif method == 'post':
-            response = client.post(url)
+        if action == 'progress':
+            response = client.post(url, query_params=url_params)
+        else:
+            response = client.get(url, query_params=url_params)
 
     assert response.status_code == 200
+
+
+@pytest.mark.performance
+def test_resolve_queries(db, client, django_assert_max_num_queries):
+    client.login(username='owner', password='owner')
+    url = reverse(urlnames['resolve'], kwargs={'pk': 1})
+    params = {
+        'set_prefix': '',
+        'set_index': 0,
+        'element_type': 'conditions',
+        'element_id': 1,
+    }
+
+    with django_assert_max_num_queries(19):
+        response = client.post(url, [params, params, params], content_type='application/json')
+
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+    assert response.json()[0] == response.json()[1] == response.json()[2]
+
+
+@pytest.mark.performance
+def test_resolve_empty_queries(db, client, django_assert_max_num_queries):
+    client.login(username='owner', password='owner')
+    url = reverse(urlnames['resolve'], kwargs={'pk': 1})
+
+    with django_assert_max_num_queries(17):
+        response = client.post(url, [], content_type='application/json')
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/rdmo/projects/tests/test_viewset_project.py
+++ b/rdmo/projects/tests/test_viewset_project.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group, User
 from django.contrib.sites.models import Site
 from django.urls import reverse
 
+from rdmo.conditions.models import Condition
 from rdmo.tasks.models import Task
 from rdmo.views.models import View
 
@@ -54,10 +55,15 @@ urlnames = {
     'copy': 'v1-projects:project-copy',
     'overview': 'v1-projects:project-overview',
     'navigation': 'v1-projects:project-navigation',
+    'answers': 'v1-projects:project-answers',
     'options': 'v1-projects:project-options',
     'resolve': 'v1-projects:project-resolve',
+    'page_detail': 'v1-projects:project-page-detail',
+    'progress': 'v1-projects:project-progress',
     'upload_accept': 'v1-projects:project-upload-accept',
-    'imports': 'v1-projects:project-imports'
+    'imports': 'v1-projects:project-imports',
+    'project_answers': 'project_answers',
+    'project_answers_export': 'project_answers_export',
 }
 
 projects = [1, 2, 3, 4, 5, 12]
@@ -734,6 +740,27 @@ def test_resolve_post(db, client, username, password, project_id, condition_id):
             assert response.status_code == 404
         else:
             assert response.status_code == 401
+
+
+def test_resolve_post_resolves_duplicate_condition_once(db, client, mocker):
+    client.login(username='owner', password='owner')
+    resolve = mocker.spy(Condition, 'resolve')
+    params = {
+        'set_prefix': '',
+        'set_index': 0,
+        'element_type': 'conditions',
+        'element_id': 1
+    }
+
+    response = client.post(
+        reverse(urlnames['resolve'], args=[1]),
+        [params, params, params],
+        content_type='application/json'
+    )
+
+    assert response.status_code == 200
+    assert response.json()[0] == response.json()[1] == response.json()[2]
+    assert resolve.call_count == 1
 
 
 @pytest.mark.parametrize('username,password', users)


### PR DESCRIPTION
## == DRAFT == :face_in_clouds:  ##
The project endpoints `navigation/` and `resolve/` have long loading times in an interview with many (1000s..) values.

This PR makes a start by testing for the max query counts and the number of times that the `Condition.resolve()` is called on the same condition.
> PS apparently the tests were already there but these changes refactor and align them with the other `test_queries.py`

:warning:  this one has **tests only** so it is meant to fail in the actions.
