### PR TITLE
Fix the "refresh" case in fetchValues

### DIFF
--- a/rdmo/projects/assets/js/interview/actions/interviewActions.js
+++ b/rdmo/projects/assets/js/interview/actions/interviewActions.js
@@ -1,4 +1,4 @@
-import { first, isEmpty, isNil } from 'lodash'
+import { first, isEmpty, isNil, sortBy } from 'lodash'
 
 import PageApi from '../api/PageApi'
 import ProjectApi from '../api/ProjectApi'
@@ -189,18 +189,23 @@ export function fetchValues(page, refresh = false) {
     dispatch(addToPending(pendingId))
     dispatch(fetchValuesInit())
     return ValueApi.fetchValues(projectId, { attribute: page.attributes })
-      .then((fetchedValues) => {
-        const values = refresh ? (
-          // if the values are just refreshed after a value is stores or deleted, loop
-          // over the existing values and inject the fetched values, keeping unsaved values
-          getState().interview.values.map(value => {
-            const fetchedValue = fetchedValues.find(v => compareValues(v, value))
-            return isNil(fetchedValue) ? value : fetchedValue
-          })
-        ) : (
-          // when loading the page, discard all existing values
-          fetchedValues
-        )
+      .then((values) => {
+        if (refresh) {
+          // if the values are just refreshed after a value is stored or deleted, loop
+          // over the existing values and add all temporary values which were not stored yet
+          const unsavedValues = getState().interview.values.filter((value) => isNil(value.id))
+
+          // extend values with all unsaved values, which are not found in values
+          const keptUnsavedValues = unsavedValues.filter(
+            (value) => isNil(values.find((v) => compareValues(v, value)))
+          )
+
+          // resort the values, to ensure the correct collection_index order
+          values = sortBy(
+            [...values, ...keptUnsavedValues],
+            ['attribute', 'set_prefix', 'set_index', 'collection_index']
+          )
+        }
 
         const sets = gatherSets(values, page)
 


### PR DESCRIPTION
Here we go again ... this PR fixes the just fixed "refresh" of values in the interview, e.g. after a value from the orcid plugin is saved and RDMO injects values on the backend, but the unsaved values in the front end should still survive, because maybe they are a default value.

Right now, this keeps the values which are not temporary and were just deleted in the front end as well.

The code in https://github.com/rdmorganiser/rdmo/pull/1702 was actually better than my approach:

```js
        if (preserveUnsaved) {
          const unsavedValues = getState().interview.values.filter((value) => isNil(value.id))

          unsavedValues.forEach((value) => {
            const question = page.questions.find((question) => question.attribute === value.attribute)
            const widgetType = question && question.widget_type

            if (!values.some((fetchedValue) => compareValues(fetchedValue, value, widgetType))) {
              values.push(value)
            }
          })

          values.sort((a, b) => (
            (a.attribute - b.attribute) ||
            a.set_prefix.localeCompare(b.set_prefix) ||
            (a.set_index - b.set_index) ||
            (a.collection_index - b.collection_index)
          ))
        }
```

The unsaved values are appended and then the values are re-sorted, because otherwise the `collection_index` is not correct.

The new code is like this, but a bit more streamlined.