### PR TITLE
Draft: Optimize project navigation queries

### DIFF
--- a/rdmo/projects/tests/test_queries.py
+++ b/rdmo/projects/tests/test_queries.py
@@ -8,7 +8,8 @@ max_queries = [
     # action, max_queries, url_kwargs, url_params
     ('project_answers', 38, {'pk': 1}, {}),
     ('project_answers_export', 31, {'pk': 1, 'format': 'html'}, {}),
-    ('navigation', 43, {'pk': 1}, {}),
+    ('navigation', 40, {'pk': 1}, {}),
+    ('navigation', 40, {'pk': 1, 'section_id': 1}, {}),
     ('answers', 43, {'pk': 1}, {}),
     ('page_detail', 46, {'parent_lookup_project': 1, 'pk': 1}, {}),
     ('page_detail', 50, {'parent_lookup_project': 1, 'pk': 42}, {}),

--- a/rdmo/projects/viewsets.py
+++ b/rdmo/projects/viewsets.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import Coalesce, Greatest
@@ -130,7 +129,12 @@ class ProjectViewSet(ModelViewSet):
     filter_for_user = False  # flag for get_queryset to return only projects like for a regular user
 
     def get_queryset(self):
-        queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct().prefetch_related(
+        queryset = Project.objects.filter_user(self.request.user, self.filter_for_user).distinct()
+        if self.action == 'navigation':
+            # navigation only needs the project catalog and visibility before computing the answer tree.
+            return queryset.select_related('catalog', 'visibility')
+
+        queryset = queryset.prefetch_related(
             'snapshots',
             'views',
             Prefetch('memberships', queryset=Membership.objects.select_related('user'), to_attr='memberships_list')
@@ -183,14 +187,13 @@ class ProjectViewSet(ModelViewSet):
         project = self.get_object()
         project.catalog.prefetch_elements()
 
-        # if a section is provided, check if it actually exists in the catalog
+        # if a section is provided, find it in the prefetched catalog elements to avoid another database query
         if section_id is None:
             section = None
         else:
-            try:
-                section = project.catalog.sections.get(pk=section_id)
-            except ObjectDoesNotExist as e:
-                raise NotFound() from e
+            section = project.catalog.get_section(section_id)
+            if section is None:
+                raise NotFound()
 
         # compute navigation from the answer tree
         navigation = compute_navigation(project, section)

--- a/rdmo/questions/models/catalog.py
+++ b/rdmo/questions/models/catalog.py
@@ -232,6 +232,12 @@ class Catalog(Model, TranslationMixin):
         except (ValueError, IndexError):
             return None
 
+    def get_section(self, section_id):
+        try:
+            return next(section for section in self.elements if section.id == int(section_id))
+        except (StopIteration, ValueError):
+            return None
+
     def get_page(self, page_id):
         try:
             return next(page for page in self.pages if page.id == int(page_id))


### PR DESCRIPTION
Tiny surgical changes to the `navigation/` endpoint that reduce the query count of the tests with `3` queries.

* new method `Catalog.get_section(self, section_id)` that can re-use the prefetched `elements` on the Catalog
* a special branch in `get_queryset` for the `'navigation'`  action
