### PR TITLE
Update for architecture docs on utils

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,10 +113,12 @@ The modules directly depend on each other (e.g. by importing classes or function
 
 Besides those dependencies:
 
-* `utils.py` and `managers.py` must not depend on anything inside the module.
+* Functions in `utils.py` and `managers.py` must be isolated from other code in the same module. Their dependencies
+  on models or other modules must follow the relationships above.
 * `models.py` must only depend on `utils.py` and `managers.py`.
 
-If utility functions are needed, which depend on the models they are put in special files, e.g. `process.py`. Utility functions for tests are placed in `tests/helpers.py`.
+Utility functions that depend on models defined in the same module are placed in special files, e.g. `process.py`.
+Utility functions for tests are placed in `tests/helpers.py`.
 
 Besides those relationships, which should not be extended, implicit dependencies exists, e.g. when functions take objects from other modules as arguments.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,8 +113,8 @@ The modules directly depend on each other (e.g. by importing classes or function
 
 Besides those dependencies:
 
-* Functions in `utils.py` and `managers.py` must be isolated from other code in the same module. Their dependencies
-  on models or other modules must follow the relationships above.
+* `utils.py` and `managers.py` must remain importable at the top of `models.py` and therefore must not depend, directly or indirectly on models defined in the same module.
+
 * `models.py` must only depend on `utils.py` and `managers.py`.
 
 Utility functions that depend on models defined in the same module are placed in special files, e.g. `process.py`.


### PR DESCRIPTION
Minor update to docs on utils. 

This was too strict I think "must not depend on anything inside the module."

Maybe discuss still? 
> Utility functions that depend on models defined in the same module are placed in special files, e.g. `process.py`.